### PR TITLE
Fix warning about signed/unsigned mismatch on x86 Windows

### DIFF
--- a/tools/sutf.cpp
+++ b/tools/sutf.cpp
@@ -273,7 +273,7 @@ void CommandLine::run_simdutf_procedure(PROCEDURE proc) {
     if(!load_chunk(&input_size)) { printf("Could not load %s\n", input_files.front().string().c_str()); input_files.pop();  continue; }
     leftovers = input_size - proc(input_size);
     // Copy leftover bytes to the start of input_data
-    for (int i = 0; i < leftovers; i++) {
+    for (size_t i = 0; i < leftovers; i++) {
       input_data[i] = input_data[input_size-leftovers+i];
     }
   }


### PR DESCRIPTION
When compiling with MSVC targeting x86, the compiler issues a warning when building `sutf`. Thanks to https://github.com/simdutf/simdutf/pull/266, this warning even gets promoted to an error, which means you currently can't build `sutf` for x86 Windows with MSVC. I know that simdutf is heavily optimitzed for 64-Bit platforms, so using it on x86 is somewhat discouraged, but I assume the code should still at least be buildable.

I tested this with Visual Studio 2022, but I assume previous versions of the compiler also issue this warning.