### PR TITLE
Fix Buffer Overrun on aarch64

### DIFF
--- a/src/arm64/arm_convert_utf16_to_utf8.cpp
+++ b/src/arm64/arm_convert_utf16_to_utf8.cpp
@@ -72,6 +72,14 @@ std::pair<const char16_t*, char*> arm_convert_utf16_to_utf8(const char16_t* buf,
     if(vmaxvq_u16(in) <= 0x7F) { // ASCII fast path!!!!
         // It is common enough that we have sequences of 16 consecutive ASCII characters.
         uint16x8_t nextin = vld1q_u16(reinterpret_cast<const uint16_t *>(buf) + 8);
+        if (big_endian) {
+          #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
+          const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
+          #else
+          const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
+          #endif
+          nextin = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(nextin), swap));
+        }
         if(vmaxvq_u16(nextin) > 0x7F) {
           // 1. pack the bytes
           // obviously suboptimal.
@@ -81,14 +89,6 @@ std::pair<const char16_t*, char*> arm_convert_utf16_to_utf8(const char16_t* buf,
           // 3. adjust pointers
           buf += 8;
           utf8_output += 8;
-          if (big_endian) {
-            #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-            const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-            #else
-            const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
-            #endif
-            nextin = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(nextin), swap));
-          }
           in = nextin;
         } else {
           // 1. pack the bytes
@@ -339,6 +339,14 @@ std::pair<result, char*> arm_convert_utf16_to_utf8_with_errors(const char16_t* b
     if(vmaxvq_u16(in) <= 0x7F) { // ASCII fast path!!!!
         // It is common enough that we have sequences of 16 consecutive ASCII characters.
         uint16x8_t nextin = vld1q_u16(reinterpret_cast<const uint16_t *>(buf) + 8);
+        if (big_endian) {
+          #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
+          const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
+          #else
+          const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
+          #endif
+          nextin = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(nextin), swap));
+        }
         if(vmaxvq_u16(nextin) > 0x7F) {
           // 1. pack the bytes
           // obviously suboptimal.
@@ -348,14 +356,6 @@ std::pair<result, char*> arm_convert_utf16_to_utf8_with_errors(const char16_t* b
           // 3. adjust pointers
           buf += 8;
           utf8_output += 8;
-          if (big_endian) {
-            #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-            const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-            #else
-            const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
-            #endif
-            nextin = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(nextin), swap));
-          }
           in = nextin;
         } else {
           // 1. pack the bytes


### PR DESCRIPTION
Current `simdutf` failes the tests on aarch64 environments like below:

```
96% tests passed, 2 tests failed out of 48

Total Test time (real) =  30.80 sec

The following tests FAILED:
         24 - convert_utf16be_to_utf8_tests (Subprocess aborted)
         34 - convert_valid_utf16be_to_utf8_tests (Subprocess aborted)
```

This PR fixes this.