### PR TITLE
Making the AVX-512 UTF-8 to UTF-16 transcoder more branchy

### DIFF
--- a/src/icelake/icelake-from-utf8.inl.cpp
+++ b/src/icelake/icelake-from-utf8.inl.cpp
@@ -37,27 +37,12 @@ std::pair<const char*, OUTPUT*> validating_utf8_to_fixed_length(const char* str,
             vec0 = _mm512_mask_expand_epi32(vec0, __mmask16(((1<<valid_count1)-1)<<valid_count0), vec1);
             valid_count0 += valid_count1;
             vec0 = expand_utf8_to_utf32(vec0);
-            if (UTF32) {
-                const __mmask16 valid = uint16_t((1 << valid_count0) - 1);
-                _mm512_mask_storeu_epi32((__m512i*)output, valid, vec0);
-                output += valid_count0;
-            } else {
-                output += utf32_to_utf16(vec0, valid_count0, reinterpret_cast<char16_t *>(output));
-            } 
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
         } else {
             vec0 = expand_utf8_to_utf32(vec0);
             vec1 = expand_utf8_to_utf32(vec1);
-            if (UTF32) {
-                const __mmask16 valid0 = uint16_t((1 << valid_count0) - 1);
-                _mm512_mask_storeu_epi32((__m512i*)output, valid0, vec0);
-                output += valid_count0;
-                const __mmask16 valid1 = uint16_t((1 << valid_count1) - 1);
-                _mm512_mask_storeu_epi32((__m512i*)output, valid1, vec1);
-                output += valid_count1;
-            } else {
-                output += utf32_to_utf16(vec0, valid_count0, reinterpret_cast<char16_t *>(output));
-                output += utf32_to_utf16(vec1, valid_count1, reinterpret_cast<char16_t *>(output));
-            } 
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec1, valid_count1)
         }
         const __m512i lane3 = broadcast_epi128<3>(utf8);
         int valid_count2;
@@ -71,27 +56,12 @@ std::pair<const char*, OUTPUT*> validating_utf8_to_fixed_length(const char* str,
             vec2 = _mm512_mask_expand_epi32(vec2, __mmask16(((1<<valid_count3)-1)<<valid_count2), vec3);
             valid_count2 += valid_count3;
             vec2 = expand_utf8_to_utf32(vec2);
-            if (UTF32) {
-                const __mmask16 valid = uint16_t((1 << valid_count2) - 1);
-                _mm512_mask_storeu_epi32((__m512i*)output, valid, vec2);
-                output += valid_count2;
-            } else {
-                output += utf32_to_utf16(vec2, valid_count2, reinterpret_cast<char16_t *>(output));
-            } 
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec2, valid_count2)
         } else {
             vec2 = expand_utf8_to_utf32(vec2);
             vec3 = expand_utf8_to_utf32(vec3);
-            if (UTF32) {
-                const __mmask16 valid2 = uint16_t((1 << valid_count2) - 1);
-                _mm512_mask_storeu_epi32((__m512i*)output, valid2, vec2);
-                output += valid_count2;
-                const __mmask16 valid3 = uint16_t((1 << valid_count3) - 1);
-                _mm512_mask_storeu_epi32((__m512i*)output, valid3, vec3);
-                output += valid_count3;
-            } else {
-                output += utf32_to_utf16(vec2, valid_count2, reinterpret_cast<char16_t *>(output));
-                output += utf32_to_utf16(vec3, valid_count3, reinterpret_cast<char16_t *>(output));
-            } 
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec2, valid_count2)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec3, valid_count3)
         }
         ptr += 4*16;
     }
@@ -117,29 +87,14 @@ std::pair<const char*, OUTPUT*> validating_utf8_to_fixed_length(const char* str,
                 vec0 = _mm512_mask_expand_epi32(vec0, __mmask16(((1<<valid_count1)-1)<<valid_count0), vec1);
                 valid_count0 += valid_count1;
                 vec0 = expand_utf8_to_utf32(vec0);
-                if (UTF32) {
-                    const __mmask16 valid = uint16_t((1 << valid_count0) - 1);
-                    _mm512_mask_storeu_epi32((__m512i*)output, valid, vec0);
-                    output += valid_count0;
-                } else {
-                    output += utf32_to_utf16(vec0, valid_count0, reinterpret_cast<char16_t *>(output));
-                } 
+                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
             } else {
                 vec0 = expand_utf8_to_utf32(vec0);
                 vec1 = expand_utf8_to_utf32(vec1);
-                if (UTF32) {
-                    const __mmask16 valid0 = uint16_t((1 << valid_count0) - 1);
-                    _mm512_mask_storeu_epi32((__m512i*)output, valid0, vec0);
-                    output += valid_count0;
-                    const __mmask16 valid1 = uint16_t((1 << valid_count1) - 1);
-                    _mm512_mask_storeu_epi32((__m512i*)output, valid1, vec1);
-                    output += valid_count1;
-               } else {
-                    output += utf32_to_utf16(vec0, valid_count0, reinterpret_cast<char16_t *>(output));
-                    output += utf32_to_utf16(vec1, valid_count1, reinterpret_cast<char16_t *>(output));
-                } 
+                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
+                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec1, valid_count1)
             }
-        
+
             const __m512i lane3 = broadcast_epi128<3>(utf8);
             SIMDUTF_ICELAKE_TRANSCODE16(lane2, lane3)
 

--- a/src/icelake/icelake-from-utf8.inl.cpp
+++ b/src/icelake/icelake-from-utf8.inl.cpp
@@ -26,22 +26,73 @@ std::pair<const char*, OUTPUT*> validating_utf8_to_fixed_length(const char* str,
             ptr += 64;
             continue;
         }
-
-
         const __m512i lane0 = broadcast_epi128<0>(utf8);
         const __m512i lane1 = broadcast_epi128<1>(utf8);
-        SIMDUTF_ICELAKE_TRANSCODE16(lane0, lane1)
-
+        int valid_count0;
+        __m512i vec0 = expand_and_identify(lane0, lane1, valid_count0);
         const __m512i lane2 = broadcast_epi128<2>(utf8);
-        SIMDUTF_ICELAKE_TRANSCODE16(lane1, lane2)
-
+        int valid_count1;
+        __m512i vec1 = expand_and_identify(lane1, lane2, valid_count1);
+        if(valid_count0 + valid_count1 <= 16) {
+            vec0 = _mm512_mask_expand_epi32(vec0, __mmask16(((1<<valid_count1)-1)<<valid_count0), vec1);
+            valid_count0 += valid_count1;
+            vec0 = expand_utf8_to_utf32(vec0);
+            if (UTF32) {
+                const __mmask16 valid = uint16_t((1 << valid_count0) - 1);
+                _mm512_mask_storeu_epi32((__m512i*)output, valid, vec0);
+                output += valid_count0;
+            } else {
+                output += utf32_to_utf16(vec0, valid_count0, reinterpret_cast<char16_t *>(output));
+            } 
+        } else {
+            vec0 = expand_utf8_to_utf32(vec0);
+            vec1 = expand_utf8_to_utf32(vec1);
+            if (UTF32) {
+                const __mmask16 valid0 = uint16_t((1 << valid_count0) - 1);
+                _mm512_mask_storeu_epi32((__m512i*)output, valid0, vec0);
+                output += valid_count0;
+                const __mmask16 valid1 = uint16_t((1 << valid_count1) - 1);
+                _mm512_mask_storeu_epi32((__m512i*)output, valid1, vec1);
+                output += valid_count1;
+            } else {
+                output += utf32_to_utf16(vec0, valid_count0, reinterpret_cast<char16_t *>(output));
+                output += utf32_to_utf16(vec1, valid_count1, reinterpret_cast<char16_t *>(output));
+            } 
+        }
         const __m512i lane3 = broadcast_epi128<3>(utf8);
-        SIMDUTF_ICELAKE_TRANSCODE16(lane2, lane3)
-
+        int valid_count2;
+        __m512i vec2 = expand_and_identify(lane2, lane3, valid_count2);
         uint32_t tmp1;
         ::memcpy(&tmp1, ptr + 64, sizeof(tmp1));
         const __m512i lane4 = _mm512_set1_epi32(tmp1);
-        SIMDUTF_ICELAKE_TRANSCODE16(lane3, lane4)
+        int valid_count3;
+        __m512i vec3 = expand_and_identify(lane3, lane4, valid_count3);
+        if(valid_count2 + valid_count3 <= 16) {
+            vec2 = _mm512_mask_expand_epi32(vec2, __mmask16(((1<<valid_count3)-1)<<valid_count2), vec3);
+            valid_count2 += valid_count3;
+            vec2 = expand_utf8_to_utf32(vec2);
+            if (UTF32) {
+                const __mmask16 valid = uint16_t((1 << valid_count2) - 1);
+                _mm512_mask_storeu_epi32((__m512i*)output, valid, vec2);
+                output += valid_count2;
+            } else {
+                output += utf32_to_utf16(vec2, valid_count2, reinterpret_cast<char16_t *>(output));
+            } 
+        } else {
+            vec2 = expand_utf8_to_utf32(vec2);
+            vec3 = expand_utf8_to_utf32(vec3);
+            if (UTF32) {
+                const __mmask16 valid2 = uint16_t((1 << valid_count2) - 1);
+                _mm512_mask_storeu_epi32((__m512i*)output, valid2, vec2);
+                output += valid_count2;
+                const __mmask16 valid3 = uint16_t((1 << valid_count3) - 1);
+                _mm512_mask_storeu_epi32((__m512i*)output, valid3, vec3);
+                output += valid_count3;
+            } else {
+                output += utf32_to_utf16(vec2, valid_count2, reinterpret_cast<char16_t *>(output));
+                output += utf32_to_utf16(vec3, valid_count3, reinterpret_cast<char16_t *>(output));
+            } 
+        }
         ptr += 4*16;
     }
     const char* validatedptr = ptr; // validated up to ptr
@@ -57,11 +108,38 @@ std::pair<const char*, OUTPUT*> validating_utf8_to_fixed_length(const char* str,
         } else {
             const __m512i lane0 = broadcast_epi128<0>(utf8);
             const __m512i lane1 = broadcast_epi128<1>(utf8);
-            SIMDUTF_ICELAKE_TRANSCODE16(lane0, lane1)
-
+            int valid_count0;
+            __m512i vec0 = expand_and_identify(lane0, lane1, valid_count0);
             const __m512i lane2 = broadcast_epi128<2>(utf8);
-            SIMDUTF_ICELAKE_TRANSCODE16(lane1, lane2)
-
+            int valid_count1;
+            __m512i vec1 = expand_and_identify(lane1, lane2, valid_count1);
+            if(valid_count0 + valid_count1 <= 16) {
+                vec0 = _mm512_mask_expand_epi32(vec0, __mmask16(((1<<valid_count1)-1)<<valid_count0), vec1);
+                valid_count0 += valid_count1;
+                vec0 = expand_utf8_to_utf32(vec0);
+                if (UTF32) {
+                    const __mmask16 valid = uint16_t((1 << valid_count0) - 1);
+                    _mm512_mask_storeu_epi32((__m512i*)output, valid, vec0);
+                    output += valid_count0;
+                } else {
+                    output += utf32_to_utf16(vec0, valid_count0, reinterpret_cast<char16_t *>(output));
+                } 
+            } else {
+                vec0 = expand_utf8_to_utf32(vec0);
+                vec1 = expand_utf8_to_utf32(vec1);
+                if (UTF32) {
+                    const __mmask16 valid0 = uint16_t((1 << valid_count0) - 1);
+                    _mm512_mask_storeu_epi32((__m512i*)output, valid0, vec0);
+                    output += valid_count0;
+                    const __mmask16 valid1 = uint16_t((1 << valid_count1) - 1);
+                    _mm512_mask_storeu_epi32((__m512i*)output, valid1, vec1);
+                    output += valid_count1;
+               } else {
+                    output += utf32_to_utf16(vec0, valid_count0, reinterpret_cast<char16_t *>(output));
+                    output += utf32_to_utf16(vec1, valid_count1, reinterpret_cast<char16_t *>(output));
+                } 
+            }
+        
             const __m512i lane3 = broadcast_epi128<3>(utf8);
             SIMDUTF_ICELAKE_TRANSCODE16(lane2, lane3)
 

--- a/src/icelake/icelake-from-utf8.inl.cpp
+++ b/src/icelake/icelake-from-utf8.inl.cpp
@@ -18,7 +18,7 @@ std::pair<const char*, OUTPUT*> validating_utf8_to_fixed_length(const char* str,
      * In the main loop, we consume 64 bytes per iteration,
      * but we access 64 + 4 bytes.
      */
-    while (ptr + 64 + 4 <= end) {
+    while (ptr + 64 + 64 <= end) {
         const __m512i utf8 = _mm512_loadu_si512((const __m512i*)ptr);
         if(checker.check_next_input(utf8)) {
             SIMDUTF_ICELAKE_STORE_ASCII(UTF32, utf8, output)
@@ -37,12 +37,12 @@ std::pair<const char*, OUTPUT*> validating_utf8_to_fixed_length(const char* str,
             vec0 = _mm512_mask_expand_epi32(vec0, __mmask16(((1<<valid_count1)-1)<<valid_count0), vec1);
             valid_count0 += valid_count1;
             vec0 = expand_utf8_to_utf32(vec0);
-            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0, false)
         } else {
             vec0 = expand_utf8_to_utf32(vec0);
             vec1 = expand_utf8_to_utf32(vec1);
-            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
-            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec1, valid_count1)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0, false)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec1, valid_count1, false)
         }
         const __m512i lane3 = broadcast_epi128<3>(utf8);
         int valid_count2;
@@ -56,12 +56,12 @@ std::pair<const char*, OUTPUT*> validating_utf8_to_fixed_length(const char* str,
             vec2 = _mm512_mask_expand_epi32(vec2, __mmask16(((1<<valid_count3)-1)<<valid_count2), vec3);
             valid_count2 += valid_count3;
             vec2 = expand_utf8_to_utf32(vec2);
-            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec2, valid_count2)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec2, valid_count2, false)
         } else {
             vec2 = expand_utf8_to_utf32(vec2);
             vec3 = expand_utf8_to_utf32(vec3);
-            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec2, valid_count2)
-            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec3, valid_count3)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec2, valid_count2, false)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec3, valid_count3, false)
         }
         ptr += 4*16;
     }
@@ -87,16 +87,16 @@ std::pair<const char*, OUTPUT*> validating_utf8_to_fixed_length(const char* str,
                 vec0 = _mm512_mask_expand_epi32(vec0, __mmask16(((1<<valid_count1)-1)<<valid_count0), vec1);
                 valid_count0 += valid_count1;
                 vec0 = expand_utf8_to_utf32(vec0);
-                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
+                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0, true)
             } else {
                 vec0 = expand_utf8_to_utf32(vec0);
                 vec1 = expand_utf8_to_utf32(vec1);
-                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
-                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec1, valid_count1)
+                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0, true)
+                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec1, valid_count1, true)
             }
 
             const __m512i lane3 = broadcast_epi128<3>(utf8);
-            SIMDUTF_ICELAKE_TRANSCODE16(lane2, lane3)
+            SIMDUTF_ICELAKE_TRANSCODE16(lane2, lane3, true)
 
             ptr += 3*16;
         }

--- a/src/icelake/icelake-from-valid-utf8.inl.cpp
+++ b/src/icelake/icelake-from-valid-utf8.inl.cpp
@@ -31,8 +31,10 @@ std::pair<const char*, OUTPUT*> valid_utf8_to_fixed_length(const char* str, size
     /**
      * In the main loop, we consume 64 bytes per iteration,
      * but we access 64 + 4 bytes.
+     * We check for ptr + 64 + 64 <= end because
+     * we want to be do maskless writes without overruns.
      */
-    while (ptr + 64 + 4 <= end) {
+    while (ptr + 64 + 64 <= end) {
         const __m512i utf8 = _mm512_loadu_si512((const __m512i*)ptr);
         const __m512i v_80 = _mm512_set1_epi8(char(0x80));
         const __mmask64 ascii = _mm512_test_epi8_mask(utf8, v_80);
@@ -54,12 +56,12 @@ std::pair<const char*, OUTPUT*> valid_utf8_to_fixed_length(const char* str, size
             vec0 = _mm512_mask_expand_epi32(vec0, __mmask16(((1<<valid_count1)-1)<<valid_count0), vec1);
             valid_count0 += valid_count1;
             vec0 = expand_utf8_to_utf32(vec0);
-            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0, false)
         } else {
             vec0 = expand_utf8_to_utf32(vec0);
             vec1 = expand_utf8_to_utf32(vec1);
-            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
-            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec1, valid_count1)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0, false)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec1, valid_count1, false)
         }
         const __m512i lane3 = broadcast_epi128<3>(utf8);
         int valid_count2;
@@ -73,12 +75,12 @@ std::pair<const char*, OUTPUT*> valid_utf8_to_fixed_length(const char* str, size
             vec2 = _mm512_mask_expand_epi32(vec2, __mmask16(((1<<valid_count3)-1)<<valid_count2), vec3);
             valid_count2 += valid_count3;
             vec2 = expand_utf8_to_utf32(vec2);
-            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec2, valid_count2)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec2, valid_count2, false)
         } else {
             vec2 = expand_utf8_to_utf32(vec2);
             vec3 = expand_utf8_to_utf32(vec3);
-            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec2, valid_count2)
-            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec3, valid_count3)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec2, valid_count2, false)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec3, valid_count3, false)
         }
         ptr += 4*16;
     }
@@ -103,16 +105,16 @@ std::pair<const char*, OUTPUT*> valid_utf8_to_fixed_length(const char* str, size
                 vec0 = _mm512_mask_expand_epi32(vec0, __mmask16(((1<<valid_count1)-1)<<valid_count0), vec1);
                 valid_count0 += valid_count1;
                 vec0 = expand_utf8_to_utf32(vec0);
-                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
+                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0, true)
             } else {
                 vec0 = expand_utf8_to_utf32(vec0);
                 vec1 = expand_utf8_to_utf32(vec1);
-                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
-                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec1, valid_count1)
+                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0, true)
+                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec1, valid_count1, true)
             }
 
             const __m512i lane3 = broadcast_epi128<3>(utf8);
-            SIMDUTF_ICELAKE_TRANSCODE16(lane2, lane3)
+            SIMDUTF_ICELAKE_TRANSCODE16(lane2, lane3, true)
 
             ptr += 3*16;
         }

--- a/src/icelake/icelake-from-valid-utf8.inl.cpp
+++ b/src/icelake/icelake-from-valid-utf8.inl.cpp
@@ -54,27 +54,12 @@ std::pair<const char*, OUTPUT*> valid_utf8_to_fixed_length(const char* str, size
             vec0 = _mm512_mask_expand_epi32(vec0, __mmask16(((1<<valid_count1)-1)<<valid_count0), vec1);
             valid_count0 += valid_count1;
             vec0 = expand_utf8_to_utf32(vec0);
-            if (UTF32) {
-                const __mmask16 valid = uint16_t((1 << valid_count0) - 1);
-                _mm512_mask_storeu_epi32((__m512i*)output, valid, vec0);
-                output += valid_count0;
-            } else {
-                output += utf32_to_utf16(vec0, valid_count0, reinterpret_cast<char16_t *>(output));
-            } 
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
         } else {
             vec0 = expand_utf8_to_utf32(vec0);
             vec1 = expand_utf8_to_utf32(vec1);
-            if (UTF32) {
-                const __mmask16 valid0 = uint16_t((1 << valid_count0) - 1);
-                _mm512_mask_storeu_epi32((__m512i*)output, valid0, vec0);
-                output += valid_count0;
-                const __mmask16 valid1 = uint16_t((1 << valid_count1) - 1);
-                _mm512_mask_storeu_epi32((__m512i*)output, valid1, vec1);
-                output += valid_count1;
-            } else {
-                output += utf32_to_utf16(vec0, valid_count0, reinterpret_cast<char16_t *>(output));
-                output += utf32_to_utf16(vec1, valid_count1, reinterpret_cast<char16_t *>(output));
-            } 
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec1, valid_count1)
         }
         const __m512i lane3 = broadcast_epi128<3>(utf8);
         int valid_count2;
@@ -88,27 +73,12 @@ std::pair<const char*, OUTPUT*> valid_utf8_to_fixed_length(const char* str, size
             vec2 = _mm512_mask_expand_epi32(vec2, __mmask16(((1<<valid_count3)-1)<<valid_count2), vec3);
             valid_count2 += valid_count3;
             vec2 = expand_utf8_to_utf32(vec2);
-            if (UTF32) {
-                const __mmask16 valid = uint16_t((1 << valid_count2) - 1);
-                _mm512_mask_storeu_epi32((__m512i*)output, valid, vec2);
-                output += valid_count2;
-            } else {
-                output += utf32_to_utf16(vec2, valid_count2, reinterpret_cast<char16_t *>(output));
-            } 
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec2, valid_count2)
         } else {
             vec2 = expand_utf8_to_utf32(vec2);
             vec3 = expand_utf8_to_utf32(vec3);
-            if (UTF32) {
-                const __mmask16 valid2 = uint16_t((1 << valid_count2) - 1);
-                _mm512_mask_storeu_epi32((__m512i*)output, valid2, vec2);
-                output += valid_count2;
-                const __mmask16 valid3 = uint16_t((1 << valid_count3) - 1);
-                _mm512_mask_storeu_epi32((__m512i*)output, valid3, vec3);
-                output += valid_count3;
-            } else {
-                output += utf32_to_utf16(vec2, valid_count2, reinterpret_cast<char16_t *>(output));
-                output += utf32_to_utf16(vec3, valid_count3, reinterpret_cast<char16_t *>(output));
-            } 
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec2, valid_count2)
+            SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec3, valid_count3)
         }
         ptr += 4*16;
     }
@@ -133,29 +103,14 @@ std::pair<const char*, OUTPUT*> valid_utf8_to_fixed_length(const char* str, size
                 vec0 = _mm512_mask_expand_epi32(vec0, __mmask16(((1<<valid_count1)-1)<<valid_count0), vec1);
                 valid_count0 += valid_count1;
                 vec0 = expand_utf8_to_utf32(vec0);
-                if (UTF32) {
-                    const __mmask16 valid = uint16_t((1 << valid_count0) - 1);
-                    _mm512_mask_storeu_epi32((__m512i*)output, valid, vec0);
-                    output += valid_count0;
-                } else {
-                    output += utf32_to_utf16(vec0, valid_count0, reinterpret_cast<char16_t *>(output));
-                } 
+                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
             } else {
                 vec0 = expand_utf8_to_utf32(vec0);
                 vec1 = expand_utf8_to_utf32(vec1);
-                if (UTF32) {
-                    const __mmask16 valid0 = uint16_t((1 << valid_count0) - 1);
-                    _mm512_mask_storeu_epi32((__m512i*)output, valid0, vec0);
-                    output += valid_count0;
-                    const __mmask16 valid1 = uint16_t((1 << valid_count1) - 1);
-                    _mm512_mask_storeu_epi32((__m512i*)output, valid1, vec1);
-                    output += valid_count1;
-               } else {
-                    output += utf32_to_utf16(vec0, valid_count0, reinterpret_cast<char16_t *>(output));
-                    output += utf32_to_utf16(vec1, valid_count1, reinterpret_cast<char16_t *>(output));
-                } 
+                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0)
+                SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec1, valid_count1)
             }
-        
+
             const __m512i lane3 = broadcast_epi128<3>(utf8);
             SIMDUTF_ICELAKE_TRANSCODE16(lane2, lane3)
 

--- a/src/icelake/icelake-from-valid-utf8.inl.cpp
+++ b/src/icelake/icelake-from-valid-utf8.inl.cpp
@@ -46,18 +46,71 @@ std::pair<const char*, OUTPUT*> valid_utf8_to_fixed_length(const char* str, size
 
         const __m512i lane0 = broadcast_epi128<0>(utf8);
         const __m512i lane1 = broadcast_epi128<1>(utf8);
-        SIMDUTF_ICELAKE_TRANSCODE16(lane0, lane1)
-
+        int valid_count0;
+        __m512i vec0 = expand_and_identify(lane0, lane1, valid_count0);
         const __m512i lane2 = broadcast_epi128<2>(utf8);
-        SIMDUTF_ICELAKE_TRANSCODE16(lane1, lane2)
-
+        int valid_count1;
+        __m512i vec1 = expand_and_identify(lane1, lane2, valid_count1);
+        if(valid_count0 + valid_count1 <= 16) {
+            vec0 = _mm512_mask_expand_epi32(vec0, __mmask16(((1<<valid_count1)-1)<<valid_count0), vec1);
+            valid_count0 += valid_count1;
+            vec0 = expand_utf8_to_utf32(vec0);
+            if (UTF32) {
+                const __mmask16 valid = uint16_t((1 << valid_count0) - 1);
+                _mm512_mask_storeu_epi32((__m512i*)output, valid, vec0);
+                output += valid_count0;
+            } else {
+                output += utf32_to_utf16(vec0, valid_count0, reinterpret_cast<char16_t *>(output));
+            } 
+        } else {
+            vec0 = expand_utf8_to_utf32(vec0);
+            vec1 = expand_utf8_to_utf32(vec1);
+            if (UTF32) {
+                const __mmask16 valid0 = uint16_t((1 << valid_count0) - 1);
+                _mm512_mask_storeu_epi32((__m512i*)output, valid0, vec0);
+                output += valid_count0;
+                const __mmask16 valid1 = uint16_t((1 << valid_count1) - 1);
+                _mm512_mask_storeu_epi32((__m512i*)output, valid1, vec1);
+                output += valid_count1;
+            } else {
+                output += utf32_to_utf16(vec0, valid_count0, reinterpret_cast<char16_t *>(output));
+                output += utf32_to_utf16(vec1, valid_count1, reinterpret_cast<char16_t *>(output));
+            } 
+        }
         const __m512i lane3 = broadcast_epi128<3>(utf8);
-        SIMDUTF_ICELAKE_TRANSCODE16(lane2, lane3)
-
+        int valid_count2;
+        __m512i vec2 = expand_and_identify(lane2, lane3, valid_count2);
         uint32_t tmp1;
         ::memcpy(&tmp1, ptr + 64, sizeof(tmp1));
         const __m512i lane4 = _mm512_set1_epi32(tmp1);
-        SIMDUTF_ICELAKE_TRANSCODE16(lane3, lane4)
+        int valid_count3;
+        __m512i vec3 = expand_and_identify(lane3, lane4, valid_count3);
+        if(valid_count2 + valid_count3 <= 16) {
+            vec2 = _mm512_mask_expand_epi32(vec2, __mmask16(((1<<valid_count3)-1)<<valid_count2), vec3);
+            valid_count2 += valid_count3;
+            vec2 = expand_utf8_to_utf32(vec2);
+            if (UTF32) {
+                const __mmask16 valid = uint16_t((1 << valid_count2) - 1);
+                _mm512_mask_storeu_epi32((__m512i*)output, valid, vec2);
+                output += valid_count2;
+            } else {
+                output += utf32_to_utf16(vec2, valid_count2, reinterpret_cast<char16_t *>(output));
+            } 
+        } else {
+            vec2 = expand_utf8_to_utf32(vec2);
+            vec3 = expand_utf8_to_utf32(vec3);
+            if (UTF32) {
+                const __mmask16 valid2 = uint16_t((1 << valid_count2) - 1);
+                _mm512_mask_storeu_epi32((__m512i*)output, valid2, vec2);
+                output += valid_count2;
+                const __mmask16 valid3 = uint16_t((1 << valid_count3) - 1);
+                _mm512_mask_storeu_epi32((__m512i*)output, valid3, vec3);
+                output += valid_count3;
+            } else {
+                output += utf32_to_utf16(vec2, valid_count2, reinterpret_cast<char16_t *>(output));
+                output += utf32_to_utf16(vec3, valid_count3, reinterpret_cast<char16_t *>(output));
+            } 
+        }
         ptr += 4*16;
     }
 
@@ -74,6 +127,7 @@ std::pair<const char*, OUTPUT*> valid_utf8_to_fixed_length(const char* str, size
         } else {
             const __m512i lane0 = broadcast_epi128<0>(utf8);
             const __m512i lane1 = broadcast_epi128<1>(utf8);
+
             SIMDUTF_ICELAKE_TRANSCODE16(lane0, lane1)
 
             const __m512i lane2 = broadcast_epi128<2>(utf8);

--- a/src/icelake/icelake-macros.inl.cpp
+++ b/src/icelake/icelake-macros.inl.cpp
@@ -40,7 +40,7 @@
         ]
 */
 
-#define SIMDUTF_ICELAKE_TRANSCODE16(LANE0, LANE1)                                                                            \
+#define SIMDUTF_ICELAKE_TRANSCODE16(LANE0, LANE1, MASKED)                                                    \
         {                                                                                                    \
             const __m512i merged = _mm512_mask_mov_epi32(LANE0, 0x1000, LANE1);                              \
             const __m512i expand_ver2 = _mm512_setr_epi64(                                                   \
@@ -74,67 +74,43 @@
             const __m512i out = _mm512_mask_compress_epi32(_mm512_setzero_si512(), leading_bytes, utf32);    \
                                                                                                              \
             if (UTF32) {                                                                                     \
-                const __mmask16 valid = uint16_t((1 << valid_count) - 1);                                    \
-                _mm512_mask_storeu_epi32((__m512i*)output, valid, out);                                      \
+                if(MASKED) {                                                                                 \
+                  const __mmask16 valid = uint16_t((1 << valid_count) - 1);                                  \
+                  _mm512_mask_storeu_epi32((__m512i*)output, valid, out);                                    \
+                } else {                                                                                     \
+                    _mm512_storeu_epi32((__m512i*)output, out);                                              \
+                }                                                                                            \
                 output += valid_count;                                                                       \
             } else {                                                                                         \
-                output += utf32_to_utf16(out, valid_count, reinterpret_cast<char16_t *>(output));            \
+                if(MASKED) {                                                                                 \
+                    output += utf32_to_utf16_masked(out, valid_count, reinterpret_cast<char16_t *>(output)); \
+                } else {                                                                                     \
+                    output += utf32_to_utf16(out, valid_count, reinterpret_cast<char16_t *>(output));        \
+                }                                                                                            \
             }                                                                                                \
         }
 
 
-#define SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(INPUT, VALID_COUNT)                                    \
-{                                                                                                   \
-    if (UTF32) {                                                                                    \
-        const __mmask16 valid_mask = uint16_t((1 << VALID_COUNT) - 1);                              \
-        _mm512_mask_storeu_epi32((__m512i*)output, valid_mask, INPUT);                              \
-        output += VALID_COUNT;                                                                      \
-    } else {                                                                                        \
-        output += utf32_to_utf16(INPUT, VALID_COUNT, reinterpret_cast<char16_t *>(output));         \
-    }                                                                                               \
+#define SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(INPUT, VALID_COUNT, MASKED)                                    \
+{                                                                                                           \
+    if (UTF32) {                                                                                            \
+        if(MASKED) {                                                                                        \
+            const __mmask16 valid_mask = uint16_t((1 << VALID_COUNT) - 1);                                  \
+            _mm512_mask_storeu_epi32((__m512i*)output, valid_mask, INPUT);                                  \
+        } else {                                                                                            \
+            _mm512_storeu_epi32((__m512i*)output, INPUT);                                              \
+        }                                                                                                   \
+        output += VALID_COUNT;                                                                              \
+    } else {                                                                                                \
+        if(MASKED) {                                                                                        \
+            output += utf32_to_utf16_masked(INPUT, VALID_COUNT, reinterpret_cast<char16_t *>(output));      \
+        } else {                                                                                            \
+            output += utf32_to_utf16(INPUT, VALID_COUNT, reinterpret_cast<char16_t *>(output));             \
+        }                                                                                                   \
+    }                                                                                                       \
 }
 
-#define SIMDUTF_ICELAKE_TRANSCODE16(LANE0, LANE1)                                                            \
-        {                                                                                                    \
-            const __m512i merged = _mm512_mask_mov_epi32(LANE0, 0x1000, LANE1);                              \
-            const __m512i expand_ver2 = _mm512_setr_epi64(                                                   \
-                0x0403020103020100,                                                                          \
-                0x0605040305040302,                                                                          \
-                0x0807060507060504,                                                                          \
-                0x0a09080709080706,                                                                          \
-                0x0c0b0a090b0a0908,                                                                          \
-                0x0e0d0c0b0d0c0b0a,                                                                          \
-                0x000f0e0d0f0e0d0c,                                                                          \
-                0x0201000f01000f0e                                                                           \
-            );                                                                                               \
-            const __m512i input = _mm512_shuffle_epi8(merged, expand_ver2);                                  \
-                                                                                                             \
-            __mmask16 leading_bytes;                                                                         \
-            const __m512i v_0000_00c0 = _mm512_set1_epi32(0xc0);                                             \
-            const __m512i t0 = _mm512_and_si512(input, v_0000_00c0);                                         \
-            const __m512i v_0000_0080 = _mm512_set1_epi32(0x80);                                             \
-            leading_bytes = _mm512_cmpneq_epu32_mask(t0, v_0000_0080);                                       \
-                                                                                                             \
-            __m512i char_class;                                                                              \
-            char_class = _mm512_srli_epi32(input, 4);                                                        \
-            /*  char_class = ((input >> 4) & 0x0f) | 0x80808000 */                                           \
-            const __m512i v_0000_000f = _mm512_set1_epi32(0x0f);                                             \
-            const __m512i v_8080_8000 = _mm512_set1_epi32(0x80808000);                                       \
-            char_class = _mm512_ternarylogic_epi32(char_class, v_0000_000f, v_8080_8000, 0xea);              \
-                                                                                                             \
-            const int valid_count = static_cast<int>(count_ones(leading_bytes));                             \
-            const __m512i utf32 = expanded_utf8_to_utf32(char_class, input);                                 \
-                                                                                                             \
-            const __m512i out = _mm512_mask_compress_epi32(_mm512_setzero_si512(), leading_bytes, utf32);    \
-                                                                                                             \
-            if (UTF32) {                                                                                     \
-                const __mmask16 valid = uint16_t((1 << valid_count) - 1);                                    \
-                _mm512_mask_storeu_epi32((__m512i*)output, valid, out);                                      \
-                output += valid_count;                                                                       \
-            } else {                                                                                         \
-                output += utf32_to_utf16(out, valid_count, reinterpret_cast<char16_t *>(output));            \
-            }                                                                                                \
-        }
+
 #define SIMDUTF_ICELAKE_STORE_ASCII(UTF32, utf8, output)                                                  \
         if (UTF32) {                                                                      \
                 const __m128i t0 = _mm512_castsi512_si128(utf8);                          \

--- a/src/icelake/icelake-macros.inl.cpp
+++ b/src/icelake/icelake-macros.inl.cpp
@@ -82,35 +82,6 @@
             }                                                                                                \
         }
 
-simdutf_really_inline __m512i expand_and_identify(__m512i lane0, __m512i lane1, int &count) {
-    const __m512i merged = _mm512_mask_mov_epi32(lane0, 0x1000, lane1);
-    const __m512i expand_ver2 = _mm512_setr_epi64(
-                0x0403020103020100,
-                0x0605040305040302,
-                0x0807060507060504,
-                0x0a09080709080706,
-                0x0c0b0a090b0a0908,
-                0x0e0d0c0b0d0c0b0a,
-                0x000f0e0d0f0e0d0c,
-                0x0201000f01000f0e
-    );
-    const __m512i input = _mm512_shuffle_epi8(merged, expand_ver2);
-    const __m512i v_0000_00c0 = _mm512_set1_epi32(0xc0);
-    const __m512i t0 = _mm512_and_si512(input, v_0000_00c0);
-    const __m512i v_0000_0080 = _mm512_set1_epi32(0x80);
-    const __mmask16 leading_bytes = _mm512_cmpneq_epu32_mask(t0, v_0000_0080);
-    count = static_cast<int>(count_ones(leading_bytes));
-    return  _mm512_mask_compress_epi32(_mm512_setzero_si512(), leading_bytes, input);
-}
-
-simdutf_really_inline __m512i expand_utf8_to_utf32(__m512i input) {
-    __m512i char_class = _mm512_srli_epi32(input, 4);
-    /*  char_class = ((input >> 4) & 0x0f) | 0x80808000 */
-    const __m512i v_0000_000f = _mm512_set1_epi32(0x0f);
-    const __m512i v_8080_8000 = _mm512_set1_epi32(0x80808000);
-    char_class = _mm512_ternarylogic_epi32(char_class, v_0000_000f, v_8080_8000, 0xea);
-    return expanded_utf8_to_utf32(char_class, input);
-}
 
 #define SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(INPUT, VALID_COUNT)                                    \
 {                                                                                                   \

--- a/src/icelake/icelake-macros.inl.cpp
+++ b/src/icelake/icelake-macros.inl.cpp
@@ -82,7 +82,77 @@
             }                                                                                                \
         }
 
+simdutf_really_inline __m512i expand_and_identify(__m512i lane0, __m512i lane1, int &count) {
+    const __m512i merged = _mm512_mask_mov_epi32(lane0, 0x1000, lane1);
+    const __m512i expand_ver2 = _mm512_setr_epi64(
+                0x0403020103020100,
+                0x0605040305040302,
+                0x0807060507060504,
+                0x0a09080709080706,
+                0x0c0b0a090b0a0908,
+                0x0e0d0c0b0d0c0b0a,
+                0x000f0e0d0f0e0d0c,
+                0x0201000f01000f0e
+    );
+    const __m512i input = _mm512_shuffle_epi8(merged, expand_ver2);
+    const __m512i v_0000_00c0 = _mm512_set1_epi32(0xc0);
+    const __m512i t0 = _mm512_and_si512(input, v_0000_00c0);
+    const __m512i v_0000_0080 = _mm512_set1_epi32(0x80);
+    const __mmask16 leading_bytes = _mm512_cmpneq_epu32_mask(t0, v_0000_0080);
+    count = static_cast<int>(count_ones(leading_bytes));
+    return  _mm512_mask_compress_epi32(_mm512_setzero_si512(), leading_bytes, input);
+}
 
+simdutf_really_inline __m512i expand_utf8_to_utf32(__m512i input) {
+    __m512i char_class = _mm512_srli_epi32(input, 4);
+    /*  char_class = ((input >> 4) & 0x0f) | 0x80808000 */
+    const __m512i v_0000_000f = _mm512_set1_epi32(0x0f);
+    const __m512i v_8080_8000 = _mm512_set1_epi32(0x80808000);
+    char_class = _mm512_ternarylogic_epi32(char_class, v_0000_000f, v_8080_8000, 0xea);
+    return expanded_utf8_to_utf32(char_class, input);
+}
+
+#define SIMDUTF_ICELAKE_TRANSCODE16(LANE0, LANE1)                                                                            \
+        {                                                                                                    \
+            const __m512i merged = _mm512_mask_mov_epi32(LANE0, 0x1000, LANE1);                              \
+            const __m512i expand_ver2 = _mm512_setr_epi64(                                                   \
+                0x0403020103020100,                                                                          \
+                0x0605040305040302,                                                                          \
+                0x0807060507060504,                                                                          \
+                0x0a09080709080706,                                                                          \
+                0x0c0b0a090b0a0908,                                                                          \
+                0x0e0d0c0b0d0c0b0a,                                                                          \
+                0x000f0e0d0f0e0d0c,                                                                          \
+                0x0201000f01000f0e                                                                           \
+            );                                                                                               \
+            const __m512i input = _mm512_shuffle_epi8(merged, expand_ver2);                                  \
+                                                                                                             \
+            __mmask16 leading_bytes;                                                                         \
+            const __m512i v_0000_00c0 = _mm512_set1_epi32(0xc0);                                             \
+            const __m512i t0 = _mm512_and_si512(input, v_0000_00c0);                                         \
+            const __m512i v_0000_0080 = _mm512_set1_epi32(0x80);                                             \
+            leading_bytes = _mm512_cmpneq_epu32_mask(t0, v_0000_0080);                                       \
+                                                                                                             \
+            __m512i char_class;                                                                              \
+            char_class = _mm512_srli_epi32(input, 4);                                                        \
+            /*  char_class = ((input >> 4) & 0x0f) | 0x80808000 */                                           \
+            const __m512i v_0000_000f = _mm512_set1_epi32(0x0f);                                             \
+            const __m512i v_8080_8000 = _mm512_set1_epi32(0x80808000);                                       \
+            char_class = _mm512_ternarylogic_epi32(char_class, v_0000_000f, v_8080_8000, 0xea);              \
+                                                                                                             \
+            const int valid_count = static_cast<int>(count_ones(leading_bytes));                             \
+            const __m512i utf32 = expanded_utf8_to_utf32(char_class, input);                                 \
+                                                                                                             \
+            const __m512i out = _mm512_mask_compress_epi32(_mm512_setzero_si512(), leading_bytes, utf32);    \
+                                                                                                             \
+            if (UTF32) {                                                                                     \
+                const __mmask16 valid = uint16_t((1 << valid_count) - 1);                                    \
+                _mm512_mask_storeu_epi32((__m512i*)output, valid, out);                                      \
+                output += valid_count;                                                                       \
+            } else {                                                                                         \
+                output += utf32_to_utf16(out, valid_count, reinterpret_cast<char16_t *>(output));            \
+            }                                                                                                \
+        }
 #define SIMDUTF_ICELAKE_STORE_ASCII(UTF32, utf8, output)                                                  \
         if (UTF32) {                                                                      \
                 const __m128i t0 = _mm512_castsi512_si128(utf8);                          \

--- a/src/icelake/icelake-utf8-common.inl.cpp
+++ b/src/icelake/icelake-utf8-common.inl.cpp
@@ -273,3 +273,34 @@ simdutf_really_inline __m512i expanded_utf8_to_utf32(__m512i char_class, __m512i
 
     return values;
 }
+
+
+simdutf_really_inline __m512i expand_and_identify(__m512i lane0, __m512i lane1, int &count) {
+    const __m512i merged = _mm512_mask_mov_epi32(lane0, 0x1000, lane1);
+    const __m512i expand_ver2 = _mm512_setr_epi64(
+                0x0403020103020100,
+                0x0605040305040302,
+                0x0807060507060504,
+                0x0a09080709080706,
+                0x0c0b0a090b0a0908,
+                0x0e0d0c0b0d0c0b0a,
+                0x000f0e0d0f0e0d0c,
+                0x0201000f01000f0e
+    );
+    const __m512i input = _mm512_shuffle_epi8(merged, expand_ver2);
+    const __m512i v_0000_00c0 = _mm512_set1_epi32(0xc0);
+    const __m512i t0 = _mm512_and_si512(input, v_0000_00c0);
+    const __m512i v_0000_0080 = _mm512_set1_epi32(0x80);
+    const __mmask16 leading_bytes = _mm512_cmpneq_epu32_mask(t0, v_0000_0080);
+    count = static_cast<int>(count_ones(leading_bytes));
+    return  _mm512_mask_compress_epi32(_mm512_setzero_si512(), leading_bytes, input);
+}
+
+simdutf_really_inline __m512i expand_utf8_to_utf32(__m512i input) {
+    __m512i char_class = _mm512_srli_epi32(input, 4);
+    /*  char_class = ((input >> 4) & 0x0f) | 0x80808000 */
+    const __m512i v_0000_000f = _mm512_set1_epi32(0x0f);
+    const __m512i v_8080_8000 = _mm512_set1_epi32(0x80808000);
+    char_class = _mm512_ternarylogic_epi32(char_class, v_0000_000f, v_8080_8000, 0xea);
+    return expanded_utf8_to_utf32(char_class, input);
+}


### PR DESCRIPTION
In this PR (to be applied to https://github.com/simdutf/simdutf/pull/97), we add a few more branches to help the performance of some Asian inputs. The net result is a slight loss of performance all around, with a nice gain in the few cases where our haswell kernel was slower. This might prove to be an interesting compromise since with this new code, the icelake kernel is always faster than haswell, except maybe on emoji inputs. 

The gist of the idea is to check when our expanded 512-bit registers contain too few valid characters and to merge two successive expanded 512-bit registers when we detect such a scenario. When this branch is not taken, we pay for some arithmetic and a branch not taken. However, when the branch is fruitful, the gains are interesting:  from   3.3 GB/s to 3.9 GB/s over some Japanese file (a 15% boost).

```
===========================
Using ICU version 70.1
testcases: 1
input detected as UTF8
current system detected as icelake
===========================
convert_utf8_to_utf16+haswell, input size: 69840, iterations: 10000, dataset: unicode_lipsum/lipsum/Chinese-Lipsum.utf8.txt
   3.851 GB/s (1.3 %)    1.294 Gc/s     2.98 byte/char
convert_utf8_to_utf16+icelake, input size: 69840, iterations: 10000, dataset: unicode_lipsum/lipsum/Chinese-Lipsum.utf8.txt
   3.331 GB/s (1.4 %)    1.119 Gc/s     2.98 byte/char
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
===========================
Using ICU version 70.1
testcases: 1
input detected as UTF8
current system detected as icelake
===========================
convert_utf8_to_utf16+haswell, input size: 67808, iterations: 10000, dataset: unicode_lipsum/lipsum/Japanese-Lipsum.utf8.txt
   3.578 GB/s (1.3 %)    1.233 Gc/s     2.90 byte/char
convert_utf8_to_utf16+icelake, input size: 67808, iterations: 10000, dataset: unicode_lipsum/lipsum/Japanese-Lipsum.utf8.txt
   3.338 GB/s (0.9 %)    1.151 Gc/s     2.90 byte/char
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
===========================
Using ICU version 70.1
testcases: 1
input detected as UTF8
current system detected as icelake
===========================
convert_utf8_to_utf16+haswell, input size: 66600, iterations: 10000, dataset: unicode_lipsum/lipsum/Korean-Lipsum.utf8.txt
   2.206 GB/s (1.1 %)    0.899 Gc/s     2.45 byte/char
convert_utf8_to_utf16+icelake, input size: 66600, iterations: 10000, dataset: unicode_lipsum/lipsum/Korean-Lipsum.utf8.txt
   3.340 GB/s (0.9 %)    1.361 Gc/s     2.45 byte/char
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
```



After:


```
===========================
Using ICU version 70.1
testcases: 1
input detected as UTF8
current system detected as icelake
===========================
convert_utf8_to_utf16+haswell, input size: 69840, iterations: 10000, dataset: unicode_lipsum/lipsum/Chinese-Lipsum.utf8.txt
   3.838 GB/s (1.6 %)    1.289 Gc/s     2.98 byte/char
convert_utf8_to_utf16+icelake, input size: 69840, iterations: 2000, dataset: unicode_lipsum/lipsum/Chinese-Lipsum.utf8.txt
   3.955 GB/s (0.8 %)    1.329 Gc/s     2.98 byte/char 
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
===========================
Using ICU version 70.1
testcases: 1
input detected as UTF8
current system detected as icelake
===========================
convert_utf8_to_utf16+haswell, input size: 67808, iterations: 10000, dataset: unicode_lipsum/lipsum/Japanese-Lipsum.utf8.txt
   3.587 GB/s (1.5 %)    1.236 Gc/s     2.90 byte/char
convert_utf8_to_utf16+icelake, input size: 67808, iterations: 2000, dataset: unicode_lipsum/lipsum/Japanese-Lipsum.utf8.txt
   3.932 GB/s (0.9 %)    1.355 Gc/s     2.90 byte/char 
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
===========================
Using ICU version 70.1
testcases: 1
input detected as UTF8
current system detected as icelake
===========================
convert_utf8_to_utf16+haswell, input size: 66600, iterations: 10000, dataset: unicode_lipsum/lipsum/Korean-Lipsum.utf8.txt
   2.204 GB/s (3.4 %)    0.898 Gc/s     2.45 byte/char
convert_utf8_to_utf16+icelake, input size: 66600, iterations: 2000, dataset: unicode_lipsum/lipsum/Korean-Lipsum.utf8.txt
   3.946 GB/s (0.9 %)    1.608 Gc/s     2.45 byte/char 
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).

```