### PR TITLE
chore: remove `[skip ci]` handling as it is natively supported

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -10,9 +10,6 @@ on:
 
 jobs:
   windows-mingw:
-    if: >-
-      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
-      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     name: ${{ matrix.msystem }}
     runs-on: windows-latest
     defaults:

--- a/.github/workflows/ubuntu18.yml
+++ b/.github/workflows/ubuntu18.yml
@@ -10,9 +10,6 @@ on:
 
 jobs:
   ubuntu-build:
-    if: >-
-      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
-      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -10,9 +10,6 @@ on:
 
 jobs:
   ubuntu-build:
-    if: >-
-      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
-      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/ubuntu20sani.yml
+++ b/.github/workflows/ubuntu20sani.yml
@@ -10,9 +10,6 @@ on:
 
 jobs:
   ubuntu-build:
-    if: >-
-      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
-      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ubuntu20single.yml
+++ b/.github/workflows/ubuntu20single.yml
@@ -10,9 +10,6 @@ on:
 
 jobs:
   ubuntu-build:
-    if: >-
-      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
-      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -10,9 +10,6 @@ on:
 
 jobs:
   ubuntu-build:
-    if: >-
-      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
-      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/ubuntu22_gcc12.yml
+++ b/.github/workflows/ubuntu22_gcc12.yml
@@ -10,9 +10,6 @@ on:
 
 jobs:
   ubuntu-build:
-    if: >-
-      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
-      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/vs17-ci.yml
+++ b/.github/workflows/vs17-ci.yml
@@ -4,9 +4,6 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    if: >-
-      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
-      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     name: windows-vs17
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/vs17-clang-ci.yml
+++ b/.github/workflows/vs17-clang-ci.yml
@@ -4,9 +4,6 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    if: >-
-      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
-      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     name: windows-vs17
     runs-on: windows-latest
     strategy:


### PR DESCRIPTION
relates to https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/