### PR TITLE
Optimize ARM utf16 validation

### DIFF
--- a/src/arm64/arm_validate_utf16le.cpp
+++ b/src/arm64/arm_validate_utf16le.cpp
@@ -1,45 +1,66 @@
 
 const char16_t* arm_validate_utf16le(const char16_t* input, size_t size) {
-    const char16_t* end = input + size;
-    const auto v_d8 = simd8<uint8_t>::splat(0xd8);
-    const auto v_f8 = simd8<uint8_t>::splat(0xf8);
-    const auto v_fc = simd8<uint8_t>::splat(0xfc);
-    const auto v_dc = simd8<uint8_t>::splat(0xdc);
-    while (input + 16 < end) {
-        // 0. Load data: since the validation takes into account only higher
-        //    byte of each word, we compress the two vectors into one which
-        //    consists only the higher bytes.
-        const auto in0 = simd16<uint16_t>(input);
-        const auto in1 = simd16<uint16_t>(input + simd16<uint16_t>::SIZE / sizeof(char16_t));
-        const auto t0 = in0.shr<8>();
-        const auto t1 = in1.shr<8>();
-        const simd8<uint8_t> in = simd16<uint16_t>::pack(t0, t1);
-        // 1. Check whether we have any 0xD800..DFFF word (0b1101'1xxx'yyyy'yyyy).
-        const auto surrogates_wordmask = ((in & v_f8) == v_d8);
-        if(surrogates_wordmask.none()) {
-            input += 16;
-        } else {
-            const auto vH = simd8<uint8_t>((in & v_fc) ==  v_dc);
-            const auto vL = simd8<uint8_t>(surrogates_wordmask).bit_andnot(vH);
-            // We are going to need these later:
-            const uint8_t low_vh = vH.first();
-            const uint8_t high_vl = vL.last();
-            // We shift vH down, possibly killing low_vh
-            const auto sh = simd8<uint8_t>({1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,0xFF});
-            const auto vHshifteddown = vH.apply_lookup_16_to(sh);
-            const auto match = vHshifteddown == vL;
-            // We need to handle the fact that high_vl is unmatched.
-            // We could use this...
-            // const uint8x16_t allbutlast = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0xFF};
-            //             match = vorrq_u8(match, allbutlast);
-            // but sh will do:
-            const auto fmatch = simd8<bool>(simd8<uint8_t>(match) | sh);
-            if (fmatch.all() && low_vh == 0) {
-                input += (high_vl == 0) ? 16 : 15;
-            } else {
-                return nullptr;
-            }
-        }
+  const char16_t* end = input + size;
+  const auto v_d8 = simd8<uint8_t>::splat(0xd8);
+  const auto v_f8 = simd8<uint8_t>::splat(0xf8);
+  const auto v_fc = simd8<uint8_t>::splat(0xfc);
+  const auto v_dc = simd8<uint8_t>::splat(0xdc);
+  while (input + 16 < end) {
+    // 0. Load data: since the validation takes into account only higher
+    //    byte of each word, we compress the two vectors into one which
+    //    consists only the higher bytes.
+    const auto in0 = simd16<uint16_t>(input);
+    const auto in1 =
+        simd16<uint16_t>(input + simd16<uint16_t>::SIZE / sizeof(char16_t));
+    const auto t0 = in0.shr<8>();
+    const auto t1 = in1.shr<8>();
+    const simd8<uint8_t> in = simd16<uint16_t>::pack(t0, t1);
+    // 1. Check whether we have any 0xD800..DFFF word (0b1101'1xxx'yyyy'yyyy).
+    const uint64_t surrogates_wordmask = ((in & v_f8) == v_d8).to_bitmask64();
+    if (surrogates_wordmask == 0) {
+      input += 16;
+    } else {
+      // 2. We have some surrogates that have to be distinguished:
+      //    - low  surrogates: 0b1101'10xx'yyyy'yyyy (0xD800..0xDBFF)
+      //    - high surrogates: 0b1101'11xx'yyyy'yyyy (0xDC00..0xDFFF)
+      //
+      //    Fact: high surrogate has 1th bit set (3rd bit in the higher word)
+
+      // V - non-surrogate words
+      //     V = not surrogates_wordmask
+      const uint64_t V = ~surrogates_wordmask;
+
+      // H - word-mask for high surrogates: the six highest bits are 0b1101'11
+      const auto vH = ((in & v_fc) == v_dc);
+      const uint64_t H = vH.to_bitmask64();
+
+      // L - word mask for low surrogates
+      //     L = not H and surrogates_wordmask
+      const uint64_t L = ~H & surrogates_wordmask;
+
+      const uint64_t a =
+          L & (H >> 4);  // A low surrogate must be followed by high one.
+                         // (A low surrogate placed in the 7th register's word
+                         // is an exception we handle.)
+      const uint64_t b =
+          a << 4;  // Just mark that the opposite fact is hold,
+                   // thanks to that we have only two masks for valid case.
+      const uint64_t c =
+          V | a | b;  // Combine all the masks into the final one.
+      if (c == ~0ull) {
+        // The whole input register contains valid UTF-16, i.e.,
+        // either single words or proper surrogate pairs.
+        input += 16;
+      } else if (c == 0xfffffffffffffffull) {
+        // The 15 lower words of the input register contains valid UTF-16.
+        // The 15th word may be either a low or high surrogate. It the next
+        // iteration we 1) check if the low surrogate is followed by a high
+        // one, 2) reject sole high surrogate.
+        input += 15;
+      } else {
+        return nullptr;
+      }
     }
-    return input;
+  }
+  return input;
 }

--- a/src/arm64/arm_validate_utf16le.cpp
+++ b/src/arm64/arm_validate_utf16le.cpp
@@ -1,66 +1,62 @@
 
 const char16_t* arm_validate_utf16le(const char16_t* input, size_t size) {
-  const char16_t* end = input + size;
-  const auto v_d8 = simd8<uint8_t>::splat(0xd8);
-  const auto v_f8 = simd8<uint8_t>::splat(0xf8);
-  const auto v_fc = simd8<uint8_t>::splat(0xfc);
-  const auto v_dc = simd8<uint8_t>::splat(0xdc);
-  while (input + 16 < end) {
-    // 0. Load data: since the validation takes into account only higher
-    //    byte of each word, we compress the two vectors into one which
-    //    consists only the higher bytes.
-    const auto in0 = simd16<uint16_t>(input);
-    const auto in1 =
-        simd16<uint16_t>(input + simd16<uint16_t>::SIZE / sizeof(char16_t));
-    const auto t0 = in0.shr<8>();
-    const auto t1 = in1.shr<8>();
-    const simd8<uint8_t> in = simd16<uint16_t>::pack(t0, t1);
-    // 1. Check whether we have any 0xD800..DFFF word (0b1101'1xxx'yyyy'yyyy).
-    const uint64_t surrogates_wordmask = ((in & v_f8) == v_d8).to_bitmask64();
-    if (surrogates_wordmask == 0) {
-      input += 16;
-    } else {
-      // 2. We have some surrogates that have to be distinguished:
-      //    - low  surrogates: 0b1101'10xx'yyyy'yyyy (0xD800..0xDBFF)
-      //    - high surrogates: 0b1101'11xx'yyyy'yyyy (0xDC00..0xDFFF)
-      //
-      //    Fact: high surrogate has 1th bit set (3rd bit in the higher word)
+    const char16_t* end = input + size;
+    const auto v_d8 = simd8<uint8_t>::splat(0xd8);
+    const auto v_f8 = simd8<uint8_t>::splat(0xf8);
+    const auto v_fc = simd8<uint8_t>::splat(0xfc);
+    const auto v_dc = simd8<uint8_t>::splat(0xdc);
+    while (input + 16 < end) {
+        // 0. Load data: since the validation takes into account only higher
+        //    byte of each word, we compress the two vectors into one which
+        //    consists only the higher bytes.
+        const auto in0 = simd16<uint16_t>(input);
+        const auto in1 = simd16<uint16_t>(input + simd16<uint16_t>::SIZE / sizeof(char16_t));
+        const auto t0 = in0.shr<8>();
+        const auto t1 = in1.shr<8>();
+        const simd8<uint8_t> in = simd16<uint16_t>::pack(t0, t1);
+        // 1. Check whether we have any 0xD800..DFFF word (0b1101'1xxx'yyyy'yyyy).
+        const uint64_t surrogates_wordmask = ((in & v_f8) == v_d8).to_bitmask64();
+        if(surrogates_wordmask == 0) {
+            input += 16;
+        } else {
+            // 2. We have some surrogates that have to be distinguished:
+            //    - low  surrogates: 0b1101'10xx'yyyy'yyyy (0xD800..0xDBFF)
+            //    - high surrogates: 0b1101'11xx'yyyy'yyyy (0xDC00..0xDFFF)
+            //
+            //    Fact: high surrogate has 1th bit set (3rd bit in the higher word)
 
-      // V - non-surrogate words
-      //     V = not surrogates_wordmask
-      const uint64_t V = ~surrogates_wordmask;
+            // V - non-surrogate words
+            //     V = not surrogates_wordmask
+            const uint64_t V = ~surrogates_wordmask;
 
-      // H - word-mask for high surrogates: the six highest bits are 0b1101'11
-      const auto vH = ((in & v_fc) == v_dc);
-      const uint64_t H = vH.to_bitmask64();
+            // H - word-mask for high surrogates: the six highest bits are 0b1101'11
+            const auto vH = ((in & v_fc) ==  v_dc);
+            const uint64_t H = vH.to_bitmask64();
 
-      // L - word mask for low surrogates
-      //     L = not H and surrogates_wordmask
-      const uint64_t L = ~H & surrogates_wordmask;
+            // L - word mask for low surrogates
+            //     L = not H and surrogates_wordmask
+            const uint64_t L = ~H & surrogates_wordmask;
 
-      const uint64_t a =
-          L & (H >> 4);  // A low surrogate must be followed by high one.
-                         // (A low surrogate placed in the 7th register's word
-                         // is an exception we handle.)
-      const uint64_t b =
-          a << 4;  // Just mark that the opposite fact is hold,
-                   // thanks to that we have only two masks for valid case.
-      const uint64_t c =
-          V | a | b;  // Combine all the masks into the final one.
-      if (c == ~0ull) {
-        // The whole input register contains valid UTF-16, i.e.,
-        // either single words or proper surrogate pairs.
-        input += 16;
-      } else if (c == 0xfffffffffffffffull) {
-        // The 15 lower words of the input register contains valid UTF-16.
-        // The 15th word may be either a low or high surrogate. It the next
-        // iteration we 1) check if the low surrogate is followed by a high
-        // one, 2) reject sole high surrogate.
-        input += 15;
-      } else {
-        return nullptr;
-      }
+            const uint64_t a = L & (H >> 4); // A low surrogate must be followed by high one.
+                              // (A low surrogate placed in the 7th register's word
+                              // is an exception we handle.)
+            const uint64_t b = a << 4; // Just mark that the opposite fact is hold,
+                          // thanks to that we have only two masks for valid case.
+            const uint64_t c = V | a | b;      // Combine all the masks into the final one.
+            if (c == ~0ull) {
+                // The whole input register contains valid UTF-16, i.e.,
+                // either single words or proper surrogate pairs.
+                input += 16;
+            } else if (c == 0xfffffffffffffffull) {
+                // The 15 lower words of the input register contains valid UTF-16.
+                // The 15th word may be either a low or high surrogate. It the next
+                // iteration we 1) check if the low surrogate is followed by a high
+                // one, 2) reject sole high surrogate.
+                input += 15;
+            } else {
+                return nullptr;
+            }
+        }
     }
-  }
-  return input;
+    return input;
 }

--- a/src/arm64/arm_validate_utf16le.cpp
+++ b/src/arm64/arm_validate_utf16le.cpp
@@ -23,7 +23,7 @@ const char16_t* arm_validate_utf16le(const char16_t* input, size_t size) {
             //    - low  surrogates: 0b1101'10xx'yyyy'yyyy (0xD800..0xDBFF)
             //    - high surrogates: 0b1101'11xx'yyyy'yyyy (0xDC00..0xDFFF)
             //
-            //    Fact: high surrogate has 1th bit set (3rd bit in the higher word)
+            //    Fact: high surrogate has 11th bit set (3rd bit in the higher word)
 
             // V - non-surrogate words
             //     V = not surrogates_wordmask

--- a/src/simdutf/arm64/simd.h
+++ b/src/simdutf/arm64/simd.h
@@ -190,6 +190,9 @@ simdutf_really_inline int16x8_t make_int16x8_t(int16_t x1,  int16_t x2,  int16_t
 
     // Returns a 64 bit integer with every bit being replicated to 4, so in
     // result it is 64 bit.
+    // This method is expected to be faster than none() and is equivalent
+    // when the vector register is the result of a comparison, with byte
+    // values 0xff and 0x00.
     simdutf_really_inline uint64_t to_bitmask64() const {
       return vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(*this), 4)), 0);
     }

--- a/src/simdutf/arm64/simd.h
+++ b/src/simdutf/arm64/simd.h
@@ -188,7 +188,7 @@ simdutf_really_inline int16x8_t make_int16x8_t(int16_t x1,  int16_t x2,  int16_t
       return vgetq_lane_u16(vreinterpretq_u16_u8(tmp), 0);
     }
 
-    // Returns a 64 bit integer with every bit being replicated to 4, so in
+    // Returns 4-bit out of each byte, alternating between the high 4 bits and low bits
     // result it is 64 bit.
     // This method is expected to be faster than none() and is equivalent
     // when the vector register is the result of a comparison, with byte

--- a/src/simdutf/arm64/simd.h
+++ b/src/simdutf/arm64/simd.h
@@ -187,6 +187,13 @@ simdutf_really_inline int16x8_t make_int16x8_t(int16_t x1,  int16_t x2,  int16_t
       tmp = vpaddq_u8(tmp, tmp);
       return vgetq_lane_u16(vreinterpretq_u16_u8(tmp), 0);
     }
+
+    // Returns a 64 bit integer with every bit being replicated to 4, so in
+    // result it is 64 bit.
+    simdutf_really_inline uint64_t to_bitmask64() const {
+      return vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(*this), 4)), 0);
+    }
+
     simdutf_really_inline bool any() const { return vmaxvq_u8(*this) != 0; }
     simdutf_really_inline bool none() const { return vmaxvq_u8(*this) == 0; }
     simdutf_really_inline bool all() const { return vminvq_u8(*this) == 0xFF; }


### PR DESCRIPTION
Closes #136

Before:

```
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
===========================
testcases: 1
input detected as UTF16 little-endian
current system detected as arm64
===========================
validate_utf16+arm64, input size: 65542, iterations: 10000, dataset: unicode_lipsum/lipsum/Emoji-Lipsum.utf16.txt
kpc_set_config failed, run the program with sudo
   1.873 GB/s (7.2 %)    0.936 Gc/s     2.00 byte/char 
validate_utf16+fallback, input size: 65542, iterations: 10000, dataset: unicode_lipsum/lipsum/Emoji-Lipsum.utf16.txt
   2.579 GB/s (3.4 %)    1.289 Gc/s     2.00 byte/char 
```

After:

```
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
===========================
testcases: 1
input detected as UTF16 little-endian
current system detected as arm64
===========================
validate_utf16+arm64, input size: 65542, iterations: 10000, dataset: unicode_lipsum/lipsum/Emoji-Lipsum.utf16.txt
kpc_set_config failed, run the program with sudo
  14.304 GB/s (20.4 %)    7.152 Gc/s     2.00 byte/char 
WARNING: Measurements are noisy, try increasing iteration count (-I).
validate_utf16+fallback, input size: 65542, iterations: 10000, dataset: unicode_lipsum/lipsum/Emoji-Lipsum.utf16.txt
   2.579 GB/s (1.1 %)    1.289 Gc/s     2.00 byte/char
```