### PR TITLE
This PR attempts to silence some spurious GCC warnings (unrelated to our code).

### DIFF
--- a/.github/workflows/msys2-clang.yml
+++ b/.github/workflows/msys2-clang.yml
@@ -45,6 +45,6 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ..
+          cmake ..  -DSIMDUTF_BENCHMARKS=OFF
           cmake --build . --verbose
           ctest -j4 --output-on-failure

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -48,6 +48,6 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake  -DCMAKE_BUILD_TYPE=${{ matrix.type }}  ..
+          cmake  -DCMAKE_BUILD_TYPE=${{ matrix.type }}  ..  -DSIMDUTF_BENCHMARKS=OFF
           cmake --build . --verbose
           ctest -j4 --output-on-failure

--- a/.github/workflows/ubuntu18.yml
+++ b/.github/workflows/ubuntu18.yml
@@ -20,6 +20,6 @@ jobs:
         run: |
           mkdir build &&
           cd build &&
-          cmake -DCMAKE_CXX_FLAGS=-Werror ..  &&
+          cmake -DCMAKE_CXX_FLAGS=-Werror ..  -DSIMDUTF_BENCHMARKS=OFF  -DSIMDUTF_BENCHMARKS=OFF &&
           cmake --build .  --verbose &&
           ctest -j --output-on-failure

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           mkdir build &&
           cd build &&
-          cmake -DCMAKE_CXX_FLAGS=-Werror -DCMAKE_INSTALL_PREFIX:PATH=destination -DBUILD_SHARED_LIBS=${{matrix.shared}} ..  &&
+          cmake -DCMAKE_CXX_FLAGS=-Werror -DCMAKE_INSTALL_PREFIX:PATH=destination -DBUILD_SHARED_LIBS=${{matrix.shared}} ..  -DSIMDUTF_BENCHMARKS=OFF &&
           cmake --build .   &&
           ctest -j --output-on-failure &&
           cmake --install . &&

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -1,4 +1,4 @@
-name: Ubuntu 20.04 Sanitized CI (GCC 9)
+name: Ubuntu 22.04 Sanitized CI (GCC 11)
 
 on:
   push:
@@ -13,7 +13,7 @@ jobs:
     if: >-
       ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           mkdir build &&
           cd build &&
-          cmake -DCMAKE_CXX_FLAGS=-Werror -DCMAKE_INSTALL_PREFIX:PATH=destination -DBUILD_SHARED_LIBS=${{matrix.shared}} ..  &&
+          cmake -DCMAKE_CXX_FLAGS=-Werror -DCMAKE_INSTALL_PREFIX:PATH=destination -DBUILD_SHARED_LIBS=${{matrix.shared}} ..   -DSIMDUTF_BENCHMARKS=OFF &&
           cmake --build .   &&
           ctest -j --output-on-failure &&
           cmake --install . &&

--- a/.github/workflows/ubuntu22_gcc12.yml
+++ b/.github/workflows/ubuntu22_gcc12.yml
@@ -25,6 +25,6 @@ jobs:
         run: |
           mkdir build &&
           cd build &&
-          CXX=g++-12 cmake -DCMAKE_CXX_FLAGS=-Werror  -DBUILD_SHARED_LIBS=${{matrix.shared}} ..  &&
+          CXX=g++-12 cmake -DCMAKE_CXX_FLAGS=-Werror  -DBUILD_SHARED_LIBS=${{matrix.shared}} ..  -DSIMDUTF_BENCHMARKS=OFF &&
           cmake --build .   &&
           ctest -j --output-on-failure

--- a/.github/workflows/ubuntu22_gcc12.yml
+++ b/.github/workflows/ubuntu22_gcc12.yml
@@ -1,4 +1,4 @@
-name: Ubuntu 18.04 CI (GCC 7)
+name: Ubuntu 22.04 Sanitized CI (GCC 12)
 
 on:
   push:
@@ -13,13 +13,18 @@ jobs:
     if: >-
       ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - {shared: ON}
+          - {shared: OFF}
     steps:
       - uses: actions/checkout@v3
       - name: Use cmake
         run: |
           mkdir build &&
           cd build &&
-          cmake -DCMAKE_CXX_FLAGS=-Werror ..  &&
-          cmake --build .  --verbose &&
+          CXX=g++-12 cmake -DCMAKE_CXX_FLAGS=-Werror  -DBUILD_SHARED_LIBS=${{matrix.shared}} ..  &&
+          cmake --build .   &&
           ctest -j --output-on-failure

--- a/include/simdutf/portability.h
+++ b/include/simdutf/portability.h
@@ -171,4 +171,12 @@ use a 64-bit target such as x64, 64-bit ARM or 64-bit PPC.")
 
 #endif
 
+
+#if defined(__GNUC__) && !defined(__clang__)
+#if __GNUC__ >= 11
+#define SIMDUTF_GCC11ORMORE 1
+#endif //  __GNUC__ >= 11
+#endif // defined(__GNUC__) && !defined(__clang__)
+
+
 #endif // SIMDUTF_PORTABILITY_H

--- a/src/icelake/icelake_convert_utf16_to_utf8.inl.cpp
+++ b/src/icelake/icelake_convert_utf16_to_utf8.inl.cpp
@@ -6,9 +6,8 @@
  * is written to 'outlen' and the function reports the number of input word
  * consumed.
  */
-
- template <endianness big_endian>
- size_t utf16_to_utf8_avx512i(const char16_t *inbuf, size_t inlen,
+template <endianness big_endian>
+size_t utf16_to_utf8_avx512i(const char16_t *inbuf, size_t inlen,
                                unsigned char *outbuf, size_t *outlen) {
   __m512i in;
   __mmask32 inmask = _cvtu32_mask32(0x7fffffff);

--- a/src/icelake/icelake_from_utf8.inl.cpp
+++ b/src/icelake/icelake_from_utf8.inl.cpp
@@ -8,6 +8,7 @@
  * Returns the position of the input and output after the processing is
  * completed. Upon error, the output is set to null.
  */
+
 template <endianness big_endian>
 utf8_to_utf16_result fast_avx512_convert_utf8_to_utf16(const char *in, size_t len, char16_t *out) {
   const char *const final_in = in + len;

--- a/src/simdutf/fallback/bitmanipulation.h
+++ b/src/simdutf/fallback/bitmanipulation.h
@@ -25,21 +25,6 @@ static unsigned char _BitScanReverse64(unsigned long* ret, uint64_t x) {
 }
 #endif
 
-/* result might be undefined when input_num is zero */
-simdutf_really_inline int leading_zeroes(uint64_t input_num) {
-#ifdef _MSC_VER
-  unsigned long leading_zero = 0;
-  // Search the mask data from most significant bit (MSB)
-  // to least significant bit (LSB) for a set bit (1).
-  if (_BitScanReverse64(&leading_zero, input_num))
-    return (int)(63 - leading_zero);
-  else
-    return 64;
-#else
-  return __builtin_clzll(input_num);
-#endif// _MSC_VER
-}
-
 } // unnamed namespace
 } // namespace SIMDUTF_IMPLEMENTATION
 } // namespace simdutf

--- a/src/simdutf/haswell/begin.h
+++ b/src/simdutf/haswell/begin.h
@@ -1,2 +1,7 @@
 #define SIMDUTF_IMPLEMENTATION haswell
 SIMDUTF_TARGET_HASWELL
+
+
+#if SIMDUTF_GCC11ORMORE // workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105593
+SIMDUTF_DISABLE_GCC_WARNING(-Wmaybe-uninitialized)
+#endif // end of workaround

--- a/src/simdutf/haswell/end.h
+++ b/src/simdutf/haswell/end.h
@@ -1,2 +1,6 @@
 SIMDUTF_UNTARGET_REGION
 #undef SIMDUTF_IMPLEMENTATION
+
+#if SIMDUTF_GCC11ORMORE // workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105593
+#pragma GCC diagnostic pop
+#endif // end of workaround

--- a/src/simdutf/haswell/intrinsics.h
+++ b/src/simdutf/haswell/intrinsics.h
@@ -7,7 +7,23 @@
 // under clang within visual studio, this will include <x86intrin.h>
 #include <intrin.h>  // visual studio or clang
 #else
+
+#if SIMDUTF_GCC11ORMORE
+// We should not get warnings while including <x86intrin.h> yet we do
+// under some versions of GCC.
+// If the x86intrin.h header has uninitialized values that are problematic,
+// it is a GCC issue, we want to ignore these warnigns.
+SIMDUTF_DISABLE_GCC_WARNING(-Wuninitialized)
+#endif
+
 #include <x86intrin.h> // elsewhere
+
+
+#if SIMDUTF_GCC11ORMORE
+// cancels the suppression of the -Wuninitialized
+SIMDUTF_POP_DISABLE_WARNINGS
+#endif
+
 #endif // SIMDUTF_VISUAL_STUDIO
 
 #ifdef SIMDUTF_CLANG_VISUAL_STUDIO

--- a/src/simdutf/icelake/begin.h
+++ b/src/simdutf/icelake/begin.h
@@ -1,3 +1,6 @@
 #define SIMDUTF_IMPLEMENTATION icelake
 SIMDUTF_TARGET_ICELAKE
 
+#if SIMDUTF_GCC11ORMORE // workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105593
+SIMDUTF_DISABLE_GCC_WARNING(-Wmaybe-uninitialized)
+#endif // end of workaround

--- a/src/simdutf/icelake/end.h
+++ b/src/simdutf/icelake/end.h
@@ -1,2 +1,6 @@
 SIMDUTF_UNTARGET_REGION
 #undef SIMDUTF_IMPLEMENTATION
+
+#if SIMDUTF_GCC11ORMORE // workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105593
+SIMDUTF_POP_DISABLE_WARNINGS
+#endif // end of workaround

--- a/src/simdutf/icelake/intrinsics.h
+++ b/src/simdutf/icelake/intrinsics.h
@@ -8,7 +8,23 @@
 #include <intrin.h>  // visual studio or clang
 #include <immintrin.h>
 #else
+
+#if SIMDUTF_GCC11ORMORE
+// We should not get warnings while including <x86intrin.h> yet we do
+// under some versions of GCC.
+// If the x86intrin.h header has uninitialized values that are problematic,
+// it is a GCC issue, we want to ignore these warnigns.
+SIMDUTF_DISABLE_GCC_WARNING(-Wuninitialized)
+#endif
+
 #include <x86intrin.h> // elsewhere
+
+
+#if SIMDUTF_GCC11ORMORE
+// cancels the suppression of the -Wuninitialized
+SIMDUTF_POP_DISABLE_WARNINGS
+#endif
+
 #ifndef _tzcnt_u64
 #define _tzcnt_u64(x) __tzcnt_u64(x)
 #endif // _tzcnt_u64
@@ -62,9 +78,11 @@
 
 
 #if defined(__GNUC__) && !defined(__clang__)
+
 #if __GNUC__ == 8
 #define SIMDUTF_GCC8 1
 #endif //  __GNUC__ == 8
+
 #endif // defined(__GNUC__) && !defined(__clang__)
 
 #if SIMDUTF_GCC8

--- a/src/simdutf/westmere/intrinsics.h
+++ b/src/simdutf/westmere/intrinsics.h
@@ -5,7 +5,23 @@
 // under clang within visual studio, this will include <x86intrin.h>
 #include <intrin.h> // visual studio or clang
 #else
+
+#if SIMDUTF_GCC11ORMORE
+// We should not get warnings while including <x86intrin.h> yet we do
+// under some versions of GCC.
+// If the x86intrin.h header has uninitialized values that are problematic,
+// it is a GCC issue, we want to ignore these warnigns.
+SIMDUTF_DISABLE_GCC_WARNING(-Wuninitialized)
+#endif
+
 #include <x86intrin.h> // elsewhere
+
+
+#if SIMDUTF_GCC11ORMORE
+// cancels the suppression of the -Wuninitialized
+SIMDUTF_POP_DISABLE_WARNINGS
+#endif
+
 #endif // SIMDUTF_VISUAL_STUDIO
 
 


### PR DESCRIPTION
The standard x86intrin.h header generates some warning under recent versions of GCC. Not our fault. But we can silence the warnings.