### PR TITLE
AVX-512 UTF-8 to UTF-32 transcoding

### DIFF
--- a/src/icelake/icelake-macros.inl.cpp
+++ b/src/icelake/icelake-macros.inl.cpp
@@ -78,7 +78,7 @@
                 _mm512_mask_storeu_epi32((__m512i*)output, valid, out);                                      \
                 output += valid_count;                                                                       \
             } else {                                                                                         \
-                output += utf32_to_utf16(out, valid_count, output);                                          \
+                output += utf32_to_utf16(out, valid_count, reinterpret_cast<char16_t *>(output));            \
             }                                                                                                \
         }
 

--- a/src/icelake/icelake-utf8-common.inl.cpp
+++ b/src/icelake/icelake-utf8-common.inl.cpp
@@ -1,6 +1,7 @@
 // Common procedures for both validating and non-validating conversions from UTF-8.
 
 using utf8_to_utf16_result = std::pair<const char*, char16_t*>;
+using utf8_to_utf32_result = std::pair<const char*, uint32_t*>;
 
 // See: http://0x80.pl/notesen/2021-12-22-test-and-clear-bit.html
 bool test_and_clear_bit(uint32_t& val, int bitpos) {

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -76,7 +76,7 @@ simdutf_warn_unused size_t implementation::convert_utf8_to_utf16(const char* buf
   }
 
   if (ret.first != end) {
-    const size_t scalar_saved_bytes = scalar::utf8_to_utf16::convert_valid(
+    const size_t scalar_saved_bytes = scalar::utf8_to_utf16::convert(
                                         ret.first, len - (ret.first - buf), ret.second);
     if (scalar_saved_bytes == 0) { return 0; }
     saved_bytes += scalar_saved_bytes;

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -135,7 +135,7 @@ simdutf_warn_unused size_t implementation::convert_utf8_to_utf32(const char* buf
 
   if (ret.first != end) {
     const size_t scalar_saved_bytes = scalar::utf8_to_utf32::convert(
-                                        ret.first, len - (ret.first - buf), reinterpret_cast<char32_t *>(ret.second));
+                                        ret.first, len - (ret.first - buf), utf32_out + saved_bytes);
     if (scalar_saved_bytes == 0) { return 0; }
     saved_bytes += scalar_saved_bytes;
   }
@@ -163,7 +163,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf32(const cha
 
   if (ret.first != end) {
     const size_t scalar_saved_bytes = scalar::utf8_to_utf32::convert_valid(
-                                        ret.first, len - (ret.first - buf), reinterpret_cast<char32_t *>(ret.second));
+                                        ret.first, len - (ret.first - buf), utf32_out + saved_bytes);
     if (scalar_saved_bytes == 0) { return 0; }
     saved_bytes += scalar_saved_bytes;
   }

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -116,9 +116,33 @@ simdutf_warn_unused size_t implementation::convert_utf8_to_utf32(const char* buf
    return scalar::utf8_to_utf32::convert(buf, len, utf32_output);
 }
 
-simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf32(const char* input, size_t size,
-    char32_t* utf32_output) const noexcept {
-  return scalar::utf8_to_utf32::convert_valid(input, size,  utf32_output);
+simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf32(const char* buf, size_t len,
+    char32_t* utf32_out) const noexcept {
+  uint32_t * utf32_output = reinterpret_cast<uint32_t *>(utf32_out);
+  utf8_to_utf32_result ret = icelake::valid_utf8_to_fixed_length<uint32_t>(buf, len, utf32_output);
+  size_t saved_bytes = ret.second - utf32_output;
+  const char* end = buf + len;
+  if (ret.first == end) {
+    return saved_bytes;
+  }
+
+  // Note: AVX512 procedure looks up 4 bytes forward, and
+  //       correctly converts multi-byte chars even if their
+  //       continuation bytes lie outsiede 16-byte window.
+  //       It meas, we have to skip continuation bytes from
+  //       the beginning ret.first, as they were already consumed.
+  while (ret.first != end && ((uint8_t(*ret.first) & 0xc0) == 0x80)) {
+      ret.first += 1;
+  }
+
+  if (ret.first != end) {
+    const size_t scalar_saved_bytes = scalar::utf8_to_utf32::convert_valid(
+                                        ret.first, len - (ret.first - buf), reinterpret_cast<char32_t *>(ret.second));
+    if (scalar_saved_bytes == 0) { return 0; }
+    saved_bytes += scalar_saved_bytes;
+  }
+
+  return saved_bytes;
 }
 
 simdutf_warn_unused size_t implementation::convert_utf16_to_utf8(const char16_t* buf, size_t len, char* utf8_output) const noexcept {


### PR DESCRIPTION
Fix #130.
The procedure was already implemented: I just needed to pass the flag `uint32_t`. I also fixed a typo in convert_utf8_to_utf16 I think. The method was calling convert_valid instead of convert to process the tail.