### PR TITLE
fix compilation error on gcc 9 debug build

### DIFF
--- a/src/icelake/icelake_utf8_common.inl.cpp
+++ b/src/icelake/icelake_utf8_common.inl.cpp
@@ -448,12 +448,12 @@ __m512i prev(__m512i input, __m512i previous) {
     static_assert(N<=32, "N must be no larger than 32");
     const __m512i movemask = _mm512_setr_epi32(28,29,30,31,0,1,2,3,4,5,6,7,8,9,10,11);
     const __m512i rotated = _mm512_permutex2var_epi32(input, movemask, previous);
-#if SIMDUTF_GCC8
-    constexpr int shift = 16-N; // workaround for GCC8
+#if SIMDUTF_GCC8 || SIMDUTF_GCC9
+    constexpr int shift = 16-N; // workaround for GCC8,9
     return _mm512_alignr_epi8(input, rotated, shift);
 #else
     return _mm512_alignr_epi8(input, rotated, 16-N);
-#endif // SIMDUTF_GCC8
+#endif // SIMDUTF_GCC8 || SIMDUTF_GCC9
 }
 
 template <unsigned idx0, unsigned idx1, unsigned idx2, unsigned idx3>

--- a/src/simdutf/icelake/intrinsics.h
+++ b/src/simdutf/icelake/intrinsics.h
@@ -81,7 +81,9 @@ SIMDUTF_POP_DISABLE_WARNINGS
 
 #if __GNUC__ == 8
 #define SIMDUTF_GCC8 1
-#endif //  __GNUC__ == 8
+#elif __GNUC__ == 9
+#define SIMDUTF_GCC9 1
+#endif //  __GNUC__ == 8 || __GNUC__ == 9
 
 #endif // defined(__GNUC__) && !defined(__clang__)
 


### PR DESCRIPTION
Hi. I am creating a simdutf conan package.
I have encountered a compilation error in gcc9 debug build.
Strangely enough, only gcc9 debug builds seem to have the compilation errors that occur with gcc8.

```
.../src/icelake/icelake_utf8_common.inl.cpp:446:12: error: the last argument must be an 8-bit immediate
  446 |     return _mm512_alignr_epi8(input, rotated, 16-N);
      |            ^~~~~~~~~~~~~~~~~~
```
original: https://c3i.jfrog.io/c3i/misc/logs/pr/13829/6-linux-gcc/simdutf/2.0.2//9cb7ac99f58a79b591516cbdd53096db4a815c86-build.txt

Now the patch is provided on the conan package side, but since it seems to be an independent issue, could you please adopt it for simdutf?


