### PR TITLE
Allow skipping the build of the tools via SIMDUTF_TOOLS=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ include(cmake/simdutf-flags.cmake)
 set(SIMDUTF_LIB_VERSION "2.0.2" CACHE STRING "simdutf library version")
 set(SIMDUTF_LIB_SOVERSION "2" CACHE STRING "simdutf library soversion")
 option(SIMDUTF_BENCHMARKS "Whether the benchmarks are included as part of the CMake Build." ON)
+option(SIMDUTF_TOOLS "Whether the tools are included as part of the CMake build." ON)
 
 set(SIMDUTF_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -34,11 +35,14 @@ else()
 endif(BUILD_TESTING)
 
 
-if(CMAKE_CXX_COMPILER_ID MATCHES GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
-  message(STATUS "The benchmark tool requires GCC 8.0 or better.")
-else()
-  add_subdirectory(tools)
+if (SIMDUTF_TOOLS)
+  if(CMAKE_CXX_COMPILER_ID MATCHES GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
+    message(STATUS "The benchmark tool requires GCC 8.0 or better.")
+  else()
+    add_subdirectory(tools)
+  endif()
 endif()
+
 
 if (SIMDUTF_BENCHMARKS)
   if((CMAKE_CXX_COMPILER_ID MATCHES GNU) AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.0"))


### PR DESCRIPTION
Allow skipping the build of the tools subdir, like it is done for the benchmarks.

This is useful when one just wants to build the static library and does not have a working or only a broken iconv installed. 

Otherwise the build fails with an error from building sutf:

```
:> cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=C:\code\img -DBUILD_TESTING=OFF -DSIMDUTF_BENCHMARKS=OFF C:\Users\msc\AppData\Local\Temp\VC19\amd64\debug\simdutf-2.0.2
-- The CXX compiler identification is MSVC 19.29.30146.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Professional/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Python3: C:/Python310/python.exe (found version "3.10.4") found components: Interpreter
-- Python found, we are going to amalgamate.py.
-- The tests are disabled.
-- Found Iconv: C:/sdk/win32/1.1/lib/iconv.lib (found version "1.9")
-- Iconv was found!
-- Iconv is a separate library, headers at C:/sdk/win32/1.1/include
-- The benchmarks can be enabled by setting SIMDUTF_BENCHMARKS, e.g., -D SIMDUTF_BENCHMARKS=ON.
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Users/msc/AppData/Local/Temp/VC19/amd64/debug/simdutf-2.0.2
==> Compiling...
:> cd C:\Users\msc\AppData\Local\Temp\VC19\amd64\debug\simdutf-2.0.2
:> nmake -f Makefile

Microsoft (R) Program Maintenance Utility, Version 14.29.30146.0
Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.

[ 25%] Building CXX object src/CMakeFiles/simdutf.dir/simdutf.cpp.obj
simdutf.cpp
[ 50%] Linking CXX static library simdutf.lib
[ 50%] Built target simdutf
[ 75%] Building CXX object tools/CMakeFiles/sutf.dir/sutf.cpp.obj
sutf.cpp
C:\Users\msc\AppData\Local\Temp\VC19\amd64\debug\simdutf-2.0.2\tools\sutf.cpp(298): error C2664: "size_t libiconv(libiconv_t,const char **,size_t *,char **,size_t *)" : Konvertierung von Argument 2 von "char **" in "const char **" nicht möglich
C:\Users\msc\AppData\Local\Temp\VC19\amd64\debug\simdutf-2.0.2\tools\sutf.cpp(298): note: Durch die Konvertierung gehen Qualifizierer verloren
C:\sdk\win32\1.1\include\iconv.h(85): note: Siehe Deklaration von "libiconv"
NMAKE : fatal error U1077: ""C:\Program Files\CMake\bin\cmake.exe"": Rckgabe-Code "0x2"
Stop.
NMAKE : fatal error U1077: ""C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\bin\HostX64\x64\nmake.exe"": Rckgabe-Code "0x2"
Stop.
NMAKE : fatal error U1077: ""C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\bin\HostX64\x64\nmake.exe"": Rckgabe-Code "0x2"
Stop.

ERROR during the build:
'nmake -f Makefile' failed to execute, returncode 2
```