### PR TITLE
Fixing issue 213

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 # Table of contents
 
+- [Table of contents](#table-of-contents)
 - [simdutf: Unicode validation and transcoding at billions of characters per second](#simdutf-unicode-validation-and-transcoding-at-billions-of-characters-per-second)
   - [How fast is it?](#how-fast-is-it)
   - [Real-World Usage](#real-world-usage)
@@ -293,7 +294,7 @@ enum error_code {
   HEADER_BITS,  // Any byte must have fewer than 5 header bits.
   TOO_SHORT,    // The leading byte must be followed by N-1 continuation bytes, where N is the UTF-8 character length
                 // This is also the error when the input is truncated.
-  TOO_LONG,     // The leading byte must not be a continuation byte.
+  TOO_LONG,     // We either have too many consecutive continuation bytes or the string starts with a continuation byte.
   OVERLONG,     // The decoded character must be above U+7F for two-byte characters, U+7FF for three-byte characters,
                 // and U+FFFF for four-byte characters.
   TOO_LARGE,    // The decoded character must be less than or equal to U+10FFFF OR less than or equal than U+7F for ASCII.

--- a/include/simdutf/error.h
+++ b/include/simdutf/error.h
@@ -7,7 +7,7 @@ enum error_code {
   HEADER_BITS,  // Any byte must have fewer than 5 header bits.
   TOO_SHORT,    // The leading byte must be followed by N-1 continuation bytes, where N is the UTF-8 character length
                 // This is also the error when the input is truncated.
-  TOO_LONG,     // The leading byte must not be a continuation byte.
+  TOO_LONG,     // We either have too many consecutive continuation bytes or the string starts with a continuation byte.
   OVERLONG,     // The decoded character must be above U+7F for two-byte characters, U+7FF for three-byte characters,
                 // and U+FFFF for four-byte characters.
   TOO_LARGE,    // The decoded character must be less than or equal to U+10FFFF OR less than or equal than U+7F for ASCII.

--- a/src/generic/utf8_to_utf16/utf8_to_utf16.h
+++ b/src/generic/utf8_to_utf16/utf8_to_utf16.h
@@ -214,7 +214,9 @@ using namespace simd;
             this->check_utf8_bytes(input.chunks[3], input.chunks[2]);
           }
           if (errors()) {
-            result res = scalar::utf8_to_utf16::rewind_and_convert_with_errors<endian>(in + pos, size - pos, utf16_output);
+            // rewind_and_convert_with_errors will seek a potential error from in+pos onward,
+            // with the ability to go back up to pos bytes, and read size-pos bytes forward.
+            result res = scalar::utf8_to_utf16::rewind_and_convert_with_errors<endian>(pos, in + pos, size - pos, utf16_output);
             res.count += pos;
             return res;
           }
@@ -248,12 +250,16 @@ using namespace simd;
         }
       }
       if(errors()) {
-        result res = scalar::utf8_to_utf16::rewind_and_convert_with_errors<endian>(in + pos, size - pos, utf16_output);
+        // rewind_and_convert_with_errors will seek a potential error from in+pos onward,
+        // with the ability to go back up to pos bytes, and read size-pos bytes forward.
+        result res = scalar::utf8_to_utf16::rewind_and_convert_with_errors<endian>(pos, in + pos, size - pos, utf16_output);
         res.count += pos;
         return res;
       }
       if(pos < size) {
-        result res = scalar::utf8_to_utf16::rewind_and_convert_with_errors<endian>(in + pos, size - pos, utf16_output);
+        // rewind_and_convert_with_errors will seek a potential error from in+pos onward,
+        // with the ability to go back up to pos bytes, and read size-pos bytes forward.
+        result res = scalar::utf8_to_utf16::rewind_and_convert_with_errors<endian>(pos, in + pos, size - pos, utf16_output);
         if (res.error) {    // In case of error, we want the error position
           res.count += pos;
           return res;

--- a/src/generic/utf8_to_utf32/utf8_to_utf32.h
+++ b/src/generic/utf8_to_utf32/utf8_to_utf32.h
@@ -213,7 +213,7 @@ using namespace simd;
             this->check_utf8_bytes(input.chunks[3], input.chunks[2]);
           }
           if (errors()) {
-            result res = scalar::utf8_to_utf32::rewind_and_convert_with_errors(in + pos, size - pos, utf32_output);
+            result res = scalar::utf8_to_utf32::rewind_and_convert_with_errors(pos, in + pos, size - pos, utf32_output);
             res.count += pos;
             return res;
           }
@@ -247,12 +247,12 @@ using namespace simd;
         }
       }
       if(errors()) {
-        result res = scalar::utf8_to_utf32::rewind_and_convert_with_errors(in + pos, size - pos, utf32_output);
+        result res = scalar::utf8_to_utf32::rewind_and_convert_with_errors(pos, in + pos, size - pos, utf32_output);
         res.count += pos;
         return res;
       }
       if(pos < size) {
-        result res = scalar::utf8_to_utf32::rewind_and_convert_with_errors(in + pos, size - pos, utf32_output);
+        result res = scalar::utf8_to_utf32::rewind_and_convert_with_errors(pos, in + pos, size - pos, utf32_output);
         if (res.error) {    // In case of error, we want the error position
           res.count += pos;
           return res;

--- a/src/icelake/icelake_from_utf8.inl.cpp
+++ b/src/icelake/icelake_from_utf8.inl.cpp
@@ -38,7 +38,9 @@ simdutf::result fast_avx512_convert_utf8_to_utf16_with_errors(const char *in, si
     } else { break; }
   }
   if(!result) {
-    simdutf::result res = scalar::utf8_to_utf16::rewind_and_convert_with_errors<big_endian>(in, final_in - in, out);
+    // rewind_and_convert_with_errors will seek a potential error from in onward,
+    // with the ability to go back up to in - init_in bytes, and read final_in - in bytes forward.
+    simdutf::result res = scalar::utf8_to_utf16::rewind_and_convert_with_errors<big_endian>(in - init_in, in, final_in - in, out);
     res.count += (in - init_in);
     return res;
   } else {

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -587,7 +587,10 @@ simdutf_warn_unused result implementation::convert_utf8_to_utf32_with_errors(con
   uint32_t * utf32_output = reinterpret_cast<uint32_t *>(utf32);
   auto ret = icelake::validating_utf8_to_fixed_length_with_constant_checks<endianness::LITTLE, uint32_t>(buf, len, utf32_output);
   if (!std::get<2>(ret)) {
-    result res = scalar::utf8_to_utf32::rewind_and_convert_with_errors(std::get<0>(ret), len - (std::get<0>(ret) - buf), reinterpret_cast<char32_t *>(std::get<1>(ret)));
+    auto new_buf = std::get<0>(ret);
+    // rewind_and_convert_with_errors will seek a potential error from new_buf onward,
+    // with the ability to go back up to new_buf - buf bytes, and read len - (new_buf - buf) bytes forward.
+    result res = scalar::utf8_to_utf32::rewind_and_convert_with_errors(new_buf - buf, new_buf, len - (new_buf - buf), reinterpret_cast<char32_t *>(std::get<1>(ret)));
     res.count += (std::get<0>(ret) - buf);
     return res;
   }

--- a/src/scalar/utf8_to_utf32/utf8_to_utf32.h
+++ b/src/scalar/utf8_to_utf32/utf8_to_utf32.h
@@ -151,17 +151,47 @@ inline result convert_with_errors(const char* buf, size_t len, char32_t* utf32_o
   return result(error_code::SUCCESS, utf32_output - start);
 }
 
-inline result rewind_and_convert_with_errors(const char* buf, size_t len, char32_t* utf32_output) {
+/**
+ * When rewind_and_convert_with_errors is called, we are pointing at 'buf' and we have
+ * up to len input bytes left, and we encountered some error. It is possible that
+ * the error is at 'buf' exactly, but it could also be in the previous bytes location (up to 3 bytes back).
+ *
+ * prior_bytes indicates how many bytes, prior to 'buf' may belong to the current memory section
+ * and can be safely accessed. We prior_bytes to access safely up to three bytes before 'buf'.
+ *
+ * The caller is responsible to ensure that len > 0.
+ *
+ * If the error is believed to have occured prior to 'buf', the count value contain in the result
+ * will be SIZE_T - 1, SIZE_T - 2, or SIZE_T - 3.
+ */
+inline result rewind_and_convert_with_errors(size_t prior_bytes, const char* buf, size_t len, char32_t* utf32_output) {
   size_t extra_len{0};
-  // A leading byte cannot be further than 4 bytes away
-  for(int i = 0; i < 5; i++) {
-    unsigned char byte = *buf;
-    if ((byte & 0b11000000) != 0b10000000) {
+  // We potentially need to go back in time and find a leading byte.
+  size_t how_far_back = 3; // 3 bytes in the past + current position
+  if(how_far_back > prior_bytes) { how_far_back = prior_bytes; }
+  bool found_leading_bytes{false};
+  // important: it is i <= how_far_back and not 'i < how_far_back'.
+  for(size_t i = 0; i <= how_far_back; i++) {
+    unsigned char byte = buf[-i];
+    found_leading_bytes = ((byte & 0b11000000) != 0b10000000);
+    if(found_leading_bytes) {
+      buf -= i;
+      extra_len = i;
       break;
-    } else {
-      buf--;
-      extra_len++;
     }
+  }
+  //
+  // It is possible for this function to return a negative count in its result.
+  // C++ Standard Section 18.1 defines size_t is in <cstddef> which is described in C Standard as <stddef.h>.
+  // C Standard Section 4.1.5 defines size_t as an unsigned integral type of the result of the sizeof operator
+  //
+  // An unsigned type will simply wrap round arithmetically (well defined).
+  //
+  if(!found_leading_bytes) {
+    // If how_far_back == 3, we may have four consecutive continuation bytes!!!
+    // [....] [continuation] [continuation] [continuation] | [buf is continuation]
+    // Or we possibly have a stream that does not start with a leading byte.
+    return result(error_code::TOO_LONG, -how_far_back);
   }
 
   result res = convert_with_errors(buf, len + extra_len, utf32_output);

--- a/tests/basic_fuzzer.cpp
+++ b/tests/basic_fuzzer.cpp
@@ -6,6 +6,7 @@
 #include <stdexcept>
 #include <random>
 #include <string>
+#include <memory>
 
 #include <tests/reference/encode_utf8.h>
 #include <tests/helpers/test.h>

--- a/tests/basic_fuzzer.cpp
+++ b/tests/basic_fuzzer.cpp
@@ -299,6 +299,53 @@ struct state_tracker {
   }
 };
 
+TEST(garbage_utf8_fuzz) {
+  // Here we generate fully random inputs and try transcoding from UTF-8.
+  // The inputs are almost certainly *NOT* valid UTF-8.
+  std::mt19937 gen(std::mt19937::result_type(123456));
+  std::uniform_int_distribution<size_t> length_generator{1, 65};
+  std::uniform_int_distribution<uint32_t> byte_generator{0, 256};
+
+  for(size_t counter = 0; counter < 100000; counter++) {
+    if ((counter % 10000) == 0) {
+      printf("-");
+      fflush(NULL);
+    }
+    size_t length = length_generator(gen);
+    std::unique_ptr<char[]> utf8_buffer(new char[length]);
+    for(size_t i = 0; i < length; i++) { utf8_buffer.get()[i] = byte_generator(gen); }
+    size_t expected_utf16_length = implementation.utf16_length_from_utf8(utf8_buffer.get(), length);
+    std::unique_ptr<char16_t[]> utf16_buffer(new char16_t[expected_utf16_length]);
+    auto r = implementation.convert_utf8_to_utf16le_with_errors(
+              utf8_buffer.get(), length,
+              utf16_buffer.get());
+    // r.count: In case of error, indicates the position of the error in the input.
+    // In case of success, indicates the number of words validated/written.
+    if(r.error == simdutf::SUCCESS) {
+      ASSERT_TRUE((r.count == expected_utf16_length));
+    } else {
+      ASSERT_TRUE(r.count <  length);
+    }
+    r = implementation.convert_utf8_to_utf16be_with_errors(
+              utf8_buffer.get(), length,
+              utf16_buffer.get());
+    if(r.error == simdutf::SUCCESS) {
+      ASSERT_TRUE((r.count == expected_utf16_length));
+    } else {
+      ASSERT_TRUE(r.count <  length);
+    }
+    size_t expected_utf32_length = implementation.utf32_length_from_utf8(utf8_buffer.get(), length);
+    std::unique_ptr<char32_t[]> utf32_buffer(new char32_t[expected_utf32_length]);
+    r = implementation.convert_utf8_to_utf32_with_errors(
+              utf8_buffer.get(), length,
+              utf32_buffer.get());
+    if(r.error == simdutf::SUCCESS) {
+      ASSERT_TRUE((r.count == expected_utf32_length));
+    } else {
+      ASSERT_TRUE(r.count <  length);
+    }
+  }
+}
 
 TEST(overflow_fuzz) {
   size_t counter{0};
@@ -385,6 +432,105 @@ TEST(overflow_fuzz) {
           utf32_to_utf16.second = implementation.convert_utf32_to_utf16le(
               reinterpret_cast<char32_t *>(input.data()),
               input.size() / sizeof(char32_t), reinterpret_cast<char16_t *>(output.data()));
+          ASSERT_TRUE(expected_length > 0 && (expected_length * sizeof(char16_t) == output.size()) && expected_length == utf32_to_utf16.second);
+        }
+      }
+    }
+  }
+}
+
+
+TEST(overflow_with_errors_fuzz) {
+  size_t counter{0};
+  for(int i = 0; i < 6; i++) {
+    state_tracker tracker(seed, weights[i][0], weights[i][1]);
+    while (counter < 100000) {
+      for (size_t size : input_size) {
+        input.clear();
+        std::vector<char> output(4*size);
+        while (input.size() < size) {
+          tracker.next(input);
+        }
+        input.shrink_to_fit(); // make sure we don't have superfluous space
+        counter++;
+        if ((counter % 10000) == 0) {
+          printf("-");
+          fflush(NULL);
+        }
+        reset();
+        is_ok_utf8.first = true;
+        is_ok_utf8.second =
+            implementation.validate_utf8(input.data(), input.size());
+        is_ok_utf16.first = true;
+        is_ok_utf16.second = implementation.validate_utf16le(
+            reinterpret_cast<char16_t *>(input.data()),
+            input.size() / sizeof(char16_t));
+        is_ok_utf32.first = true;
+        is_ok_utf32.second = implementation.validate_utf32(
+            reinterpret_cast<char32_t *>(input.data()),
+            input.size() / sizeof(char32_t));
+        if (is_ok_utf8.second) {
+          size_t expected_length = implementation.utf16_length_from_utf8(input.data(), input.size());
+          output.resize(expected_length * sizeof(char16_t));
+          output.shrink_to_fit(); // make sure we don't have superfluous space
+          auto r = implementation.convert_utf8_to_utf16le_with_errors(
+              input.data(), input.size(),
+              reinterpret_cast<char16_t *>(output.data()));
+          utf8_to_utf16.second = r.count;
+          utf8_to_utf16.first = (r.error == simdutf::SUCCESS);
+          ASSERT_TRUE(expected_length > 0 && (expected_length * sizeof(char16_t) == output.size()) && expected_length == utf8_to_utf16.second);
+
+          expected_length = implementation.utf32_length_from_utf8(input.data(), input.size());
+          output.resize(expected_length * sizeof(char32_t));
+          output.shrink_to_fit(); // make sure we don't have superfluous space
+          r = implementation.convert_utf8_to_utf32_with_errors(
+              input.data(), input.size(),
+              reinterpret_cast<char32_t *>(output.data()));
+          utf8_to_utf32.second = r.count;
+          utf8_to_utf32.first = (r.error == simdutf::SUCCESS);
+          ASSERT_TRUE(expected_length > 0 && (expected_length * sizeof(char32_t) == output.size()) && expected_length == utf8_to_utf32.second);
+        }
+        if (is_ok_utf16.second) {
+          size_t expected_length = implementation.utf8_length_from_utf16le(reinterpret_cast<char16_t *>(input.data()), input.size() / sizeof(char16_t));
+          output.resize(expected_length);
+          output.shrink_to_fit(); // make sure we don't have superfluous space
+          auto r = implementation.convert_utf16le_to_utf8_with_errors(
+              reinterpret_cast<char16_t *>(input.data()),
+              input.size() / sizeof(char16_t), output.data());
+          utf16_to_utf8.second = r.count;
+          utf16_to_utf8.first = (r.error == simdutf::SUCCESS);
+          ASSERT_TRUE(expected_length > 0 && expected_length == output.size() && expected_length == utf16_to_utf8.second);
+
+          expected_length = implementation.utf32_length_from_utf16le(reinterpret_cast<char16_t *>(input.data()), input.size() / sizeof(char16_t));
+          output.resize(expected_length * sizeof(char32_t));
+
+          output.shrink_to_fit(); // make sure we don't have superfluous space
+          r = implementation.convert_utf16le_to_utf32_with_errors(
+              reinterpret_cast<char16_t *>(input.data()),
+              input.size() / sizeof(char16_t), reinterpret_cast<char32_t *>(output.data()));
+          utf16_to_utf32.first = true;
+          utf16_to_utf32.second = r.count;
+          ASSERT_TRUE(expected_length > 0 && (expected_length  * sizeof(char32_t) == output.size()) && expected_length == utf16_to_utf32.second);
+        }
+        if (is_ok_utf32.second) {
+          size_t expected_length = implementation.utf8_length_from_utf32(reinterpret_cast<char32_t *>(input.data()), input.size() / sizeof(char32_t));
+          output.resize(expected_length);
+          output.shrink_to_fit(); // make sure we don't have superfluous space
+          auto r = implementation.convert_utf32_to_utf8_with_errors(
+              reinterpret_cast<char32_t *>(input.data()),
+              input.size() / sizeof(char32_t), output.data());
+          utf32_to_utf8.first = (r.error == simdutf::SUCCESS);
+          utf32_to_utf8.second = r.count;
+          ASSERT_TRUE(expected_length > 0 && expected_length == output.size() && expected_length == utf32_to_utf8.second);
+
+          expected_length = implementation.utf16_length_from_utf32(reinterpret_cast<char32_t *>(input.data()), input.size() / sizeof(char32_t));
+          output.resize(expected_length * sizeof(char16_t));
+          output.shrink_to_fit(); // make sure we don't have superfluous space
+          r = implementation.convert_utf32_to_utf16le_with_errors(
+              reinterpret_cast<char32_t *>(input.data()),
+              input.size() / sizeof(char32_t), reinterpret_cast<char16_t *>(output.data()));
+          utf32_to_utf16.first = (r.error == simdutf::SUCCESS);
+          utf32_to_utf16.second = r.count;
           ASSERT_TRUE(expected_length > 0 && (expected_length * sizeof(char16_t) == output.size()) && expected_length == utf32_to_utf16.second);
         }
       }

--- a/tests/convert_utf8_to_utf16be_with_errors_tests.cpp
+++ b/tests/convert_utf8_to_utf16be_with_errors_tests.cpp
@@ -19,6 +19,19 @@ namespace {
   constexpr size_t fix_size = 512;
 }
 
+TEST(issue_213) {
+  const char buf[] = "\x01\x9a\x84";
+  // We select the byte 0x84. It is a continuation byte so it is possible
+  // that the predicted output might be zero.
+  size_t expected_size = implementation.utf16_length_from_utf8(buf + 2, 1);
+  std::unique_ptr<char16_t[]>buffer(new char16_t[expected_size]);
+  simdutf::result r = simdutf::convert_utf8_to_utf16be_with_errors(buf + 2, 1, buffer.get());
+  ASSERT_TRUE(r.error != simdutf::SUCCESS);
+  // r.count: In case of error, indicates the position of the error in the input.
+  // In case of success, indicates the number of words validated/written.
+  ASSERT_TRUE(r.count == 0);
+}
+
 TEST(convert_pure_ASCII) {
   for(size_t trial = 0; trial < trials; trial ++) {
     if((trial % 100) == 0) { std::cout << "."; std::cout.flush(); }

--- a/tests/convert_utf8_to_utf16le_with_errors_tests.cpp
+++ b/tests/convert_utf8_to_utf16le_with_errors_tests.cpp
@@ -19,6 +19,19 @@ namespace {
   constexpr size_t fix_size = 512;
 }
 
+TEST(issue_213) {
+  const char buf[] = "\x01\x9a\x84";
+  // We select the byte 0x84. It is a continuation byte so it is possible
+  // that the predicted output might be zero.
+  size_t expected_size = implementation.utf16_length_from_utf8(buf + 2, 1);
+  std::unique_ptr<char16_t[]>buffer(new char16_t[expected_size]);
+  simdutf::result r = simdutf::convert_utf8_to_utf16le_with_errors(buf + 2, 1, buffer.get());
+  ASSERT_TRUE(r.error != simdutf::SUCCESS);
+  // r.count: In case of error, indicates the position of the error in the input.
+  // In case of success, indicates the number of words validated/written.
+  ASSERT_TRUE(r.count == 0);
+}
+
 TEST(convert_pure_ASCII) {
   for(size_t trial = 0; trial < trials; trial ++) {
     if((trial % 100) == 0) { std::cout << "."; std::cout.flush(); }

--- a/tests/convert_utf8_to_utf16le_with_errors_tests.cpp
+++ b/tests/convert_utf8_to_utf16le_with_errors_tests.cpp
@@ -20,7 +20,7 @@ namespace {
 }
 
 TEST(issue_213) {
-  const char buf[] = "\x01\x9a\x84";
+  const char* buf = "\x01\x9a\x84";
   // We select the byte 0x84. It is a continuation byte so it is possible
   // that the predicted output might be zero.
   size_t expected_size = implementation.utf16_length_from_utf8(buf + 2, 1);

--- a/tests/convert_utf8_to_utf32_with_errors_tests.cpp
+++ b/tests/convert_utf8_to_utf32_with_errors_tests.cpp
@@ -18,6 +18,19 @@ namespace {
   constexpr size_t fix_size = 512;
 }
 
+TEST(issue_213) {
+  const char buf[] = "\x01\x9a\x84";
+  // We select the byte 0x84. It is a continuation byte so it is possible
+  // that the predicted output might be zero.
+  size_t expected_size = implementation.utf32_length_from_utf8(buf + 2, 1);
+  std::unique_ptr<char32_t[]>buffer(new char32_t[expected_size]);
+  simdutf::result r = simdutf::convert_utf8_to_utf32_with_errors(buf + 2, 1, buffer.get());
+  ASSERT_TRUE(r.error != simdutf::SUCCESS);
+  //r.count: In case of error, indicates the position of the error in the input.
+  // In case of success, indicates the number of words validated/written.
+  ASSERT_TRUE(r.count == 0);
+}
+
 TEST(convert_pure_ASCII) {
   for(size_t trial = 0; trial < trials; trial ++) {
     if((trial % 100) == 0) { std::cout << "."; std::cout.flush(); }

--- a/tests/convert_utf8_to_utf32_with_errors_tests.cpp
+++ b/tests/convert_utf8_to_utf32_with_errors_tests.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <iostream>
+#include <memory>
 
 #include <tests/helpers/transcode_test_base.h>
 #include <tests/helpers/random_int.h>


### PR DESCRIPTION
For short strings,`convert_utf8_to_utf16le_with_errors` may sometimes cause buffer overflows by reading before the buffer when the input is not UTF-8.

It is a rather silly bug, and it was easily fixed. It is disappointing that our fuzzer did not catch this: I have therefore extended it. We are now doing more testing over (small) garbage inputs.

Credit to @Jarred-Sumner and his team.

Fixes https://github.com/simdutf/simdutf/issues/213