### PR TITLE
AVX512 latin1 to utf8

### DIFF
--- a/src/icelake/icelake_convert_latin1_to_utf8.inl.cpp
+++ b/src/icelake/icelake_convert_latin1_to_utf8.inl.cpp
@@ -1,0 +1,199 @@
+// file included directly
+
+
+void printbinary(uint64_t n) {
+  for (size_t i = 0; i < 64; i++) {
+    if (n & 1)
+      printf("1");
+    else
+      printf("0");
+
+    n >>= 1;
+  }
+  printf("\n");
+}
+void print8(const char *name, __m512i x) {
+  printf("%.32s : ", name);
+  uint8_t buffer[64];
+  _mm512_storeu_si512((__m512i *)buffer, x);
+  for (size_t i = 0; i < 64; i++) {
+    printf("%02x ", buffer[i]);
+  }
+  printf("\n");
+}
+
+static inline size_t latin1_to_utf8_avx512_vec(__m512i input, size_t input_len, char *utf8_output, int mask_output) {
+  __mmask64 nonascii = _mm512_movepi8_mask(input);
+  size_t output_size = input_len + (size_t)_popcnt64(nonascii);
+  
+  // Mask to denote whether the byte is a leading byte that is not ascii
+  __mmask64 sixth =
+      _mm512_cmpge_epu8_mask(input, _mm512_set1_epi8(-64)); //binary representation of -64: 1100 0000
+  
+  const uint64_t alternate_bits = UINT64_C(0x5555555555555555);
+  uint64_t ascii = ~nonascii;
+  // the bits in ascii are inverted and zeros are interspersed in between them
+  uint64_t maskA = ~_pdep_u64(ascii, alternate_bits);
+  uint64_t maskB = ~_pdep_u64(ascii>>32, alternate_bits);
+  
+  // interleave bytes from top and bottom halves (abcd...ABCD -> aAbBcCdD)
+  __m512i input_interleaved = _mm512_permutexvar_epi8(_mm512_set_epi32(
+    0x3f1f3e1e, 0x3d1d3c1c, 0x3b1b3a1a, 0x39193818,
+    0x37173616, 0x35153414, 0x33133212, 0x31113010,
+    0x2f0f2e0e, 0x2d0d2c0c, 0x2b0b2a0a, 0x29092808,
+    0x27072606, 0x25052404, 0x23032202, 0x21012000
+  ), input);
+  
+  // double size of each byte, and insert the leading byte 1100 0010
+
+/* 
+upscale the bytes to 16-bit value, adding the 0b11000000 leading byte in the process.
+We adjust for the bytes that have their two most significant bits. This takes care of the first 32 bytes, assuming we interleaved the bytes. */
+  // Recall: twos complement of -62 = 1100 0010 = 0xc2
+  // say we have aaAA 16 byte unit => 
+  __m512i outputA = _mm512_shldi_epi16(input_interleaved, _mm512_set1_epi8(-62), 8); //this makes C2C2aaAA => C2aaAA00 => C2aa
+  // so we'll get C2aa , C2bb , C2cc ... etc
+  //  here we set up '11' as the leading bits of the 16-bit units if said respective unit IN THE ORIGINAL INPUT is a leading byte
+  outputA = _mm512_mask_add_epi16(
+                                  outputA, 
+                                 (__mmask32)sixth, 
+                                  outputA, 
+                                  _mm512_set1_epi16(1 - 0x4000)); // 1- 0x4000 = 1100 0000 0000 0001????
+  
+  // in the second 32-bit half, set first or second option based on whether original input is leading byte (second case) or not (first case)
+  __m512i leadingB = _mm512_mask_blend_epi16(
+                                              (__mmask32)(sixth>>32), 
+                                              _mm512_set1_epi16(0x00c2), // 0000 0000 1101 0010
+                                              _mm512_set1_epi16(0x40c3));// 0100 0000 1100 0011
+  __m512i outputB = _mm512_ternarylogic_epi32(
+                                              input_interleaved, 
+                                              leadingB, 
+                                              _mm512_set1_epi16((short)0xff00), 
+                                              (240 & 170) ^ 204); // (input_interleaved & 0xff00) ^ leadingB
+  
+  // prune redundant bytes
+  outputA = _mm512_maskz_compress_epi8(maskA, outputA);
+  outputB = _mm512_maskz_compress_epi8(maskB, outputB);
+  
+  
+  size_t output_sizeA = (size_t)_popcnt32((uint32_t)nonascii) + 32;
+  if(mask_output) {
+    if(input_len > 32) { // is the second half of the input vector used?
+      __mmask64 write_mask = _bzhi_u64(~0ULL, output_sizeA);
+      _mm512_mask_storeu_epi8(utf8_output, write_mask, outputA);
+      utf8_output += output_sizeA;
+      write_mask = _bzhi_u64(~0ULL, output_size - output_sizeA);
+      _mm512_mask_storeu_epi8(utf8_output, write_mask, outputB);
+    } else {
+      __mmask64 write_mask = _bzhi_u64(~0ULL, output_size);
+      _mm512_mask_storeu_epi8(utf8_output, write_mask, outputA);
+    }
+  } else {
+    _mm512_storeu_si512(utf8_output, outputA);
+    utf8_output += output_sizeA;
+    _mm512_storeu_si512(utf8_output, outputB);
+  }
+  return output_size;
+}
+ 
+// if the likelihood of non-ASCII characters is low, it may make sense to add a branch for a faster routine
+static inline size_t latin1_to_utf8_avx512_branch(__m512i input, char *utf8_output, int br) {
+  __mmask64 nonascii = _mm512_movepi8_mask(input);
+  size_t nonascii_count = (size_t)_popcnt64(nonascii);
+  
+  if(br == 0) { // shortcut for no non-ASCII characters
+    if(nonascii_count > 0)
+      return latin1_to_utf8_avx512_vec(input, 64, utf8_output, 0);
+    _mm512_storeu_si512(utf8_output, input);
+    return 64;
+    
+  } else { // shortcut for up to 1 non-ASCII characters
+    if(nonascii_count > 1)
+      return latin1_to_utf8_avx512_vec(input, 64, utf8_output, 0);
+    
+    __mmask64 sixth =
+        _mm512_cmpge_epu8_mask(input, _mm512_set1_epi8(-64));
+    input = _mm512_mask_add_epi8(input, 
+                                  sixth, 
+                                  input, _mm512_set1_epi8(-64));
+    
+    // we're writing either 64 or 65 bytes; write the last byte to cater for the latter case (the earlier bytes will get overwritten)
+    //_mm512_storeu_si512(utf8_output + 1, input);
+    utf8_output[64] = (char)_mm_extract_epi8(_mm512_extracti32x4_epi32(input, 3), 15);
+    
+    __m512i leading = _mm512_mask_blend_epi8(sixth, _mm512_set1_epi8(-62), _mm512_set1_epi8(-61));
+    input = _mm512_mask_expand_epi8(leading, ~nonascii, input);
+    _mm512_storeu_si512(utf8_output, input);
+    
+    return 64 + nonascii_count;
+  }
+}
+ 
+/* size_t latin1_to_utf8_avx512_my_nobranch(const char *buf, size_t len, char *utf8_output) {
+  char *start = utf8_output;
+  size_t pos = 0;
+  // if there's at least 128 bytes remaining, we don't need to mask the output
+  for (; pos + 128 <= len; pos += 64) {
+    __m512i input = _mm512_loadu_si512((__m512i *)(buf + pos));
+    utf8_output += latin1_to_utf8_avx512_vec(input, 64, utf8_output, 0);
+  }
+  // in the last 128 bytes, the first 64 may require masking the output
+  if (pos + 64 <= len) {
+    __m512i input = _mm512_loadu_si512((__m512i *)(buf + pos));
+    utf8_output += latin1_to_utf8_avx512_vec(input, 64, utf8_output, 1);
+    pos += 64;
+  }
+  // with the last 64 bytes, the input also needs to be masked
+  if (pos < len) {
+    __mmask64 load_mask = _bzhi_u64(~0ULL, (unsigned int)(len - pos));
+    __m512i input = _mm512_maskz_loadu_epi8(load_mask, (__m512i *)(buf + pos));
+    utf8_output += latin1_to_utf8_avx512_vec(input, len - pos, utf8_output, 1);
+  }
+  return (size_t)(utf8_output - start);
+} */
+ 
+size_t latin1_to_utf8_avx512_my_branch0(const char *buf, size_t len, char *utf8_output) {
+  char *start = utf8_output;
+  size_t pos = 0;
+  // if there's at least 128 bytes remaining, we don't need to mask the output
+  for (; pos + 128 <= len; pos += 64) {
+    __m512i input = _mm512_loadu_si512((__m512i *)(buf + pos));
+    utf8_output += latin1_to_utf8_avx512_branch(input, utf8_output, 0);
+  }
+  // in the last 128 bytes, the first 64 may require masking the output
+  if (pos + 64 <= len) {
+    __m512i input = _mm512_loadu_si512((__m512i *)(buf + pos));
+    utf8_output += latin1_to_utf8_avx512_vec(input, 64, utf8_output, 1);
+    pos += 64;
+  }
+  // with the last 64 bytes, the input also needs to be masked
+  if (pos < len) {
+    __mmask64 load_mask = _bzhi_u64(~0ULL, (unsigned int)(len - pos));
+    __m512i input = _mm512_maskz_loadu_epi8(load_mask, (__m512i *)(buf + pos));
+    utf8_output += latin1_to_utf8_avx512_vec(input, len - pos, utf8_output, 1);
+  }
+  return (size_t)(utf8_output - start);
+}
+ 
+size_t latin1_to_utf8_avx512_my_branch1(const char *buf, size_t len, char *utf8_output) {
+  char *start = utf8_output;
+  size_t pos = 0;
+  // if there's at least 128 bytes remaining, we don't need to mask the output
+  for (; pos + 128 <= len; pos += 64) {
+    __m512i input = _mm512_loadu_si512((__m512i *)(buf + pos));
+    utf8_output += latin1_to_utf8_avx512_branch(input, utf8_output, 1);
+  }
+  // in the last 128 bytes, the first 64 may require masking the output
+  if (pos + 64 <= len) {
+    __m512i input = _mm512_loadu_si512((__m512i *)(buf + pos));
+    utf8_output += latin1_to_utf8_avx512_vec(input, 64, utf8_output, 1);
+    pos += 64;
+  }
+  // with the last 64 bytes, the input also needs to be masked
+  if (pos < len) {
+    __mmask64 load_mask = _bzhi_u64(~0ULL, (unsigned int)(len - pos));
+    __m512i input = _mm512_maskz_loadu_epi8(load_mask, (__m512i *)(buf + pos));
+    utf8_output += latin1_to_utf8_avx512_vec(input, len - pos, utf8_output, 1);
+  }
+  return (size_t)(utf8_output - start);
+}

--- a/src/icelake/icelake_convert_latin1_to_utf8.inl.cpp
+++ b/src/icelake/icelake_convert_latin1_to_utf8.inl.cpp
@@ -50,7 +50,9 @@ We adjust for the bytes that have their two most significant bits. This takes ca
   outputB = _mm512_maskz_compress_epi8(maskB, outputB);
   
   
-  size_t output_sizeA = (size_t)count_ones((uint32_t)nonascii) + 32;
+  // size_t output_sizeA = (size_t)count_ones((uint32_t)nonascii) + 32;
+  unsigned int output_sizeA = (unsigned int)(count_ones(static_cast<uint32_t>(nonascii))) + 32;
+
   if(mask_output) {
     if(input_len > 32) { // is the second half of the input vector used?
       __mmask64 write_mask = _bzhi_u64(~0ULL, output_sizeA);

--- a/src/icelake/icelake_convert_latin1_to_utf8.inl.cpp
+++ b/src/icelake/icelake_convert_latin1_to_utf8.inl.cpp
@@ -78,7 +78,7 @@ static inline size_t latin1_to_utf8_avx512_branch(__m512i input, char *utf8_outp
     return latin1_to_utf8_avx512_vec(input, 64, utf8_output, 0);
   } else {
     _mm512_storeu_si512(utf8_output, input);
-    return 64;}
+    return 64 + nonascii_count;}
 }
  
 size_t latin1_to_utf8_avx512_start(const char *buf, size_t len, char *utf8_output) {

--- a/src/icelake/icelake_convert_latin1_to_utf8.inl.cpp
+++ b/src/icelake/icelake_convert_latin1_to_utf8.inl.cpp
@@ -50,18 +50,17 @@ We adjust for the bytes that have their two most significant bits. This takes ca
   outputB = _mm512_maskz_compress_epi8(maskB, outputB);
   
   
-  // size_t output_sizeA = (size_t)count_ones((uint32_t)nonascii) + 32;
-  unsigned int output_sizeA = (unsigned int)(count_ones(static_cast<uint32_t>(nonascii))) + 32;
+  size_t output_sizeA = (size_t)count_ones((uint32_t)nonascii) + 32;
 
   if(mask_output) {
     if(input_len > 32) { // is the second half of the input vector used?
-      __mmask64 write_mask = _bzhi_u64(~0ULL, output_sizeA);
+      __mmask64 write_mask = _bzhi_u64(~0ULL, (unsigned int)output_sizeA);
       _mm512_mask_storeu_epi8(utf8_output, write_mask, outputA);
       utf8_output += output_sizeA;
-      write_mask = _bzhi_u64(~0ULL, output_size - output_sizeA);
+      write_mask = _bzhi_u64(~0ULL, (unsigned int)(output_size - output_sizeA));
       _mm512_mask_storeu_epi8(utf8_output, write_mask, outputB);
     } else {
-      __mmask64 write_mask = _bzhi_u64(~0ULL, output_size);
+      __mmask64 write_mask = _bzhi_u64(~0ULL, (unsigned int)output_size);
       _mm512_mask_storeu_epi8(utf8_output, write_mask, outputA);
     }
   } else {

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -480,10 +480,7 @@ simdutf_warn_unused result implementation::validate_utf32_with_errors(const char
 }
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(const char * buf, size_t len, char* utf8_output) const noexcept {
-  // __m512i input_data = _mm512_loadu_si512((__m512i*)buf);
   return icelake::latin1_to_utf8_avx512_start(buf, len, utf8_output);
-  // return icelake::latin1_to_utf8_avx512_branch(buf,len,utf8_output);
-  // return scalar::latin1_to_utf8::convert(buf,len,utf8_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16le(const char* buf, size_t len, char16_t* utf16_output) const noexcept {

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -481,7 +481,7 @@ simdutf_warn_unused result implementation::validate_utf32_with_errors(const char
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(const char * buf, size_t len, char* utf8_output) const noexcept {
   // __m512i input_data = _mm512_loadu_si512((__m512i*)buf);
-  return icelake::latin1_to_utf8_avx512_my_branch0(buf, len, utf8_output);
+  return icelake::latin1_to_utf8_avx512_start(buf, len, utf8_output);
   // return icelake::latin1_to_utf8_avx512_branch(buf,len,utf8_output);
   // return scalar::latin1_to_utf8::convert(buf,len,utf8_output);
 }

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -28,6 +28,8 @@ namespace {
 #include "icelake/icelake_ascii_validation.inl.cpp"
 #include "icelake/icelake_utf32_validation.inl.cpp"
 #include "icelake/icelake_convert_utf16_to_utf8.inl.cpp"
+#include "icelake/icelake_convert_latin1_to_utf8.inl.cpp"
+
 
 #include <cstdint>
 
@@ -478,7 +480,10 @@ simdutf_warn_unused result implementation::validate_utf32_with_errors(const char
 }
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(const char * buf, size_t len, char* utf8_output) const noexcept {
-  return scalar::latin1_to_utf8::convert(buf,len,utf8_output);
+  // __m512i input_data = _mm512_loadu_si512((__m512i*)buf);
+  return icelake::latin1_to_utf8_avx512_my_branch0(buf, len, utf8_output);
+  // return icelake::latin1_to_utf8_avx512_branch(buf,len,utf8_output);
+  // return scalar::latin1_to_utf8::convert(buf,len,utf8_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16le(const char* buf, size_t len, char16_t* utf16_output) const noexcept {


### PR DESCRIPTION
These are the benchmarks for this PR: 

convert_latin1_to_utf8+haswell, input size: 440052, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin8.txt
   5.440 ins/byte,    1.842 cycle/byte,    1.734 GB/s (1.7 %),     3.193 GHz,    2.954 ins/cycle 
   5.440 ins/char,    1.842 cycle/char,    1.734 Gc/s (1.7 %)     1.00 byte/char 
convert_latin1_to_utf8+icelake, input size: 440052, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin8.txt
   0.437 ins/byte,    0.170 cycle/byte,   18.199 GB/s (1.4 %),     3.100 GHz,    2.564 ins/cycle 
   0.437 ins/char,    0.170 cycle/char,   18.199 Gc/s (1.4 %)     1.00 byte/char 
convert_latin1_to_utf8+iconv, input size: 440052, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin8.txt
  26.865 ins/byte,    7.232 cycle/byte,    0.441 GB/s (28.2 %),     3.189 GHz,    3.715 ins/cycle 
  26.865 ins/char,    7.232 cycle/char,    0.441 Gc/s (28.2 %)     1.00 byte/char 
WARNING: Measurements are noisy, try increasing iteration count (-I).
convert_latin1_to_utf8+icu, input size: 440052, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin8.txt
  16.176 ins/byte,    3.370 cycle/byte,    0.947 GB/s (16.6 %),     3.193 GHz,    4.800 ins/cycle 
  16.176 ins/char,    3.370 cycle/char,    0.947 Gc/s (16.6 %)     1.00 byte/char 
WARNING: Measurements are noisy, try increasing iteration count (-I).
convert_latin1_to_utf8+westmere, input size: 440052, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin8.txt
   5.440 ins/byte,    1.902 cycle/byte,    1.679 GB/s (1.4 %),     3.193 GHz,    2.861 ins/cycle 
   5.440 ins/char,    1.902 cycle/char,    1.679 Gc/s (1.4 %)     1.00 byte/char 