### PR TITLE
Use non-atomic pointer for dynamic dispatch when atomic is not available

### DIFF
--- a/include/simdutf.h
+++ b/include/simdutf.h
@@ -2,7 +2,9 @@
 #define SIMDUTF_H
 #include <string>
 #include <cstring>
+#if !defined(SIMDUTF_NO_THREADS)
 #include <atomic>
+#endif
 #include <vector>
 
 #include "simdutf/compiler_check.h"

--- a/include/simdutf.h
+++ b/include/simdutf.h
@@ -2,9 +2,6 @@
 #define SIMDUTF_H
 #include <string>
 #include <cstring>
-#if !defined(SIMDUTF_NO_THREADS)
-#include <atomic>
-#endif
 #include <vector>
 
 #include "simdutf/compiler_check.h"

--- a/include/simdutf/compiler_check.h
+++ b/include/simdutf/compiler_check.h
@@ -32,4 +32,10 @@
 #error simdutf requires a compiler compliant with the C++11 standard
 #endif
 
+#if defined(SIMDUTF_CPLUSPLUS17)
+#if !__has_include(<atomic>)
+#define SIMDUTF_NO_THREADS 1
+#endif
+#endif
+
 #endif // SIMDUTF_COMPILER_CHECK_H

--- a/include/simdutf/compiler_check.h
+++ b/include/simdutf/compiler_check.h
@@ -32,10 +32,4 @@
 #error simdutf requires a compiler compliant with the C++11 standard
 #endif
 
-#if defined(SIMDUTF_CPLUSPLUS17)
-#if !__has_include(<atomic>)
-#define SIMDUTF_NO_THREADS 1
-#endif
-#endif
-
 #endif // SIMDUTF_COMPILER_CHECK_H

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -1,7 +1,9 @@
 #ifndef SIMDUTF_IMPLEMENTATION_H
 #define SIMDUTF_IMPLEMENTATION_H
 #include <string>
+#if !defined(SIMDUTF_NO_THREADS)
 #include <atomic>
+#endif
 #include <vector>
 #include "simdutf/common_defs.h"
 #include "simdutf/internal/isadetection.h"
@@ -425,6 +427,17 @@ class atomic_ptr {
 public:
   atomic_ptr(T *_ptr) : ptr{_ptr} {}
 
+#if defined(SIMDUTF_NO_THREADS)
+  operator const T*() const { return ptr; }
+  const T& operator*() const { return *ptr; }
+  const T* operator->() const { return ptr; }
+
+  operator T*() { return ptr; }
+  T& operator*() { return *ptr; }
+  T* operator->() { return ptr; }
+  atomic_ptr& operator=(T *_ptr) { ptr = _ptr; return *this; }
+
+#else
   operator const T*() const { return ptr.load(); }
   const T& operator*() const { return *ptr; }
   const T* operator->() const { return ptr.load(); }
@@ -434,8 +447,14 @@ public:
   T* operator->() { return ptr.load(); }
   atomic_ptr& operator=(T *_ptr) { ptr = _ptr; return *this; }
 
+#endif
+
 private:
+#if defined(SIMDUTF_NO_THREADS)
+  T* ptr;
+#else
   std::atomic<T*> ptr;
+#endif
 };
 
 } // namespace internal


### PR DESCRIPTION
Closes #90