### PR TITLE
AVX-512 UTF-16 to UTF-32

### DIFF
--- a/src/icelake/icelake-convert-utf16-to-utf32.inl.cpp
+++ b/src/icelake/icelake-convert-utf16-to-utf32.inl.cpp
@@ -13,14 +13,14 @@ std::pair<const char16_t*, char32_t*> convert_utf16_to_utf32(const char16_t* buf
   while (buf + 32 <= end) {
     __m512i in = _mm512_loadu_si512((__m512i*)buf);
 
-    // L - bitmask for surrogates
-    const __mmask32 L = _mm512_cmpeq_epi16_mask(_mm512_and_si512(in, v_fc00), v_d800);
     // H - bitmask for high surrogates
-    const __mmask32 H = _mm512_cmpeq_epi16_mask(_mm512_and_si512(in, v_fc00), v_dc00);
+    const __mmask32 H = _mm512_cmpeq_epi16_mask(_mm512_and_si512(in, v_fc00), v_d800);
+    // H - bitmask for low surrogates
+    const __mmask32 L = _mm512_cmpeq_epi16_mask(_mm512_and_si512(in, v_fc00), v_dc00);
 
     if ((H|L)) {
       // surrogate pair(s) in a register
-      const __mmask32 V = (H ^ (L << 1));   // A low surrogate must be followed by high one and a high one must be preceded by a low one.
+      const __mmask32 V = (L ^ (H << 1));   // A high surrogate must be followed by low one and a low one must be preceded by a high one.
                                             // If valid, V should be equal to 0. We must also handle when the last word of the chunk is a
                                             // low surrogate.
 
@@ -28,8 +28,8 @@ std::pair<const char16_t*, char32_t*> convert_utf16_to_utf32(const char16_t* buf
         // valid case
         /*
             Input surrogate pair:
-            |1101.10aa.aaaa.aaaa|1101.10bb.bbbb.bbbb|
-                high surrogate      low surrogate
+            |1101.11aa.aaaa.aaaa|1101.10bb.bbbb.bbbb|
+                low surrogate      high surrogate
         */
         /*  1. Expand all words to 32-bit words
             in  |0000.0000.0000.0000.1101.11aa.aaaa.aaaa|0000.0000.0000.0000.1101.10bb.bbbb.bbbb|
@@ -37,18 +37,18 @@ std::pair<const char16_t*, char32_t*> convert_utf16_to_utf32(const char16_t* buf
         const __m512i first = _mm512_cvtepu16_epi32(_mm512_castsi512_si256(in));
         const __m512i second = _mm512_cvtepu16_epi32(_mm512_extracti32x8_epi32(in,1));
 
-        /*  2. Shift by one 16-bit word to align high surrogates with low surrogates
+        /*  2. Shift by one 16-bit word to align low surrogates with high surrogates
             in      |0000.0000.0000.0000.1101.11aa.aaaa.aaaa|0000.0000.0000.0000.1101.10bb.bbbb.bbbb|
             shifted |????.????.????.????.????.????.????.????|0000.0000.0000.0000.1101.11aa.aaaa.aaaa|
         */
         const __m512i shifted_first = _mm512_alignr_epi32(second, first, 1);
         const __m512i shifted_second = _mm512_alignr_epi32(_mm512_setzero_si512(), second, 1);
 
-        /*  3. Align all low surrogates in first and second by shifting to the left by 10 bits
+        /*  3. Align all high surrogates in first and second by shifting to the left by 10 bits
             |0000.0000.0000.0000.1101.11aa.aaaa.aaaa|0000.0011.0110.bbbb.bbbb.bb00.0000.0000|
         */
-        const __m512i aligned_first = _mm512_mask_slli_epi32(first, (__mmask16)L, first, 10);
-        const __m512i aligned_second = _mm512_mask_slli_epi32(second, (__mmask16)(L>>16), second, 10);
+        const __m512i aligned_first = _mm512_mask_slli_epi32(first, (__mmask16)H, first, 10);
+        const __m512i aligned_second = _mm512_mask_slli_epi32(second, (__mmask16)(H>>16), second, 10);
 
         /*  4. Remove surrogate prefixes and add offset 0x10000 by adding in, shifted and constant
             in      |0000.0000.0000.0000.1101.11aa.aaaa.aaaa|0000.0011.0110.bbbb.bbbb.bb00.0000.0000|
@@ -56,24 +56,23 @@ std::pair<const char16_t*, char32_t*> convert_utf16_to_utf32(const char16_t* buf
             constant|1111.1100.1010.0000.0010.0100.0000.0000|1111.1100.1010.0000.0010.0100.0000.0000|
         */
         const __m512i constant = _mm512_set1_epi32((uint32_t)0xfca02400);
-        const __m512i added_first = _mm512_mask_add_epi32(aligned_first, (__mmask16)L, aligned_first, shifted_first);
-        const __m512i utf32_first = _mm512_mask_add_epi32(added_first, (__mmask16)L, added_first, constant);
+        const __m512i added_first = _mm512_mask_add_epi32(aligned_first, (__mmask16)H, aligned_first, shifted_first);
+        const __m512i utf32_first = _mm512_mask_add_epi32(added_first, (__mmask16)H, added_first, constant);
 
-        const __m512i added_second = _mm512_mask_add_epi32(aligned_second, (__mmask16)(L>>16), aligned_second, shifted_second);
-        const __m512i utf32_second = _mm512_mask_add_epi32(added_second, (__mmask16)(L>>16), added_second, constant);
+        const __m512i added_second = _mm512_mask_add_epi32(aligned_second, (__mmask16)(H>>16), aligned_second, shifted_second);
+        const __m512i utf32_second = _mm512_mask_add_epi32(added_second, (__mmask16)(H>>16), added_second, constant);
 
-        //  5. Store all valid UTF-32 words (only high surrogate positions are invalid)
-        _mm512_mask_compressstoreu_epi32((__m512i *)utf32_output, (__mmask16)(~H), utf32_first);
-        utf32_output += count_ones((uint16_t)(~H));
-        _mm512_mask_compressstoreu_epi32((__m512i *)utf32_output, (__mmask16)((~H)>>16), utf32_second);
-        utf32_output += count_ones((~H)>>16);
-
-        buf += 32;
-        // If last word in the chunk is a low surrogate, we process it in the next iteration to check if valid
-        if ((L & 0x80000000) == 0x80000000) {
-          utf32_output--;
-          buf--;
-        }
+        //  5. Store all valid UTF-32 words (only low surrogate positions are invalid)
+        const __m512i compressed_first = _mm512_maskz_compress_epi32((__mmask16)(~L), utf32_first);
+        const auto count_first = count_ones((uint16_t)(~L));
+        _mm512_mask_storeu_epi32((__m512i *) utf32_output, __mmask16((1 << count_first) - 1),compressed_first);
+        utf32_output += count_first;
+        const __m512i compressed_second = _mm512_maskz_compress_epi32((__mmask16)((~L)>>16), utf32_second);
+        const auto count_second = count_ones((~L)>>16);
+        _mm512_mask_storeu_epi32((__m512i *) utf32_output, __mmask16((1 << count_second) - 1), compressed_second);
+        utf32_output += count_second;
+        // Only process 31 words, but keep track of the 32nd word as a lookahead/carry for next iteration
+        buf += 31;
       } else {
         // invalid case
         return std::make_pair(nullptr, utf32_output);

--- a/src/icelake/icelake-convert-utf16-to-utf32.inl.cpp
+++ b/src/icelake/icelake-convert-utf16-to-utf32.inl.cpp
@@ -85,6 +85,7 @@ std::pair<const char16_t*, char32_t*> convert_utf16_to_utf32(const char16_t* buf
       _mm512_storeu_si512((__m512i *)(utf32_output + 16), _mm512_cvtepu16_epi32(_mm512_extracti32x8_epi32(in,1)));
       utf32_output += 32;
       buf += 32;
+      carry = 0;
     }
   } // while
 

--- a/src/icelake/icelake-convert-utf16-to-utf32.inl.cpp
+++ b/src/icelake/icelake-convert-utf16-to-utf32.inl.cpp
@@ -39,31 +39,18 @@ std::pair<const char16_t*, char32_t*> convert_utf16_to_utf32(const char16_t* buf
             |1101.10aa.aaaa.aaaa|1101.10bb.bbbb.bbbb|
                 high surrogate      low surrogate
         */
-
-        /*  1. Load an offset by one 16-bit word to align high surrogates with low surrogates
-            in      |1101.11aa.aaaa.aaaa|1101.10bb.bbbb.bbbb|
-            shifted |????.????.????.????|1101.11aa.aaaa.aaaa|
-        */
-        const __m512i shift_right = _mm512_setr_epi64(
-              0x0004000300020001,
-              0x0008000700060005,
-              0x000c000b000a0009,
-              0x0010000f000e000d,
-              0x0014001300120011,
-              0x0018001700160015,
-              0x001c001b001a0019,
-              0x0000001f001e001d
-        );
-        const __m512i shifted = _mm512_permutexvar_epi16(shift_right, in);
-
-        /*  2. Expand all words to 32-bit words
-            in      |0000.0000.0000.0000.1101.11aa.aaaa.aaaa|0000.0000.0000.0000.1101.10bb.bbbb.bbbb|
-            shifted |????.????.????.????.????.????.????.????|0000.0000.0000.0000.1101.11aa.aaaa.aaaa|
+        /*  1. Expand all words to 32-bit words
+            in  |0000.0000.0000.0000.1101.11aa.aaaa.aaaa|0000.0000.0000.0000.1101.10bb.bbbb.bbbb|
         */
         const __m512i first = _mm512_cvtepu16_epi32(_mm512_castsi512_si256(in));
         const __m512i second = _mm512_cvtepu16_epi32(_mm512_extracti32x8_epi32(in,1));
-        const __m512i shifted_first = _mm512_cvtepu16_epi32(_mm512_castsi512_si256(shifted));
-        const __m512i shifted_second = _mm512_cvtepu16_epi32(_mm512_extracti32x8_epi32(shifted,1));
+
+        /*  2. Shift by one 16-bit word to align high surrogates with low surrogates
+            in      |0000.0000.0000.0000.1101.11aa.aaaa.aaaa|0000.0000.0000.0000.1101.10bb.bbbb.bbbb|
+            shifted |????.????.????.????.????.????.????.????|0000.0000.0000.0000.1101.11aa.aaaa.aaaa|
+        */
+        const __m512i shifted_first = _mm512_alignr_epi32(second, first, 1);
+        const __m512i shifted_second = _mm512_alignr_epi32(_mm512_setzero_si512(), second, 1);
 
         /*  3. Align all low surrogates in first and second by shifting to the left by 10 bits
             |0000.0000.0000.0000.1101.11aa.aaaa.aaaa|0000.0011.0110.bbbb.bbbb.bb00.0000.0000|

--- a/src/icelake/icelake-convert-utf16-to-utf32.inl.cpp
+++ b/src/icelake/icelake-convert-utf16-to-utf32.inl.cpp
@@ -28,12 +28,11 @@ std::pair<const char16_t*, char32_t*> convert_utf16_to_utf32(const char16_t* buf
       const __mmask32 L = _mm512_cmpeq_epi16_mask(_mm512_and_si512(in, v_fc00), v_d800);
       // H - bitmask for high surrogates
       const __mmask32 H = ~L & S;
-      const __mmask32 V = (L ^ (H >> 1)) | (H ^ (L << 1));
-                                                                    // A low surrogate must be followed by high one and a high one must be preceded by a low one.
-                                                                    // If valid, V should be equal to 0, except if a surrogate is the last word of the chunk.
-                                                                    // This is special (valid) case that we need to handle.
+      const __mmask32 V = (H ^ (L << 1));   // A low surrogate must be followed by high one and a high one must be preceded by a low one.
+                                            // If valid, V should be equal to 0. We must also handle when the last word of the chunk is a
+                                            // low surrogate.
 
-      if(V == 0 || V == 0x80000000) {
+      if(V == 0) {
         // valid case
         /*
             Input surrogate pair:
@@ -41,52 +40,48 @@ std::pair<const char16_t*, char32_t*> convert_utf16_to_utf32(const char16_t* buf
                 high surrogate      low surrogate
         */
 
-        /*  0. Remove all surrogate prefixes
-            |0000.00aa.aaaa.aaaa|0000.00bb.bbbb.bbbb|
+        /*  1. Load an offset by one 16-bit word to align high surrogates with low surrogates
+            in      |1101.11aa.aaaa.aaaa|1101.10bb.bbbb.bbbb|
+            shifted |????.????.????.????|1101.11aa.aaaa.aaaa|
         */
-        const __m512i v_0000_03ff = _mm512_set1_epi16((uint16_t)0x3ff);
-        const __m512i no_prefix = _mm512_mask_blend_epi16(S, in, _mm512_and_si512(in, v_0000_03ff));
+        const __m512i shifted = _mm512_loadu_si512((__m512i*)(buf+1));
 
-        /*  1. Shift whole register by 16 bits (one word) to the right
-            |????.????.????.????|0000.00aa.aaaa.aaaa|
+        /*  2. Expand all words to 32-bit words
+            in      |0000.0000.0000.0000.1101.11aa.aaaa.aaaa|0000.0000.0000.0000.1101.10bb.bbbb.bbbb|
+            shifted |????.????.????.????.????.????.????.????|0000.0000.0000.0000.1101.11aa.aaaa.aaaa|
         */
-        const __m512i shifted = _mm512_and_si512(v_0000_03ff, _mm512_loadu_si512((__m512i*)(buf+1)));
-
-        /*  2. Expand all words in no_prefix and shifted to 32-bit words
-            no_prefix |0000.0000.0000.0000.0000.00aa.aaaa.aaaa|0000.0000.0000.0000.0000.00bb.bbbb.bbbb|
-            shifted   |????.????.????.????.????.????.????.????|0000.0000.0000.0000.0000.00aa.aaaa.aaaa|
-        */
-        const __m512i first = _mm512_cvtepu16_epi32(_mm512_castsi512_si256(no_prefix));
-        const __m512i second = _mm512_cvtepu16_epi32(_mm512_extracti32x8_epi32(no_prefix,1));
+        const __m512i first = _mm512_cvtepu16_epi32(_mm512_castsi512_si256(in));
+        const __m512i second = _mm512_cvtepu16_epi32(_mm512_extracti32x8_epi32(in,1));
         const __m512i shifted_first = _mm512_cvtepu16_epi32(_mm512_castsi512_si256(shifted));
         const __m512i shifted_second = _mm512_cvtepu16_epi32(_mm512_extracti32x8_epi32(shifted,1));
 
         /*  3. Align all low surrogates in first and second by shifting to the left by 10 bits
-            |0000.0000.0000.0000.0000.00aa.aaaa.aaaa|0000.0000.0000.bbbb.bbbb.bb00.0000.0000|
+            |0000.0000.0000.0000.1101.11aa.aaaa.aaaa|0000.0011.0110.bbbb.bbbb.bb00.0000.0000|
         */
         const __m512i aligned_first = _mm512_mask_slli_epi32(first, (__mmask16)L, first, 10);
         const __m512i aligned_second = _mm512_mask_slli_epi32(second, (__mmask16)(L>>16), second, 10);
 
-        /*  4. Join fields A and B in lower 32-bit word (lower surrogate position)
-            |0000.0000.0000.0000.0000.00aa.aaaa.aaaa|0000.0000.0000.bbbb.bbbb.bbaa.aaaa.aaaa|
+        /*  4. Remove surrogate prefixes and add offset 0x10000 by adding in, shifted and constant
+            in      |0000.0000.0000.0000.1101.11aa.aaaa.aaaa|0000.0011.0110.bbbb.bbbb.bb00.0000.0000|
+            shifted |????.????.????.????.????.????.????.????|0000.0000.0000.0000.1101.11aa.aaaa.aaaa|
+            constant|1111.1100.1010.0000.0010.0100.0000.0000|1111.1100.1010.0000.0010.0100.0000.0000|
         */
-        const __m512i joined_first = _mm512_mask_or_epi32(aligned_first, (__mmask16)L, shifted_first, aligned_first);
-        const __m512i joined_second = _mm512_mask_or_epi32(aligned_second, (__mmask16)(L>>16), shifted_second, aligned_second);
+        const __m512i constant = _mm512_set1_epi32((uint32_t)0xfca02400);
+        const __m512i added_first = _mm512_mask_add_epi32(aligned_first, (__mmask16)L, aligned_first, shifted_first);
+        const __m512i utf32_first = _mm512_mask_add_epi32(added_first, (__mmask16)L, added_first, constant);
 
-        //  5. Add offset 0x10000 to lower 32-bit word to obtain valid UTF-32
-        const __m512i v_0001_0000 = _mm512_set1_epi32((uint32_t)0x10000);
-        const __m512i utf32_first = _mm512_mask_add_epi32(joined_first, (__mmask16)L, joined_first, v_0001_0000);
-        const __m512i utf32_second = _mm512_mask_add_epi32(joined_second, (__mmask16)(L>>16), joined_second, v_0001_0000);
+        const __m512i added_second = _mm512_mask_add_epi32(aligned_second, (__mmask16)(L>>16), aligned_second, shifted_second);
+        const __m512i utf32_second = _mm512_mask_add_epi32(added_second, (__mmask16)(L>>16), added_second, constant);
 
-        //  6. Store all valid UTF-32 words (only high surrogate positions are invalid)
+        //  5. Store all valid UTF-32 words (only high surrogate positions are invalid)
         _mm512_mask_compressstoreu_epi32((__m512i *)utf32_output, (__mmask16)(~H), utf32_first);
         utf32_output += count_ones((uint16_t)(~H));
         _mm512_mask_compressstoreu_epi32((__m512i *)utf32_output, (__mmask16)((~H)>>16), utf32_second);
         utf32_output += count_ones((~H)>>16);
 
         buf += 32;
-        // If last word in the chunk is a lone a surrogate, we process it in the next iteration to check if valid
-        if (V == 0x80000000) {
+        // If last word in the chunk is a low surrogate, we process it in the next iteration to check if valid
+        if ((L & 0x80000000) == 0x80000000) {
           utf32_output--;
           buf--;
         }

--- a/src/icelake/icelake-convert-utf16-to-utf32.inl.cpp
+++ b/src/icelake/icelake-convert-utf16-to-utf32.inl.cpp
@@ -27,10 +27,10 @@ std::pair<const char16_t*, char32_t*> convert_utf16_to_utf32(const char16_t* buf
       // L - bitmask for low surrogates
       const __mmask32 L = _mm512_cmpeq_epi16_mask(_mm512_and_si512(in, v_fc00), v_d800);
       // H - bitmask for high surrogates
-      const __mmask32 H = _kand_mask32(_knot_mask32(L), S); // H = ~L & S
-      const __mmask32 V = _kxor_mask32(L, _kshiftri_mask32(H, 1));  // V = L ^ (H >> 1)
+      const __mmask32 H = ~L & S;
+      const __mmask32 V = (L ^ (H >> 1)) | (H ^ (L << 1));
                                                                     // A low surrogate must be followed by high one and a high one must be preceded by a low one.
-                                                                    // If valid, V should be equal to 0, except if a low surrogate is the last word of the chunk.
+                                                                    // If valid, V should be equal to 0, except if a surrogate is the last word of the chunk.
                                                                     // This is special (valid) case that we need to handle.
 
       if(V == 0 || V == 0x80000000) {
@@ -50,17 +50,7 @@ std::pair<const char16_t*, char32_t*> convert_utf16_to_utf32(const char16_t* buf
         /*  1. Shift whole register by 16 bits (one word) to the right
             |????.????.????.????|0000.00aa.aaaa.aaaa|
         */
-        const __m512i shift_right = _mm512_setr_epi64(
-            0x0908070605040302,
-            0x11100f0e0d0c0b0a,
-            0x1918171615141312,
-            0x21201f1e1d1c1b1a,
-            0x2928272625242322,
-            0x31302f2e2d2c2b2a,
-            0x3938373635343332,
-            0x80803f3e3d3c3b3a
-        );
-        const __m512i shifted = _mm512_shuffle_epi8(no_prefix, shift_right);
+        const __m512i shifted = _mm512_and_si512(v_0000_03ff, _mm512_loadu_si512((__m512i*)(buf+1)));
 
         /*  2. Expand all words in no_prefix and shifted to 32-bit words
             no_prefix |0000.0000.0000.0000.0000.00aa.aaaa.aaaa|0000.0000.0000.0000.0000.00bb.bbbb.bbbb|
@@ -75,24 +65,24 @@ std::pair<const char16_t*, char32_t*> convert_utf16_to_utf32(const char16_t* buf
             |0000.0000.0000.0000.0000.00aa.aaaa.aaaa|0000.0000.0000.bbbb.bbbb.bb00.0000.0000|
         */
         const __m512i aligned_first = _mm512_mask_slli_epi32(first, (__mmask16)L, first, 10);
-        const __m512i aligned_second = _mm512_mask_slli_epi32(second, (__mmask16)(_kshiftri_mask32(L, 16)), second, 10);
+        const __m512i aligned_second = _mm512_mask_slli_epi32(second, (__mmask16)(L>>16), second, 10);
 
         /*  4. Join fields A and B in lower 32-bit word (lower surrogate position)
             |0000.0000.0000.0000.0000.00aa.aaaa.aaaa|0000.0000.0000.bbbb.bbbb.bbaa.aaaa.aaaa|
         */
         const __m512i joined_first = _mm512_mask_or_epi32(aligned_first, (__mmask16)L, shifted_first, aligned_first);
-        const __m512i joined_second = _mm512_mask_or_epi32(aligned_second, (__mmask16)(_kshiftri_mask32(L, 16)), shifted_second, aligned_second);
+        const __m512i joined_second = _mm512_mask_or_epi32(aligned_second, (__mmask16)(L>>16), shifted_second, aligned_second);
 
         //  5. Add offset 0x10000 to lower 32-bit word to obtain valid UTF-32
         const __m512i v_0001_0000 = _mm512_set1_epi32((uint32_t)0x10000);
         const __m512i utf32_first = _mm512_mask_add_epi32(joined_first, (__mmask16)L, joined_first, v_0001_0000);
-        const __m512i utf32_second = _mm512_mask_add_epi32(joined_second, (__mmask16)(_kshiftri_mask32(L, 16)), joined_second, v_0001_0000);
+        const __m512i utf32_second = _mm512_mask_add_epi32(joined_second, (__mmask16)(L>>16), joined_second, v_0001_0000);
 
         //  6. Store all valid UTF-32 words (only high surrogate positions are invalid)
-        _mm512_mask_compressstoreu_epi32((__m512i *)utf32_output, (__mmask16)(_knot_mask32(H)), utf32_first);
-        utf32_output += count_ones(_cvtmask16_u32((__mmask16)_knot_mask32(H)));
-        _mm512_mask_compressstoreu_epi32((__m512i *)utf32_output, (__mmask16)(_kshiftri_mask32(_knot_mask32(H), 16)), utf32_second);
-        utf32_output += count_ones(_cvtmask32_u32(_kshiftri_mask32(_knot_mask32(H),16)));
+        _mm512_mask_compressstoreu_epi32((__m512i *)utf32_output, (__mmask16)(~H), utf32_first);
+        utf32_output += count_ones((uint16_t)(~H));
+        _mm512_mask_compressstoreu_epi32((__m512i *)utf32_output, (__mmask16)((~H)>>16), utf32_second);
+        utf32_output += count_ones((~H)>>16);
 
         buf += 32;
         // If last word in the chunk is a lone a surrogate, we process it in the next iteration to check if valid

--- a/src/icelake/icelake-convert-utf16-to-utf32.inl.cpp
+++ b/src/icelake/icelake-convert-utf16-to-utf32.inl.cpp
@@ -44,7 +44,17 @@ std::pair<const char16_t*, char32_t*> convert_utf16_to_utf32(const char16_t* buf
             in      |1101.11aa.aaaa.aaaa|1101.10bb.bbbb.bbbb|
             shifted |????.????.????.????|1101.11aa.aaaa.aaaa|
         */
-        const __m512i shifted = _mm512_loadu_si512((__m512i*)(buf+1));
+        const __m512i shift_right = _mm512_setr_epi64(
+              0x0004000300020001,
+              0x0008000700060005,
+              0x000c000b000a0009,
+              0x0010000f000e000d,
+              0x0014001300120011,
+              0x0018001700160015,
+              0x001c001b001a0019,
+              0x0000001f001e001d
+        );
+        const __m512i shifted = _mm512_permutexvar_epi16(shift_right, in);
 
         /*  2. Expand all words to 32-bit words
             in      |0000.0000.0000.0000.1101.11aa.aaaa.aaaa|0000.0000.0000.0000.1101.10bb.bbbb.bbbb|

--- a/src/icelake/icelake-convert-utf16-to-utf32.inl.cpp
+++ b/src/icelake/icelake-convert-utf16-to-utf32.inl.cpp
@@ -1,0 +1,110 @@
+// file included directly
+
+/*
+  Returns a pair: the first unprocessed byte from buf and utf32_output
+  A scalar routing should carry on the conversion of the tail.
+*/
+std::pair<const char16_t*, char32_t*> convert_utf16_to_utf32(const char16_t* buf, size_t len, char32_t* utf32_output) {
+  const char16_t* end = buf + len;
+  const __m512i v_f800 = _mm512_set1_epi16((uint16_t)0xf800);
+  const __m512i v_d800 = _mm512_set1_epi16((uint16_t)0xd800);
+
+  while (buf + 32 <= end) {
+    __m512i in = _mm512_loadu_si512((__m512i*)buf);
+
+    // S - bitmask for surrogates
+    const __mmask32 S = _mm512_cmpeq_epi16_mask(_mm512_and_si512(in, v_f800), v_d800);
+
+    if (S == 0x00000000) {
+    // extend all thirty-two 16-bit words to thirty-two 32-bit words
+      _mm512_storeu_si512((__m512i *)(utf32_output), _mm512_cvtepu16_epi32(_mm512_castsi512_si256(in)));
+      _mm512_storeu_si512((__m512i *)(utf32_output + 16), _mm512_cvtepu16_epi32(_mm512_extracti32x8_epi32(in,1)));
+      utf32_output += 32;
+      buf += 32;
+    // surrogate pair(s) in a register
+    } else {
+      const __m512i v_fc00 = _mm512_set1_epi16((uint16_t)0xfc00);
+      // L - bitmask for low surrogates
+      const __mmask32 L = _mm512_cmpeq_epi16_mask(_mm512_and_si512(in, v_fc00), v_d800);
+      // H - bitmask for high surrogates
+      const __mmask32 H = _kand_mask32(_knot_mask32(L), S); // H = ~L & S
+      const __mmask32 V = _kxor_mask32(L, _kshiftri_mask32(H, 1));  // V = L ^ (H >> 1)
+                                                                    // A low surrogate must be followed by high one and a high one must be preceded by a low one.
+                                                                    // If valid, V should be equal to 0, except if a low surrogate is the last word of the chunk.
+                                                                    // This is special (valid) case that we need to handle.
+
+      if(V == 0 || V == 0x80000000) {
+        // valid case
+        /*
+            Input surrogate pair:
+            |1101.10aa.aaaa.aaaa|1101.10bb.bbbb.bbbb|
+                high surrogate      low surrogate
+        */
+
+        /*  0. Remove all surrogate prefixes
+            |0000.00aa.aaaa.aaaa|0000.00bb.bbbb.bbbb|
+        */
+        const __m512i v_0000_03ff = _mm512_set1_epi16((uint16_t)0x3ff);
+        const __m512i no_prefix = _mm512_mask_blend_epi16(S, in, _mm512_and_si512(in, v_0000_03ff));
+
+        /*  1. Shift whole register by 16 bits (one word) to the right
+            |????.????.????.????|0000.00aa.aaaa.aaaa|
+        */
+        const __m512i shift_right = _mm512_setr_epi64(
+            0x0908070605040302,
+            0x11100f0e0d0c0b0a,
+            0x1918171615141312,
+            0x21201f1e1d1c1b1a,
+            0x2928272625242322,
+            0x31302f2e2d2c2b2a,
+            0x3938373635343332,
+            0x80803f3e3d3c3b3a
+        );
+        const __m512i shifted = _mm512_shuffle_epi8(no_prefix, shift_right);
+
+        /*  2. Expand all words in no_prefix and shifted to 32-bit words
+            no_prefix |0000.0000.0000.0000.0000.00aa.aaaa.aaaa|0000.0000.0000.0000.0000.00bb.bbbb.bbbb|
+            shifted   |????.????.????.????.????.????.????.????|0000.0000.0000.0000.0000.00aa.aaaa.aaaa|
+        */
+        const __m512i first = _mm512_cvtepu16_epi32(_mm512_castsi512_si256(no_prefix));
+        const __m512i second = _mm512_cvtepu16_epi32(_mm512_extracti32x8_epi32(no_prefix,1));
+        const __m512i shifted_first = _mm512_cvtepu16_epi32(_mm512_castsi512_si256(shifted));
+        const __m512i shifted_second = _mm512_cvtepu16_epi32(_mm512_extracti32x8_epi32(shifted,1));
+
+        /*  3. Align all low surrogates in first and second by shifting to the left by 10 bits
+            |0000.0000.0000.0000.0000.00aa.aaaa.aaaa|0000.0000.0000.bbbb.bbbb.bb00.0000.0000|
+        */
+        const __m512i aligned_first = _mm512_mask_slli_epi32(first, (__mmask16)L, first, 10);
+        const __m512i aligned_second = _mm512_mask_slli_epi32(second, (__mmask16)(_kshiftri_mask32(L, 16)), second, 10);
+
+        /*  4. Join fields A and B in lower 32-bit word (lower surrogate position)
+            |0000.0000.0000.0000.0000.00aa.aaaa.aaaa|0000.0000.0000.bbbb.bbbb.bbaa.aaaa.aaaa|
+        */
+        const __m512i joined_first = _mm512_mask_or_epi32(aligned_first, (__mmask16)L, shifted_first, aligned_first);
+        const __m512i joined_second = _mm512_mask_or_epi32(aligned_second, (__mmask16)(_kshiftri_mask32(L, 16)), shifted_second, aligned_second);
+
+        //  5. Add offset 0x10000 to lower 32-bit word to obtain valid UTF-32
+        const __m512i v_0001_0000 = _mm512_set1_epi32((uint32_t)0x10000);
+        const __m512i utf32_first = _mm512_mask_add_epi32(joined_first, (__mmask16)L, joined_first, v_0001_0000);
+        const __m512i utf32_second = _mm512_mask_add_epi32(joined_second, (__mmask16)(_kshiftri_mask32(L, 16)), joined_second, v_0001_0000);
+
+        //  6. Store all valid UTF-32 words (only high surrogate positions are invalid)
+        _mm512_mask_compressstoreu_epi32((__m512i *)utf32_output, (__mmask16)(_knot_mask32(H)), utf32_first);
+        utf32_output += count_ones(_cvtmask16_u32((__mmask16)_knot_mask32(H)));
+        _mm512_mask_compressstoreu_epi32((__m512i *)utf32_output, (__mmask16)(_kshiftri_mask32(_knot_mask32(H), 16)), utf32_second);
+        utf32_output += count_ones(_cvtmask32_u32(_kshiftri_mask32(_knot_mask32(H),16)));
+
+        buf += 32;
+        // If last word in the chunk is a lone a surrogate, we process it in the next iteration to check if valid
+        if (V == 0x80000000) {
+          utf32_output--;
+          buf--;
+        }
+      } else {
+        // invalid case
+        return std::make_pair(nullptr, utf32_output);
+      }
+    }
+  } // while
+  return std::make_pair(buf, utf32_output);
+}

--- a/tests/helpers/transcode_test_base.h
+++ b/tests/helpers/transcode_test_base.h
@@ -301,7 +301,7 @@ namespace simdutf { namespace tests { namespace helpers {
 
     std::vector<char16_t> input_utf16; // source-encoded mesage: what we're going to transcode
 
-    static constexpr size_t output_size_margin = 0; // extra room for buggy procedures
+    static constexpr size_t output_size_margin = 16; // extra room for buggy procedures
 
   public:
     transcode_utf16_to_utf32_test_base(GenerateCodepoint generate, size_t input_size);


### PR DESCRIPTION
Fix #129
The algorithm offers a vectorized approach in the presence of surrogate pairs instead of the scalar fallback that we have for other architectures. For surrogates, the idea is to have a register that is shifted by one 16-bit word to the right to align high surrogate words with low surrogate words. We expand all words to 32-bit words of both registers (shifted and non-shifted registers). Then, we shift the bits of the low surrogates by 10 to the left in the non-shifted register, add both registers together and add a constant (0xfca04200, credits to @clausecker) to remove surrogates prefixes and to add the plane shift 0x10000. 

With AVX-512, this is not too hard to do with all the masked instructions and _mm512_mask_compressstoreu_epi32. I might have used too many masked instructions, but I do not know if this affects performance (in Intel's documentation, the throughput and the latency of masked vs non-masked instructions are the same I think). I will test it to be sure.