### PR TITLE
Fix issue #132.

### DIFF
--- a/src/generic/utf8_to_utf32/valid_utf8_to_utf32.h
+++ b/src/generic/utf8_to_utf32/valid_utf8_to_utf32.h
@@ -15,22 +15,22 @@ simdutf_warn_unused size_t convert_valid(const char* input, size_t size,
   const size_t safety_margin = 16; // to avoid overruns!
   while(pos + 64 + safety_margin <= size) {
     simd8x64<int8_t> in(reinterpret_cast<const int8_t *>(input + pos));
-    uint64_t utf8_continuation_mask = in.lt(-65 + 1);
-    // -65 is 0b10111111 in two-complement's, so largest possible continuation byte
-    if(utf8_continuation_mask != 0) {
-      uint64_t utf8_leading_mask = ~utf8_continuation_mask;
-      uint64_t utf8_end_of_code_point_mask = utf8_leading_mask>>1;
-      size_t max_starting_point = (pos + 64) - 12;
-      while(pos < max_starting_point) {
-        size_t consumed = convert_masked_utf8_to_utf32(input + pos,
-                            utf8_end_of_code_point_mask, utf32_output);
-        pos += consumed;
-        utf8_end_of_code_point_mask >>= consumed;
-      }
-    } else {
+    if(in.is_ascii()) {
       in.store_ascii_as_utf32(utf32_output);
       utf32_output += 64;
       pos += 64;
+    } else {
+    // -65 is 0b10111111 in two-complement's, so largest possible continuation byte
+    uint64_t utf8_continuation_mask = in.lt(-65 + 1);
+    uint64_t utf8_leading_mask = ~utf8_continuation_mask;
+    uint64_t utf8_end_of_code_point_mask = utf8_leading_mask>>1;
+    size_t max_starting_point = (pos + 64) - 12;
+    while(pos < max_starting_point) {
+      size_t consumed = convert_masked_utf8_to_utf32(input + pos,
+                          utf8_end_of_code_point_mask, utf32_output);
+      pos += consumed;
+      utf8_end_of_code_point_mask >>= consumed;
+      }
     }
   }
   utf32_output += scalar::utf8_to_utf32::convert_valid(input + pos, size - pos, utf32_output);

--- a/tests/convert_valid_utf8_to_utf32_tests.cpp
+++ b/tests/convert_valid_utf8_to_utf32_tests.cpp
@@ -90,7 +90,7 @@ TEST(convert_3_or_4_UTF8_bytes) {
   }
 }
 
-TEST(convert_a_lot_of_ASCII) {
+TEST(issue132) {
   uint32_t seed{1234};
 
   // range for 2,3 and 4 UTF-8 bytes 

--- a/tests/convert_valid_utf8_to_utf32_tests.cpp
+++ b/tests/convert_valid_utf8_to_utf32_tests.cpp
@@ -1,10 +1,12 @@
 #include "simdutf.h"
 
 #include <array>
+#include <queue>
 #include <iostream>
 
 #include <tests/helpers/transcode_test_base.h>
 #include <tests/helpers/random_int.h>
+#include <tests/reference/encode_utf8.h>
 #include <tests/helpers/test.h>
 
 namespace {
@@ -84,6 +86,32 @@ TEST(convert_3_or_4_UTF8_bytes) {
     for (size_t size: input_size) {
       transcode_utf8_to_utf32_test_base test(random, size);
       ASSERT_TRUE(test(procedure));
+    }
+  }
+}
+
+TEST(convert_a_lot_of_ASCII) {
+  uint32_t seed{1234};
+
+  // range for 2,3 and 4 UTF-8 bytes 
+  simdutf::tests::helpers::RandomIntRanges random({{0x080, 0xd800-1},
+                                                    {0xe000, 0x10ffff}}, seed);
+
+  auto procedure = [&implementation](const char* utf8, size_t size, char32_t* utf32) -> size_t {
+    return implementation.convert_valid_utf8_to_utf32(utf8, size, utf32);
+  };
+
+  const size_t size = 200;
+  std::vector<uint32_t> data(size+32, '*');
+
+  for (size_t j = 0; j < 1000; j++) {
+    uint32_t non_ascii = random();
+    for (size_t i=0; i < size; i++) {
+      auto old = data[i];
+      data[i] = non_ascii;
+      transcode_utf8_to_utf32_test_base test(data);
+      ASSERT_TRUE(test(procedure));
+      data[i] = old;
     }
   }
 }


### PR DESCRIPTION
Fix #132. There is an issue when using `convert_valid_utf8_to_utf32` related to a non-ASCII character following a long chain of ASCII characters. Credit to @KaiserLancelot for identifying the bug.