### PR TITLE
fix valid_utf8_to_utf16.h producing invalid utf16

### DIFF
--- a/src/generic/utf8_to_utf16/valid_utf8_to_utf16.h
+++ b/src/generic/utf8_to_utf16/valid_utf8_to_utf16.h
@@ -25,12 +25,16 @@ simdutf_warn_unused size_t convert_valid(const char* input, size_t size,
     // involved.
     //
     simd8x64<int8_t> in(reinterpret_cast<const int8_t *>(input + pos));
-    uint64_t utf8_continuation_mask = in.lt(-65 + 1);
-    // -65 is 0b10111111 in two-complement's, so largest possible continuation byte
-    if(utf8_continuation_mask != 0) {
+    if(in.is_ascii()) {
+      in.store_ascii_as_utf16(utf16_output);
+      utf16_output += 64;
+      pos += 64;
+    } else {
       // Slow path. We hope that the compiler will recognize that this is a slow path.
       // Anything that is not a continuation mask is a 'leading byte', that is, the
       // start of a new code point.
+      uint64_t utf8_continuation_mask = in.lt(-65 + 1);
+      // -65 is 0b10111111 in two-complement's, so largest possible continuation byte
       uint64_t utf8_leading_mask = ~utf8_continuation_mask;
       // The *start* of code points is not so useful, rather, we want the *end* of code points.
       uint64_t utf8_end_of_code_point_mask = utf8_leading_mask>>1;
@@ -63,10 +67,6 @@ simdutf_warn_unused size_t convert_valid(const char* input, size_t size,
       // 64-byte block.These bytes will be processed again. So we have an 
       // 80% efficiency (in the worst case). In practice we expect an 
       // 85% to 90% efficiency.
-    } else {
-      in.store_ascii_as_utf16(utf16_output);
-      utf16_output += 64;
-      pos += 64;
     }
   }
   utf16_output += scalar::utf8_to_utf16::convert_valid(input + pos, size - pos, utf16_output);

--- a/tests/convert_valid_utf8_to_utf16_tests.cpp
+++ b/tests/convert_valid_utf8_to_utf16_tests.cpp
@@ -91,19 +91,21 @@ TEST(convert_3_or_4_UTF8_bytes) {
 
 TEST(issue111) {
   char16_t input[] = u"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaコaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-  size_t strlen = sizeof(input)/sizeof(char16_t)-1;
-  ASSERT_TRUE(implementation.validate_utf16(input, strlen));
-  ASSERT_TRUE(implementation.utf8_length_from_utf16(input, strlen)
-              == 2 + strlen);
-  size_t size = implementation.utf8_length_from_utf16(input, strlen);
-  std::unique_ptr<char[]> utf8_buffer{new char[size]};
-  ASSERT_TRUE(implementation.convert_valid_utf16_to_utf8(input, strlen, utf8_buffer.get()) == size);
+  size_t utf16_len = sizeof(input) / sizeof(char16_t) - 1;
+  ASSERT_TRUE(implementation.validate_utf16(input, utf16_len));
+  ASSERT_TRUE(implementation.utf8_length_from_utf16(input, utf16_len)
+              == 2 + utf16_len);
+  size_t utf8_len = implementation.utf8_length_from_utf16(input, utf16_len);
+  std::unique_ptr<char[]> utf8_buffer{new char[utf8_len]};
+  ASSERT_TRUE(implementation.convert_valid_utf16_to_utf8(input, utf16_len, utf8_buffer.get())
+              == utf8_len);
 
-  std::unique_ptr<char16_t[]> utf16_buffer{new char16_t[strlen]};
+  std::unique_ptr<char16_t[]> utf16_buffer{new char16_t[utf16_len]};
 
-  ASSERT_TRUE(implementation.convert_valid_utf8_to_utf16(utf8_buffer.get(), size, utf16_buffer.get()) == strlen);
+  ASSERT_TRUE(implementation.convert_valid_utf8_to_utf16(utf8_buffer.get(), utf8_len, utf16_buffer.get())
+              == utf16_len);
 
-  ASSERT_TRUE(std::char_traits<char16_t>::compare(input, utf16_buffer.get(), strlen) == 0);
+  ASSERT_TRUE(std::char_traits<char16_t>::compare(input, utf16_buffer.get(), utf16_len) == 0);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
This was causing weird behaviour:
when previous block is ending with start of multi byte UTF sequence, whole block counted as ASCII.
