### PR TITLE
Fast UTF-16 to UTF-8 transcoder (AVX-512)

### DIFF
--- a/src/icelake/icelake_convert_utf16_to_utf8.inl.cpp
+++ b/src/icelake/icelake_convert_utf16_to_utf8.inl.cpp
@@ -1,0 +1,185 @@
+// file included directly
+
+/**
+ * This function converts the input (inbuf, inlen), assumed to be valid
+ * UTF16 (little endian) into UTF-8 (to outbuf). The number of words written
+ * is written to 'outlen' and the function reports the number of input word
+ * consumed.
+ */
+size_t utf16le_to_utf8_avx512i(const char16_t *inbuf, size_t inlen,
+                               unsigned char *outbuf, size_t *outlen) {
+  __m512i in;
+  __mmask32 inmask = _cvtu32_mask32(0x7fffffff);
+  const char16_t *inbuf_orig = inbuf;
+  unsigned char *outbuf_orig = outbuf;
+  int adjust = 0, carry = 0;
+
+  while (inlen >= 32) {
+    __m512i hi, lo, fc00masked, taghi, taglo, mslo, mshi, outlo, outhi, magiclo,
+        magichi;
+    __mmask16 is12blo, is12bhi, is1blo, is1bhi, outmlo, outmhi;
+    __mmask32 is234byte, is12byte, is1byte, hisurr, losurr, outmask;
+    __mmask64 wantlo, wanthi;
+    int advlo, advhi, carryout;
+
+    in = _mm512_loadu_epi16(inbuf);
+    inlen -= 31;
+
+  lastiteration:
+    inbuf += 31;
+
+  failiteration:
+    is234byte = _mm512_mask_cmp_epu16_mask(
+        inmask, in, _mm512_set1_epi16(0x0080), _MM_CMPINT_NLT);
+    if (_ktestz_mask32_u8(is234byte, is234byte)) {
+      /* fast path for ASCII only */
+      _mm512_mask_cvtepi16_storeu_epi8(outbuf, (__mmask64)inmask, in);
+      outbuf += 31;
+      carry = 0;
+
+      if (inlen < 32) {
+        goto tail;
+      } else {
+        continue;
+      }
+    }
+
+    is12byte =
+        _mm512_cmp_epu16_mask(in, _mm512_set1_epi16(0x0800), _MM_CMPINT_LT);
+    if (_ktestc_mask32_u8(is12byte, inmask)) {
+      /* fast path for 1 and 2 byte only */
+      __m512i twobytes, out, cmpmask;
+      __mmask64 smoosh;
+
+      twobytes = _mm512_ternarylogic_epi32(
+          _mm512_slli_epi16(in, 8), _mm512_srli_epi16(in, 6),
+          _mm512_set1_epi16(0x3f3f), 0xa8 /* (A|B)&C */);
+      in = _mm512_mask_add_epi16(in, is234byte, twobytes,
+                                 _mm512_set1_epi16(int16_t(0x80c0)));
+      cmpmask =
+          _mm512_mask_blend_epi16(inmask, _mm512_set1_epi16(int16_t(0xffff)),
+                                  _mm512_set1_epi16(0x0800));
+      smoosh = _mm512_cmp_epu8_mask(in, cmpmask, _MM_CMPINT_NLT);
+      out = _mm512_maskz_compress_epi8(smoosh, in);
+      _mm512_mask_storeu_epi8(outbuf, (__mmask64)_pext_u64(smoosh, smoosh),
+                              out);
+      outbuf += 31 + __builtin_popcountl((int)is234byte);
+      carry = 0;
+
+      if (inlen < 32) {
+        goto tail;
+      } else {
+        continue;
+      }
+    }
+
+    lo = _mm512_cvtepu16_epi32(_mm512_castsi512_si256(in));
+    hi = _mm512_cvtepu16_epi32(_mm512_extracti32x8_epi32(in, 1));
+    carryout = _cvtu32_mask32(0);
+
+    taglo = taghi = _mm512_set1_epi32(0x8080e000);
+
+    fc00masked = _mm512_and_epi32(in, _mm512_set1_epi16(int16_t(0xfc00)));
+    hisurr = _mm512_mask_cmp_epu16_mask(
+        inmask, fc00masked, _mm512_set1_epi16(int16_t(0xd800)), _MM_CMPINT_EQ);
+    losurr = _mm512_cmp_epu16_mask(
+        fc00masked, _mm512_set1_epi16(int16_t(0xdc00)), _MM_CMPINT_EQ);
+
+    carryout = 0;
+    if (!_kortestz_mask32_u8(hisurr, losurr)) {
+      /* handle surrogates */
+      __m512i his, los;
+      __mmask16 hisurrhi, hisurrlo;
+      unsigned int h = (unsigned)hisurr, l = (unsigned)losurr, hinolo, lonohi;
+
+      los = _mm512_alignr_epi32(hi, lo, 1);
+      his = _mm512_alignr_epi32(lo, hi, 1);
+
+      hisurrlo = (__mmask16)hisurr;
+      hisurrhi = (__mmask16)_kshiftri_mask32(hisurr, 16);
+      taglo =
+          _mm512_mask_mov_epi32(taglo, hisurrlo, _mm512_set1_epi32(0x808080f0));
+      taghi =
+          _mm512_mask_mov_epi32(taghi, hisurrhi, _mm512_set1_epi32(0x808080f0));
+
+      lo = _mm512_mask_slli_epi32(lo, hisurrlo, lo, 10);
+      hi = _mm512_mask_slli_epi32(hi, hisurrhi, hi, 10);
+      los = _mm512_add_epi32(los, _mm512_set1_epi32(0xfca02400));
+      his = _mm512_add_epi32(his, _mm512_set1_epi32(0xfca02400));
+      lo = _mm512_mask_add_epi32(lo, hisurrlo, lo, los);
+      hi = _mm512_mask_add_epi32(hi, hisurrhi, hi, his);
+
+      carryout = _kshiftri_mask32(hisurr, 30);
+
+      /* check for mismatched surrogates */
+      if ((h + h + carry) ^ l) {
+        lonohi = l & ~(h + h + carry);
+        hinolo = h & ~(l >> 1);
+        inlen = _tzcnt_u32(hinolo | lonohi);
+        inmask = __mmask32(0x7fffffff & ((1 << inlen) - 1));
+        in = _mm512_maskz_mov_epi16(inmask, in);
+        adjust = (int)inlen - 31;
+        inlen = 0;
+        goto failiteration;
+      }
+    }
+
+    carry = carryout;
+
+    mslo =
+        _mm512_multishift_epi64_epi8(_mm512_set1_epi64(0x20262c3200060c12), lo);
+    mshi =
+        _mm512_multishift_epi64_epi8(_mm512_set1_epi64(0x20262c3200060c12), hi);
+
+    outmask = _kandn_mask32(losurr, inmask);
+    outmlo = (__mmask16)outmask;
+    outmhi = (__mmask16)_kshiftri_mask32(outmask, 16);
+    is1byte = _knot_mask32(is234byte);
+    is1blo = (__mmask16)is1byte;
+    is1bhi = (__mmask16)_kshiftri_mask32(is1byte, 16);
+    is12blo = (__mmask16)is12byte;
+    is12bhi = (__mmask16)_kshiftri_mask32(is12byte, 16);
+
+    taglo =
+        _mm512_mask_mov_epi32(taglo, is12blo, _mm512_set1_epi32(0x80c00000));
+    taghi =
+        _mm512_mask_mov_epi32(taghi, is12bhi, _mm512_set1_epi32(0x80c00000));
+    magiclo = _mm512_mask_blend_epi32(outmlo, _mm512_set1_epi32(0xffffffff),
+                                      _mm512_set1_epi32(0x00010101));
+    magichi = _mm512_mask_blend_epi32(outmhi, _mm512_set1_epi32(0xffffffff),
+                                      _mm512_set1_epi32(0x00010101));
+    mslo = _mm512_ternarylogic_epi32(mslo, _mm512_set1_epi32(0x3f3f3f3f), taglo,
+                                     0xea); /* A&B|C */
+    mshi = _mm512_ternarylogic_epi32(mshi, _mm512_set1_epi32(0x3f3f3f3f), taghi,
+                                     0xea);
+    mslo = _mm512_mask_slli_epi32(mslo, is1blo, lo, 24);
+    mshi = _mm512_mask_slli_epi32(mshi, is1bhi, hi, 24);
+
+    wantlo = _mm512_cmp_epu8_mask(mslo, magiclo, _MM_CMPINT_NLT);
+    wanthi = _mm512_cmp_epu8_mask(mshi, magichi, _MM_CMPINT_NLT);
+
+    outlo = _mm512_maskz_compress_epi8(wantlo, mslo);
+    outhi = _mm512_maskz_compress_epi8(wanthi, mshi);
+    advlo = __builtin_popcountll(wantlo);
+    advhi = __builtin_popcountll(wanthi);
+
+    _mm512_mask_storeu_epi8(outbuf, _pext_u64(wantlo, wantlo), outlo);
+    _mm512_mask_storeu_epi8(outbuf + advlo, _pext_u64(wanthi, wanthi), outhi);
+    outbuf += advlo + advhi;
+  }
+
+  outbuf -= adjust;
+
+tail:
+  if (inlen != 0) {
+    inmask = _cvtu32_mask32((0x7fffffff & (1 << inlen)) - 1);
+    in = _mm512_maskz_loadu_epi16(inmask, inbuf);
+    adjust = (int)inlen - 31;
+    inlen = 0;
+
+    goto lastiteration;
+  }
+
+  *outlen = (outbuf - outbuf_orig) + adjust;
+  return ((inbuf - inbuf_orig) + adjust);
+}

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -22,6 +22,7 @@ namespace {
 #include "icelake/icelake-convert-utf16-to-utf32.inl.cpp"
 #include "icelake/icelake-ascii-validation.inl.cpp"
 #include "icelake/icelake-utf32-validation.inl.cpp"
+#include "icelake/icelake_convert_utf16_to_utf8.inl.cpp"
 
 } // namespace
 } // namespace SIMDUTF_IMPLEMENTATION
@@ -186,11 +187,14 @@ simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf32(const cha
 }
 
 simdutf_warn_unused size_t implementation::convert_utf16_to_utf8(const char16_t* buf, size_t len, char* utf8_output) const noexcept {
-  return scalar::utf16_to_utf8::convert(buf, len, utf8_output);
+  size_t outlen;
+  size_t inlen = utf16le_to_utf8_avx512i(buf, len, (unsigned char*)utf8_output, &outlen);
+  if(inlen != len) { return 0; }
+  return outlen;
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16_to_utf8(const char16_t* buf, size_t len, char* utf8_output) const noexcept {
-  return scalar::utf16_to_utf8::convert_valid(buf, len, utf8_output);
+  return convert_utf16_to_utf8(buf, len, utf8_output);
 }
 
 

--- a/src/simdutf/icelake.h
+++ b/src/simdutf/icelake.h
@@ -37,7 +37,7 @@
 #define SIMDUTF_TARGET_ICELAKE
 #define SIMDJSON_UNTARGET_ICELAKE
 #else
-#define SIMDUTF_TARGET_ICELAKE SIMDUTF_TARGET_REGION("avx512f,avx512dq,avx512cd,avx512bw,avx512vbmi,avx512vbmi2,avx512vl,avx2,bmi,pclmul,lzcnt")
+#define SIMDUTF_TARGET_ICELAKE SIMDUTF_TARGET_REGION("avx512f,avx512dq,avx512cd,avx512bw,avx512vbmi,avx512vbmi2,avx512vl,avx2,bmi,bmi2,pclmul,lzcnt")
 #define SIMDUTF_UNTARGET_ICELAKE SIMDUTF_UNTARGET_REGION
 #endif
 

--- a/src/simdutf/icelake/intrinsics.h
+++ b/src/simdutf/icelake/intrinsics.h
@@ -6,6 +6,7 @@
 #ifdef SIMDUTF_VISUAL_STUDIO
 // under clang within visual studio, this will include <x86intrin.h>
 #include <intrin.h>  // visual studio or clang
+#include <immintrin.h>
 #else
 #include <x86intrin.h> // elsewhere
 #endif // SIMDUTF_VISUAL_STUDIO
@@ -30,6 +31,7 @@
  * are fooled.
  */
 #include <bmiintrin.h>   // for _blsr_u64
+#include <bmi2intrin.h> // for _pext_u64, _pdep_u64
 #include <lzcntintrin.h> // for  __lzcnt64
 #include <immintrin.h>   // for most things (AVX2, AVX512, _popcnt64)
 #include <smmintrin.h>

--- a/tests/convert_utf16_to_utf32_tests.cpp
+++ b/tests/convert_utf16_to_utf32_tests.cpp
@@ -98,7 +98,7 @@ TEST(convert_fails_if_there_is_sole_high_surrogate) {
   }
 }
 
-TEST(convert_fails_if_there_is_low_surrogate_is_followed_by_another_low_surrogate) {
+TEST(convert_fails_if_there_is_low_surrogate_followed_by_another_low_surrogate) {
   auto procedure = [&implementation](const char16_t* utf16, size_t size, char32_t* utf32) -> size_t {
     return implementation.convert_utf16_to_utf32(utf16, size, utf32);
   };
@@ -120,7 +120,7 @@ TEST(convert_fails_if_there_is_low_surrogate_is_followed_by_another_low_surrogat
   }
 }
 
-TEST(convert_fails_if_there_is_surrogate_pair_is_followed_by_high_surrogate) {
+TEST(convert_fails_if_there_is_surrogate_pair_followed_by_high_surrogate) {
   auto procedure = [&implementation](const char16_t* utf16, size_t size, char32_t* utf32) -> size_t {
     return implementation.convert_utf16_to_utf32(utf16, size, utf32);
   };

--- a/tests/convert_utf16_to_utf8_tests.cpp
+++ b/tests/convert_utf16_to_utf8_tests.cpp
@@ -138,7 +138,7 @@ TEST(convert_fails_if_there_is_sole_high_surrogate) {
   }
 }
 
-TEST(convert_fails_if_there_is_low_surrogate_is_followed_by_another_low_surrogate) {
+TEST(convert_fails_if_there_is_low_surrogate_followed_by_another_low_surrogate) {
   auto procedure = [&implementation](const char16_t* utf8, size_t size, char* utf16) -> size_t {
     return implementation.convert_utf16_to_utf8(utf8, size, utf16);
   };
@@ -160,7 +160,7 @@ TEST(convert_fails_if_there_is_low_surrogate_is_followed_by_another_low_surrogat
   }
 }
 
-TEST(convert_fails_if_there_is_surrogate_pair_is_followed_by_high_surrogate) {
+TEST(convert_fails_if_there_is_surrogate_pair_followed_by_high_surrogate) {
   auto procedure = [&implementation](const char16_t* utf8, size_t size, char* utf16) -> size_t {
     return implementation.convert_utf16_to_utf8(utf8, size, utf16);
   };
@@ -240,7 +240,7 @@ namespace {
       // next pattern
       int i = 0;
       int carry = 1;
-      for (/**/; i < 8 && carry; i++) {
+      for (; i < 8 && carry; i++) {
         pattern[i] += carry;
         if (pattern[i] == 5) {
           pattern[i] = 0;


### PR DESCRIPTION
This PR integrates Robert's transcoder. The results are excellent. The new transcoder is 50% faster than the haswell (previous best) transcoder on non-trivial inputs. Importantly, it transcodes emojis at full speed.

```
For each file, the first numbers are for the new transcoder (icelake), and the second one is the existing transcoder (haswell).
../unicode_lipsum/wikipedia_mars/arabic.utf16.txt
  15.988 GB/s (2.8 %)    7.994 Gc/s     2.00 byte/char 
  10.356 GB/s (1.3 %)    5.178 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/chinese.utf16.txt
  14.184 GB/s (1.2 %)    7.092 Gc/s     2.00 byte/char 
   9.980 GB/s (1.3 %)    4.990 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/czech.utf16.txt
  22.842 GB/s (1.8 %)   11.421 Gc/s     2.00 byte/char 
  12.955 GB/s (1.0 %)    6.477 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/english.utf16.txt
  30.443 GB/s (1.9 %)   15.222 Gc/s     2.00 byte/char 
  27.273 GB/s (1.4 %)   13.637 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/esperanto.utf16.txt
  27.678 GB/s (3.4 %)   13.839 Gc/s     2.00 byte/char 
  18.628 GB/s (1.5 %)    9.314 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/french.utf16.txt
  12.482 GB/s (2.1 %)    6.241 Gc/s     2.00 byte/char 
   8.724 GB/s (1.3 %)    4.362 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/german.utf16.txt
  27.102 GB/s (1.3 %)   13.551 Gc/s     2.00 byte/char 
  19.284 GB/s (17.4 %)    9.642 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/greek.utf16.txt
  23.821 GB/s (1.8 %)   11.911 Gc/s     2.00 byte/char 
  12.677 GB/s (1.0 %)    6.339 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/hebrew.utf16.txt
  22.659 GB/s (1.2 %)   11.329 Gc/s     2.00 byte/char 
  11.403 GB/s (1.0 %)    5.701 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/hindi.utf16.txt
  13.256 GB/s (1.9 %)    6.628 Gc/s     2.00 byte/char 
  10.093 GB/s (1.4 %)    5.046 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/japanese.utf16.txt
  13.854 GB/s (1.1 %)    6.927 Gc/s     2.00 byte/char 
   9.903 GB/s (1.5 %)    4.952 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/korean.utf16.txt
  14.361 GB/s (1.1 %)    7.181 Gc/s     2.00 byte/char 
   9.341 GB/s (2.0 %)    4.670 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/persan.utf16.txt
  20.915 GB/s (1.3 %)   10.457 Gc/s     2.00 byte/char 
  11.798 GB/s (1.0 %)    5.899 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/portuguese.utf16.txt
  17.745 GB/s (35.6 %)    8.872 Gc/s     2.00 byte/char 
  13.601 GB/s (65.7 %)    6.800 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/russian.utf16.txt
  18.451 GB/s (2.2 %)    9.225 Gc/s     2.00 byte/char 
  10.833 GB/s (1.9 %)    5.416 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/thai.utf16.txt
  12.964 GB/s (1.5 %)    6.482 Gc/s     2.00 byte/char 
  10.263 GB/s (3.0 %)    5.132 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/turkish.utf16.txt
  25.246 GB/s (1.7 %)   12.623 Gc/s     2.00 byte/char 
  14.471 GB/s (0.9 %)    7.235 Gc/s     2.00 byte/char 
../unicode_lipsum/wikipedia_mars/vietnamese.utf16.txt
  13.333 GB/s (1.5 %)    6.667 Gc/s     2.00 byte/char 
   8.917 GB/s (13.9 %)    4.459 Gc/s     2.00 byte/char 
../unicode_lipsum/lipsum/Arabic-Lipsum.utf16.txt
  21.531 GB/s (2.3 %)   10.765 Gc/s     2.00 byte/char 
   7.867 GB/s (1.0 %)    3.934 Gc/s     2.00 byte/char 
../unicode_lipsum/lipsum/Chinese-Lipsum.utf16.txt
   9.470 GB/s (1.0 %)    4.735 Gc/s     2.00 byte/char 
   5.000 GB/s (0.9 %)    2.500 Gc/s     2.00 byte/char 
../unicode_lipsum/lipsum/Emoji-Lipsum.utf16.txt
   7.219 GB/s (0.9 %)    1.805 Gc/s     4.00 byte/char 
   1.506 GB/s (6.5 %)    0.376 Gc/s     4.00 byte/char 
../unicode_lipsum/lipsum/Hebrew-Lipsum.utf16.txt
  20.841 GB/s (2.9 %)   10.420 Gc/s     2.00 byte/char 
   7.922 GB/s (1.3 %)    3.961 Gc/s     2.00 byte/char 
../unicode_lipsum/lipsum/Hindi-Lipsum.utf16.txt
   9.535 GB/s (0.9 %)    4.767 Gc/s     2.00 byte/char 
   5.013 GB/s (1.1 %)    2.507 Gc/s     2.00 byte/char 
../unicode_lipsum/lipsum/Japanese-Lipsum.utf16.txt
   9.471 GB/s (1.2 %)    4.735 Gc/s     2.00 byte/char 
   4.945 GB/s (1.1 %)    2.472 Gc/s     2.00 byte/char 
../unicode_lipsum/lipsum/Korean-Lipsum.utf16.txt
   9.756 GB/s (0.9 %)    4.878 Gc/s     2.00 byte/char 
   4.952 GB/s (1.4 %)    2.476 Gc/s     2.00 byte/char 
../unicode_lipsum/lipsum/Latin-Lipsum.utf16.txt
  38.813 GB/s (2.0 %)   19.406 Gc/s     2.00 byte/char 
  36.676 GB/s (1.1 %)   18.338 Gc/s     2.00 byte/char 
../unicode_lipsum/lipsum/Russian-Lipsum.utf16.txt
  21.635 GB/s (2.3 %)   10.817 Gc/s     2.00 byte/char 
   7.906 GB/s (0.9 %)    3.953 Gc/s     2.00 byte/char 
```