### PR TITLE
AVX-512 miscellaneous functions 

### DIFF
--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -192,7 +192,33 @@ simdutf_warn_unused size_t implementation::count_utf8(const char * input, size_t
 }
 
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16(const char16_t * input, size_t length) const noexcept {
-  return scalar::utf16::utf8_length_from_utf16(input, length);
+  const char16_t* end = length >= 32 ? input + length - 32 : nullptr;
+  const char16_t* ptr = input;
+
+  const __m512i v_007f = _mm512_set1_epi16((uint16_t)0x007f);
+  const __m512i v_07ff = _mm512_set1_epi16((uint16_t)0x07ff);
+  const __m512i v_dfff = _mm512_set1_epi16((uint16_t)0xdfff);
+  const __m512i v_d800 = _mm512_set1_epi16((uint16_t)0xd800);
+
+  size_t count{0};
+
+  while (ptr <= end) {
+    __m512i utf16 = _mm512_loadu_si512((const __m512i*)ptr);
+    ptr += 32;
+    __mmask32 ascii_bitmask = _mm512_cmple_epu16_mask(utf16, v_007f);
+    __mmask32 two_bytes_bitmask = _mm512_mask_cmple_epu16_mask(~ascii_bitmask, utf16, v_07ff);
+    __mmask32 not_one_two_bytes = ~ascii_bitmask | ~two_bytes_bitmask;
+    __mmask32 surrogates_bitmask = _mm512_mask_cmple_epu16_mask(not_one_two_bytes, utf16, v_dfff) & _mm512_mask_cmpge_epu16_mask(not_one_two_bytes, utf16, v_d800);
+
+    size_t ascii_count = count_ones(ascii_bitmask);
+    size_t two_bytes_count = count_ones(two_bytes_bitmask);
+    size_t surrogate_bytes_count = count_ones(surrogates_bitmask);
+    size_t three_bytes_count = 32 - ascii_count - two_bytes_count - surrogate_bytes_count;
+
+    count += ascii_count + 2*two_bytes_count + 3*three_bytes_count + 2*surrogate_bytes_count;
+  }
+
+  return count + scalar::utf16::utf8_length_from_utf16(ptr, length - (ptr - input));
 }
 
 simdutf_warn_unused size_t implementation::utf8_length_from_utf32(const char32_t * input, size_t length) const noexcept {

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -200,7 +200,23 @@ simdutf_warn_unused size_t implementation::utf8_length_from_utf32(const char32_t
 }
 
 simdutf_warn_unused size_t implementation::utf16_length_from_utf8(const char * input, size_t length) const noexcept {
-  return scalar::utf8::utf16_length_from_utf8(input, length);
+  const char* end = length >= 64 ? input + length - 64 : nullptr;
+  const char* ptr = input;
+
+  const __m512i continuation = _mm512_set1_epi8(char(0b10111111));
+  const __m512i utf8_4bytes = _mm512_set1_epi8(char(0b11110000));
+
+  size_t count{0};
+
+  while (ptr <= end) {
+    __m512i utf8 = _mm512_loadu_si512((const __m512i*)ptr);
+    ptr += 64;
+    uint64_t continuation_bitmask = static_cast<uint64_t>(_mm512_cmple_epi8_mask(utf8, continuation));
+    uint64_t utf8_4bytes_bitmask = static_cast<uint64_t>(_mm512_cmpge_epu8_mask(utf8, utf8_4bytes));
+    count += 64 + count_ones(utf8_4bytes_bitmask) - count_ones(continuation_bitmask);
+  }
+
+  return count + scalar::utf8::utf16_length_from_utf8(ptr, length - (ptr - input));
 }
 
 simdutf_warn_unused size_t implementation::utf32_length_from_utf16(const char16_t * input, size_t length) const noexcept {

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -309,7 +309,7 @@ simdutf_warn_unused size_t implementation::utf16_length_from_utf8(const char * i
 }
 
 simdutf_warn_unused size_t implementation::utf32_length_from_utf16(const char16_t * input, size_t length) const noexcept {
-  return scalar::utf16::utf32_length_from_utf16(input, length);
+  return implementation::count_utf16(input, length);
 }
 
 simdutf_warn_unused size_t implementation::utf16_length_from_utf32(const char32_t * input, size_t length) const noexcept {
@@ -317,7 +317,7 @@ simdutf_warn_unused size_t implementation::utf16_length_from_utf32(const char32_
 }
 
 simdutf_warn_unused size_t implementation::utf32_length_from_utf8(const char * input, size_t length) const noexcept {
-  return scalar::utf8::utf32_length_from_utf8(input, length);
+  return implementation::count_utf8(input, length);
 }
 
 } // namespace SIMDUTF_IMPLEMENTATION


### PR DESCRIPTION
Fix #107 
Implements functions from #107 except UTF-16LE validation (I think @clausecker has that part). Also adds utf32_length_from_utf8 and utf32_length_from utf16 (same as count_utf8 and count_utf16 respectively) as well as utf8_length_from_utf32 and utf16_length_from_utf32. Nothing differs significantly from haswell and westmere implementations.