### PR TITLE
Guarding calls to iconv to accommodate win-iconv

### DIFF
--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -776,8 +776,13 @@ void Benchmark::run_convert_utf8_to_utf16_iconv(size_t iterations) {
     auto proc = [&cv, data, size, &output_buffer, &sink]() {
         size_t inbytes = size;
         size_t outbytes = sizeof(uint16_t) * size;
+        // win-iconv includes WINICONV_CONST in its function signatures
+        // https://github.com/simdutf/simdutf/pull/178
+#ifdef WINICONV_CONST
+        WINICONV_CONST char * inptr = reinterpret_cast<WINICONV_CONST char *>(data);
+#else
         char * inptr = data;
-       // inbytes = strlen(inptr);
+#endif
         char * outptr = reinterpret_cast<char *>(output_buffer.get());
         size_t result = iconv(cv, &inptr, &inbytes, &outptr, &outbytes);
         if (result == static_cast<size_t>(-1)) {
@@ -820,7 +825,11 @@ void Benchmark::run_convert_utf16_to_utf8_iconv(size_t iterations) {
     auto proc = [cv, data, size, &output_buffer, &sink]() {
         size_t inbytes = sizeof(uint16_t) * size;
         size_t outbytes = 4 * size;
+#ifdef WINICONV_CONST
+        WINICONV_CONST char * inptr = reinterpret_cast<WINICONV_CONST char *>(data);
+#else
         char * inptr = reinterpret_cast<char *>(data);
+#endif
         char * outptr = output_buffer.get();
         size_t result = iconv(cv, &inptr, &inbytes, &outptr, &outbytes);
         if (result == static_cast<size_t>(-1)) {

--- a/tools/sutf.cpp
+++ b/tools/sutf.cpp
@@ -293,7 +293,13 @@ void CommandLine::iconv_fallback(std::FILE *fpout) {
     size_t inbytes = input_size;
     size_t outbytes = sizeof(uint32_t) * inbytes;
     size_t start_outbytes = outbytes;
+    // win-iconv includes WINICONV_CONST in its function signatures
+    // https://github.com/simdutf/simdutf/pull/178
+#ifdef WINICONV_CONST
+    WINICONV_CONST char * inptr = reinterpret_cast<WINICONV_CONST char *>(input_data.data());
+#else
     char * inptr = reinterpret_cast<char *>(input_data.data());
+#endif
     char * outptr = reinterpret_cast<char *>(output_buffer.data());
     size_t result = iconv(cv, &inptr, &inbytes, &outptr, &outbytes);
     if (result == static_cast<size_t>(-1)) {


### PR DESCRIPTION
There is a version of iconv under windows called win-iconv. Unfortunately, it has a non-standard function signature:

```c++
size_t iconv(iconv_t cd, WINICONV_CONST char **inbuf, size_t *inbytesleft, char **outbuf, size_t *outbytesleft);
```

To accommodate it, we can branch on the existence of the macro WINICONV_CONST  at compile-time. It makes the code somewhat uglier, but it should make compilation more robust.

This relates to issue https://github.com/simdutf/simdutf/pull/178
