### PR TITLE
UTF 8 => Latin (Westmere/SSE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,53 +569,51 @@ are fast and non-validating.
 
 ```c++
 
- /**
-   * Return the number of bytes that this Latin1 string would require in UTF-8 format.
-   *
-   * @param input         the Latin1 string to convert
-   * @param length        the length of the string bytes
-   * @return the number of bytes required to encode the Latin1 string as UTF-8
-   */
-    simdutf_warn_unused size_t utf8_length_from_latin1(const char * input, size_t length) noexcept;
+/**
+ * Return the number of bytes that this Latin1 string would require in UTF-8 format.
+ *
+ * @param input         the Latin1 string to convert
+ * @param length        the length of the string bytes
+ * @return the number of bytes required to encode the Latin1 string as UTF-8
+ */
+simdutf_warn_unused size_t utf8_length_from_latin1(const char * input, size_t length) noexcept;
 
-  /**
-   * Compute the number of bytes that this UTF-8 string would require in Latin1 format.
-   *
-   * This function does not validate the input.
-   *
-   * This function is not BOM-aware.
-   *
-   * @param input         the UTF-8 string to convert
-   * @param length        the length of the string in byte
-   * @return the number of bytes required to encode the UTF-8 string as Latin1
-   */
-    simdutf_warn_unused size_t latin1_length_from_utf8(const char * input, size_t length) noexcept;
+/**
+ * Compute the number of bytes that this UTF-8 string would require in Latin1 format.
+ *
+ * This function does not validate the input.
+ *
+ * This function is not BOM-aware.
+ *
+ * @param input         the UTF-8 string to convert
+ * @param length        the length of the string in byte
+ * @return the number of bytes required to encode the UTF-8 string as Latin1
+ */
+simdutf_warn_unused size_t latin1_length_from_utf8(const char * input, size_t length) noexcept;
 
 /*
-   * Compute the number of bytes that this UTF-16LE/BE string would require in Latin1 format.
-   *
-   * This function does not validate the input.
-   *
-   * This function is not BOM-aware.
-   *
-   * @param input         the UTF-16LE string to convert
-   * @param length        the length of the string in 2-byte words (char16_t)
-   * @return the number of bytes required to encode the UTF-16LE string as Latin1
-   */
-  simdutf_warn_unused size_t latin1_length_from_utf16(size_t length) noexcept;
+ * Compute the number of bytes that this UTF-16LE/BE string would require in Latin1 format.
+ *
+ * This function does not validate the input.
+ *
+ * This function is not BOM-aware.
+ *
+ * @param length        the length of the string in 2-byte words (char16_t)
+ * @return the number of bytes required to encode the UTF-16LE string as Latin1
+ */
+simdutf_warn_unused size_t latin1_length_from_utf16(size_t length) noexcept;
 
-  /**
-   * Compute the number of bytes that this UTF-32 string would require in Latin1 format.
-   *
-   * This function does not validate the input.
-   *
-   * This function is not BOM-aware.
-   *
-   * @param input         the UTF-32 string to convert
-   * @param length        the length of the string in 4-byte words (char32_t)
-   * @return the number of bytes required to encode the UTF-32 string as Latin1
-   */
-    simdutf_warn_unused size_t latin1_length_from_utf32( size_t length) noexcept;
+/**
+ * Compute the number of bytes that this UTF-32 string would require in Latin1 format.
+ *
+ * This function does not validate the input.
+ *
+ * This function is not BOM-aware.
+ *
+ * @param length        the length of the string in 4-byte words (char32_t)
+ * @return the number of bytes required to encode the UTF-32 string as Latin1
+ */
+simdutf_warn_unused size_t latin1_length_from_utf32(size_t length) noexcept;
 
 /**
  * Compute the number of 2-byte words that this UTF-8 string would require in UTF-16 format.

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -859,17 +859,16 @@ simdutf_warn_unused size_t convert_valid_utf16be_to_utf32(const char16_t * input
 
 
 /*
-   * Compute the number of bytes that this UTF-16LE/BE string would require in Latin1 format.
-   *
-   * This function does not validate the input.
-   *
-   * This function is not BOM-aware.
-   *
-   * @param input         the UTF-16LE string to convert
-   * @param length        the length of the string in 2-byte words (char16_t)
-   * @return the number of bytes required to encode the UTF-16LE string as Latin1
-   */
-  simdutf_warn_unused size_t latin1_length_from_utf16(size_t length) noexcept;
+ * Compute the number of bytes that this UTF-16LE/BE string would require in Latin1 format.
+ *
+ * This function does not validate the input.
+ *
+ * This function is not BOM-aware.
+ *
+ * @param length        the length of the string in 2-byte words (char16_t)
+ * @return the number of bytes required to encode the UTF-16LE string as Latin1
+ */
+simdutf_warn_unused size_t latin1_length_from_utf16(size_t length) noexcept;
 
 
 /**
@@ -2203,11 +2202,10 @@ public:
    *
    * This function does not validate the input.
    *
-   * @param input         the UTF-32 string to convert
    * @param length        the length of the string in 4-byte words (char32_t)
    * @return the number of bytes required to encode the UTF-32 string as Latin1
    */
-    simdutf_warn_unused virtual size_t latin1_length_from_utf32( size_t length) const noexcept = 0;
+  simdutf_warn_unused virtual size_t latin1_length_from_utf32(size_t length) const noexcept = 0;
 
   /**
    * Compute the number of bytes that this UTF-8 string would require in Latin1 format.
@@ -2218,9 +2216,9 @@ public:
    * @param length        the length of the string in byte
    * @return the number of bytes required to encode the UTF-8 string as Latin1
    */
-    simdutf_warn_unused virtual size_t latin1_length_from_utf8(const char * input, size_t length) const noexcept = 0;
+  simdutf_warn_unused virtual size_t latin1_length_from_utf8(const char * input, size_t length) const noexcept = 0;
 
-/*
+  /*
    * Compute the number of bytes that this UTF-16LE/BE string would require in Latin1 format.
    *
    * This function does not validate the input.

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -451,27 +451,27 @@ simdutf_warn_unused size_t convert_valid_utf8_to_utf16be(const char * input, siz
 simdutf_warn_unused size_t convert_valid_utf8_to_utf32(const char * input, size_t length, char32_t* utf32_buffer) noexcept;
 
 
- /**
-   * Return the number of bytes that this Latin1 string would require in UTF-8 format.
-   *
-   * @param input         the Latin1 string to convert
-   * @param length        the length of the string bytes
-   * @return the number of bytes required to encode the Latin1 string as UTF-8
-   */
-    simdutf_warn_unused size_t utf8_length_from_latin1(const char * input, size_t length) noexcept;
+/**
+ * Return the number of bytes that this Latin1 string would require in UTF-8 format.
+ *
+ * @param input         the Latin1 string to convert
+ * @param length        the length of the string bytes
+ * @return the number of bytes required to encode the Latin1 string as UTF-8
+ */
+simdutf_warn_unused size_t utf8_length_from_latin1(const char * input, size_t length) noexcept;
 
-  /**
-   * Compute the number of bytes that this UTF-8 string would require in Latin1 format.
-   *
-   * This function does not validate the input.
-   *
-   * This function is not BOM-aware.
-   *
-   * @param input         the UTF-8 string to convert
-   * @param length        the length of the string in byte
-   * @return the number of bytes required to encode the UTF-8 string as Latin1
-   */
-    simdutf_warn_unused size_t latin1_length_from_utf8(const char * input, size_t length) noexcept;
+/**
+ * Compute the number of bytes that this UTF-8 string would require in Latin1 format.
+ *
+ * This function does not validate the input.
+ *
+ * This function is not BOM-aware.
+ *
+ * @param input         the UTF-8 string to convert
+ * @param length        the length of the string in byte
+ * @return the number of bytes required to encode the UTF-8 string as Latin1
+ */
+simdutf_warn_unused size_t latin1_length_from_utf8(const char * input, size_t length) noexcept;
 
 /**
  * Compute the number of 2-byte words that this UTF-8 string would require in UTF-16LE format.

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -600,7 +600,7 @@ simdutf_warn_unused size_t implementation::count_utf8(const char * input, size_t
 }
 
 simdutf_warn_unused size_t implementation::latin1_length_from_utf8(const char* buf, size_t len) const noexcept {
-  return scalar::utf8::latin1_length_from_utf8(buf,len);
+  return count_utf8(buf,len);
 }
 
 simdutf_warn_unused size_t implementation::latin1_length_from_utf16(size_t length) const noexcept {

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -607,7 +607,7 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf16(size_t lengt
   return scalar::utf16::latin1_length_from_utf16(length);
 }
 
-simdutf_warn_unused size_t implementation::latin1_length_from_utf32( size_t length) const noexcept {
+simdutf_warn_unused size_t implementation::latin1_length_from_utf32(size_t length) const noexcept {
   return scalar::utf32::latin1_length_from_utf32(length);
 }
 

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -296,7 +296,7 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf16(size_t lengt
   return scalar::utf16::latin1_length_from_utf16(length);
 }
 
-simdutf_warn_unused size_t implementation::latin1_length_from_utf32( size_t length) const noexcept {
+simdutf_warn_unused size_t implementation::latin1_length_from_utf32(size_t length) const noexcept {
   return length;
 }
 

--- a/src/generic/utf8_to_latin1/utf8_to_latin1.h
+++ b/src/generic/utf8_to_latin1/utf8_to_latin1.h
@@ -1,0 +1,297 @@
+#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
+
+
+namespace simdutf {
+namespace SIMDUTF_IMPLEMENTATION {
+namespace {
+namespace utf8_to_latin1 {
+using namespace simd;
+
+
+  simdutf_really_inline simd8<uint8_t> check_special_cases(const simd8<uint8_t> input, const simd8<uint8_t> prev1) {
+// For UTF-8 to Latin 1, we can allow any ASCII character, and any continuation byte,
+// but the non-ASCII leading bytes must be 0b11000011 or 0b11000010 and nothing else.
+//
+// Bit 0 = Too Short (lead byte/ASCII followed by lead byte/ASCII)
+// Bit 1 = Too Long (ASCII followed by continuation)
+// Bit 2 = Overlong 3-byte
+// Bit 4 = Surrogate
+// Bit 5 = Overlong 2-byte
+// Bit 7 = Two Continuations
+    constexpr const uint8_t TOO_SHORT   = 1<<0; // 11______ 0_______
+                                                // 11______ 11______
+    constexpr const uint8_t TOO_LONG    = 1<<1; // 0_______ 10______
+    constexpr const uint8_t OVERLONG_3  = 1<<2; // 11100000 100_____
+    constexpr const uint8_t SURROGATE   = 1<<4; // 11101101 101_____
+    constexpr const uint8_t OVERLONG_2  = 1<<5; // 1100000_ 10______
+    constexpr const uint8_t TWO_CONTS   = 1<<7; // 10______ 10______
+    constexpr const uint8_t TOO_LARGE   = 1<<3; // 11110100 1001____
+                                                // 11110100 101_____
+                                                // 11110101 1001____
+                                                // 11110101 101_____
+                                                // 1111011_ 1001____
+                                                // 1111011_ 101_____
+                                                // 11111___ 1001____
+                                                // 11111___ 101_____
+    constexpr const uint8_t TOO_LARGE_1000 = 1<<6;
+                                                // 11110101 1000____
+                                                // 1111011_ 1000____
+                                                // 11111___ 1000____
+    constexpr const uint8_t OVERLONG_4  = 1<<6; // 11110000 1000____
+    constexpr const uint8_t FORBIDDEN  = 0xff;
+
+    const simd8<uint8_t> byte_1_high = prev1.shr<4>().lookup_16<uint8_t>(
+      // 0_______ ________ <ASCII in byte 1>
+      TOO_LONG, TOO_LONG, TOO_LONG, TOO_LONG,
+      TOO_LONG, TOO_LONG, TOO_LONG, TOO_LONG,
+      // 10______ ________ <continuation in byte 1>
+      TWO_CONTS, TWO_CONTS, TWO_CONTS, TWO_CONTS,
+      // 1100____ ________ <two byte lead in byte 1>
+      TOO_SHORT | OVERLONG_2,
+      // 1101____ ________ <two byte lead in byte 1>
+      FORBIDDEN,
+      // 1110____ ________ <three byte lead in byte 1>
+      FORBIDDEN,
+      // 1111____ ________ <four+ byte lead in byte 1>
+      FORBIDDEN
+    );
+    constexpr const uint8_t CARRY = TOO_SHORT | TOO_LONG | TWO_CONTS; // These all have ____ in byte 1 .
+    const simd8<uint8_t> byte_1_low = (prev1 & 0x0F).lookup_16<uint8_t>(
+      // ____0000 ________
+      CARRY | OVERLONG_3 | OVERLONG_2 | OVERLONG_4,
+      // ____0001 ________
+      CARRY | OVERLONG_2,
+      // ____001_ ________
+      CARRY,
+      CARRY,
+
+      // ____0100 ________
+      FORBIDDEN,
+      // ____0101 ________
+      FORBIDDEN,
+      // ____011_ ________
+      FORBIDDEN,
+      FORBIDDEN,
+
+      // ____1___ ________
+      FORBIDDEN,
+      FORBIDDEN,
+      FORBIDDEN,
+      FORBIDDEN,
+      FORBIDDEN,
+      // ____1101 ________
+      FORBIDDEN,
+      FORBIDDEN,
+      FORBIDDEN
+    );
+    const simd8<uint8_t> byte_2_high = input.shr<4>().lookup_16<uint8_t>(
+      // ________ 0_______ <ASCII in byte 2>
+      TOO_SHORT, TOO_SHORT, TOO_SHORT, TOO_SHORT,
+      TOO_SHORT, TOO_SHORT, TOO_SHORT, TOO_SHORT,
+
+      // ________ 1000____
+      TOO_LONG | OVERLONG_2 | TWO_CONTS | OVERLONG_3 | TOO_LARGE_1000 | OVERLONG_4,
+      // ________ 1001____
+      TOO_LONG | OVERLONG_2 | TWO_CONTS | OVERLONG_3 | TOO_LARGE,
+      // ________ 101_____
+      TOO_LONG | OVERLONG_2 | TWO_CONTS | SURROGATE  | TOO_LARGE,
+      TOO_LONG | OVERLONG_2 | TWO_CONTS | SURROGATE  | TOO_LARGE,
+
+      // ________ 11______
+      TOO_SHORT, TOO_SHORT, TOO_SHORT, TOO_SHORT
+    );
+    return (byte_1_high & byte_1_low & byte_2_high);
+  }
+
+  struct validating_transcoder {
+    // If this is nonzero, there has been a UTF-8 error.
+    simd8<uint8_t> error;
+
+    validating_transcoder() : error(uint8_t(0)) {}
+    //
+    // Check whether the current bytes are valid UTF-8.
+    //
+    simdutf_really_inline void check_utf8_bytes(const simd8<uint8_t> input, const simd8<uint8_t> prev_input) {
+      // Flip prev1...prev3 so we can easily determine if they are 2+, 3+ or 4+ lead bytes
+      // (2, 3, 4-byte leads become large positive numbers instead of small negative numbers)
+      simd8<uint8_t> prev1 = input.prev<1>(prev_input);
+      this->error |= check_special_cases(input, prev1);
+    }
+
+
+    simdutf_really_inline size_t convert(const char* in, size_t size, char* latin1_output) {
+      size_t pos = 0;
+      char* start{latin1_output};
+      // In the worst case, we have the haswell kernel which can cause an overflow of
+      // 8 bytes when calling convert_masked_utf8_to_latin1. If you skip the last 16 bytes,
+      // and if the data is valid, then it is entirely safe because 16 UTF-8 bytes generate
+      // much more than 8 bytes. However, you cannot generally assume that you have valid
+      // UTF-8 input, so we are going to go back from the end counting 8 leading bytes,
+      // to give us a good margin.
+      size_t leading_byte = 0;
+      size_t margin = size;
+      for(; margin > 0 && leading_byte < 8; margin--) {
+        leading_byte += (int8_t(in[margin-1]) > -65); //twos complement of -65 is 1011 1111 ...
+      }
+      // If the input is long enough, then we have that margin-1 is the eight last leading byte.
+      const size_t safety_margin = size - margin + 1; // to avoid overruns!
+      while(pos + 64 + safety_margin <= size) {
+        simd8x64<int8_t> input(reinterpret_cast<const int8_t *>(in + pos));
+        if(input.is_ascii()) {
+          input.store((int8_t*)latin1_output);
+          latin1_output += 64;
+          pos += 64;
+        } else {
+          // you might think that a for-loop would work, but under Visual Studio, it is not good enough.
+          static_assert((simd8x64<uint8_t>::NUM_CHUNKS == 2) || (simd8x64<uint8_t>::NUM_CHUNKS == 4),
+              "We support either two or four chunks per 64-byte block.");
+          auto zero = simd8<uint8_t>{uint8_t(0)};
+          if(simd8x64<uint8_t>::NUM_CHUNKS == 2) {
+            this->check_utf8_bytes(input.chunks[0], zero);
+            this->check_utf8_bytes(input.chunks[1], input.chunks[0]);
+          } else if(simd8x64<uint8_t>::NUM_CHUNKS == 4) {
+            this->check_utf8_bytes(input.chunks[0], zero);
+            this->check_utf8_bytes(input.chunks[1], input.chunks[0]);
+            this->check_utf8_bytes(input.chunks[2], input.chunks[1]);
+            this->check_utf8_bytes(input.chunks[3], input.chunks[2]);
+          }
+          uint64_t utf8_continuation_mask = input.lt(-65 + 1); // -64 is 1100 0000 in twos complement. Note: in this case, we also have ASCII to account for.
+          uint64_t utf8_leading_mask = ~utf8_continuation_mask;
+          uint64_t utf8_end_of_code_point_mask = utf8_leading_mask>>1;
+          // We process in blocks of up to 12 bytes except possibly
+          // for fast paths which may process up to 16 bytes. For the
+          // slow path to work, we should have at least 12 input bytes left.
+          size_t max_starting_point = (pos + 64) - 12;
+          // Next loop is going to run at least five times.
+          while(pos < max_starting_point) {
+            // Performance note: our ability to compute 'consumed' and
+            // then shift and recompute is critical. If there is a
+            // latency of, say, 4 cycles on getting 'consumed', then
+            // the inner loop might have a total latency of about 6 cycles.
+            // Yet we process between 6 to 12 inputs bytes, thus we get
+            // a speed limit between 1 cycle/byte and 0.5 cycle/byte
+            // for this section of the code. Hence, there is a limit
+            // to how much we can further increase this latency before
+            // it seriously harms performance.
+            size_t consumed = convert_masked_utf8_to_latin1(in + pos,
+                            utf8_end_of_code_point_mask, latin1_output);
+            pos += consumed;
+            utf8_end_of_code_point_mask >>= consumed;
+          }
+          // At this point there may remain between 0 and 12 bytes in the
+          // 64-byte block. These bytes will be processed again. So we have an
+          // 80% efficiency (in the worst case). In practice we expect an
+          // 85% to 90% efficiency.
+        }
+      }
+      if(errors()) { return 0; }
+      if(pos < size) {
+        size_t howmany  = scalar::utf8_to_latin1::convert(in + pos, size - pos, latin1_output);
+        if(howmany == 0) { return 0; }
+        latin1_output += howmany;
+      }
+      return latin1_output - start;
+    }
+
+    simdutf_really_inline result convert_with_errors(const char* in, size_t size, char* latin1_output) {
+      size_t pos = 0;
+      char* start{latin1_output};
+      // In the worst case, we have the haswell kernel which can cause an overflow of
+      // 8 bytes when calling convert_masked_utf8_to_latin1. If you skip the last 16 bytes,
+      // and if the data is valid, then it is entirely safe because 16 UTF-8 bytes generate
+      // much more than 8 bytes. However, you cannot generally assume that you have valid
+      // UTF-8 input, so we are going to go back from the end counting 8 leading bytes,
+      // to give us a good margin.
+      size_t leading_byte = 0;
+      size_t margin = size;
+      for(; margin > 0 && leading_byte < 8; margin--) {
+        leading_byte += (int8_t(in[margin-1]) > -65);
+      }
+      // If the input is long enough, then we have that margin-1 is the eight last leading byte.
+      const size_t safety_margin = size - margin + 1; // to avoid overruns!
+      while(pos + 64 + safety_margin <= size) {
+        simd8x64<int8_t> input(reinterpret_cast<const int8_t *>(in + pos));
+        if(input.is_ascii()) {
+          input.store((int8_t*)latin1_output);
+          latin1_output += 64;
+          pos += 64;
+        } else {
+          // you might think that a for-loop would work, but under Visual Studio, it is not good enough.
+          static_assert((simd8x64<uint8_t>::NUM_CHUNKS == 2) || (simd8x64<uint8_t>::NUM_CHUNKS == 4),
+              "We support either two or four chunks per 64-byte block.");
+          auto zero = simd8<uint8_t>{uint8_t(0)};
+          if(simd8x64<uint8_t>::NUM_CHUNKS == 2) {
+            this->check_utf8_bytes(input.chunks[0], zero);
+            this->check_utf8_bytes(input.chunks[1], input.chunks[0]);
+          } else if(simd8x64<uint8_t>::NUM_CHUNKS == 4) {
+            this->check_utf8_bytes(input.chunks[0], zero);
+            this->check_utf8_bytes(input.chunks[1], input.chunks[0]);
+            this->check_utf8_bytes(input.chunks[2], input.chunks[1]);
+            this->check_utf8_bytes(input.chunks[3], input.chunks[2]);
+          }
+          if (errors()) {
+            // rewind_and_convert_with_errors will seek a potential error from in+pos onward,
+            // with the ability to go back up to pos bytes, and read size-pos bytes forward.
+            result res = scalar::utf8_to_latin1::rewind_and_convert_with_errors(pos, in + pos, size - pos, latin1_output);
+            res.count += pos;
+            return res;
+          }
+          uint64_t utf8_continuation_mask = input.lt(-65 + 1);
+          uint64_t utf8_leading_mask = ~utf8_continuation_mask;
+          uint64_t utf8_end_of_code_point_mask = utf8_leading_mask>>1;
+          // We process in blocks of up to 12 bytes except possibly
+          // for fast paths which may process up to 16 bytes. For the
+          // slow path to work, we should have at least 12 input bytes left.
+          size_t max_starting_point = (pos + 64) - 12;
+          // Next loop is going to run at least five times.
+          while(pos < max_starting_point) {
+            // Performance note: our ability to compute 'consumed' and
+            // then shift and recompute is critical. If there is a
+            // latency of, say, 4 cycles on getting 'consumed', then
+            // the inner loop might have a total latency of about 6 cycles.
+            // Yet we process between 6 to 12 inputs bytes, thus we get
+            // a speed limit between 1 cycle/byte and 0.5 cycle/byte
+            // for this section of the code. Hence, there is a limit
+            // to how much we can further increase this latency before
+            // it seriously harms performance.
+            size_t consumed = convert_masked_utf8_to_latin1(in + pos,
+                            utf8_end_of_code_point_mask, latin1_output);
+            pos += consumed;
+            utf8_end_of_code_point_mask >>= consumed;
+          }
+          // At this point there may remain between 0 and 12 bytes in the
+          // 64-byte block. These bytes will be processed again. So we have an
+          // 80% efficiency (in the worst case). In practice we expect an
+          // 85% to 90% efficiency.
+        }
+      }
+      if(errors()) {
+        // rewind_and_convert_with_errors will seek a potential error from in+pos onward,
+        // with the ability to go back up to pos bytes, and read size-pos bytes forward.
+        result res = scalar::utf8_to_latin1::rewind_and_convert_with_errors(pos, in + pos, size - pos, latin1_output);
+        res.count += pos;
+        return res;
+      }
+      if(pos < size) {
+        // rewind_and_convert_with_errors will seek a potential error from in+pos onward,
+        // with the ability to go back up to pos bytes, and read size-pos bytes forward.
+        result res = scalar::utf8_to_latin1::rewind_and_convert_with_errors(pos, in + pos, size - pos, latin1_output);
+        if (res.error) {    // In case of error, we want the error position
+          res.count += pos;
+          return res;
+        } else {    // In case of success, we want the number of word written
+          latin1_output += res.count;
+        }
+      }
+      return result(error_code::SUCCESS, latin1_output - start);
+    }
+
+    simdutf_really_inline bool errors() const {
+      return this->error.any_bits_set_anywhere();
+    }
+
+  }; // struct utf8_checker
+} // utf8_to_latin1 namespace
+} // unnamed namespace
+} // namespace SIMDUTF_IMPLEMENTATION
+} // namespace simdutf

--- a/src/generic/utf8_to_latin1/valid_utf8_to_latin1.h
+++ b/src/generic/utf8_to_latin1/valid_utf8_to_latin1.h
@@ -31,7 +31,7 @@ using namespace simd;
           latin1_output += 64;
           pos += 64;
         } else {
-/*           // you might think that a for-loop would work, but under Visual Studio, it is not good enough. */
+          // you might think that a for-loop would work, but under Visual Studio, it is not good enough.
           uint64_t utf8_continuation_mask = input.lt(-65 + 1); // -64 is 1100 0000 in twos complement. Note: in this case, we also have ASCII to account for.
           uint64_t utf8_leading_mask = ~utf8_continuation_mask;
           uint64_t utf8_end_of_code_point_mask = utf8_leading_mask>>1;

--- a/src/generic/utf8_to_latin1/valid_utf8_to_latin1.h
+++ b/src/generic/utf8_to_latin1/valid_utf8_to_latin1.h
@@ -1,0 +1,76 @@
+#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
+
+
+namespace simdutf {
+namespace SIMDUTF_IMPLEMENTATION {
+namespace {
+namespace utf8_to_latin1 {
+using namespace simd;
+
+
+    simdutf_really_inline size_t convert_valid(const char* in, size_t size, char* latin1_output) {
+      size_t pos = 0;
+      char* start{latin1_output};
+      // In the worst case, we have the haswell kernel which can cause an overflow of
+      // 8 bytes when calling convert_masked_utf8_to_latin1. If you skip the last 16 bytes,
+      // and if the data is valid, then it is entirely safe because 16 UTF-8 bytes generate
+      // much more than 8 bytes. However, you cannot generally assume that you have valid
+      // UTF-8 input, so we are going to go back from the end counting 8 leading bytes,
+      // to give us a good margin.
+      size_t leading_byte = 0;
+      size_t margin = size;
+      for(; margin > 0 && leading_byte < 8; margin--) {
+        leading_byte += (int8_t(in[margin-1]) > -65); //twos complement of -65 is 1011 1111 ...
+      }
+      // If the input is long enough, then we have that margin-1 is the eight last leading byte.
+      const size_t safety_margin = size - margin + 1; // to avoid overruns!
+      while(pos + 64 + safety_margin <= size) {
+        simd8x64<int8_t> input(reinterpret_cast<const int8_t *>(in + pos));
+        if(input.is_ascii()) {
+          input.store((int8_t*)latin1_output);
+          latin1_output += 64;
+          pos += 64;
+        } else {
+/*           // you might think that a for-loop would work, but under Visual Studio, it is not good enough. */
+          uint64_t utf8_continuation_mask = input.lt(-65 + 1); // -64 is 1100 0000 in twos complement. Note: in this case, we also have ASCII to account for.
+          uint64_t utf8_leading_mask = ~utf8_continuation_mask;
+          uint64_t utf8_end_of_code_point_mask = utf8_leading_mask>>1;
+          // We process in blocks of up to 12 bytes except possibly
+          // for fast paths which may process up to 16 bytes. For the
+          // slow path to work, we should have at least 12 input bytes left.
+          size_t max_starting_point = (pos + 64) - 12;
+          // Next loop is going to run at least five times.
+          while(pos < max_starting_point) {
+            // Performance note: our ability to compute 'consumed' and
+            // then shift and recompute is critical. If there is a
+            // latency of, say, 4 cycles on getting 'consumed', then
+            // the inner loop might have a total latency of about 6 cycles.
+            // Yet we process between 6 to 12 inputs bytes, thus we get
+            // a speed limit between 1 cycle/byte and 0.5 cycle/byte
+            // for this section of the code. Hence, there is a limit
+            // to how much we can further increase this latency before
+            // it seriously harms performance.
+            size_t consumed = convert_masked_utf8_to_latin1(in + pos,
+                            utf8_end_of_code_point_mask, latin1_output);
+            pos += consumed;
+            utf8_end_of_code_point_mask >>= consumed;
+          }
+          // At this point there may remain between 0 and 12 bytes in the
+          // 64-byte block. These bytes will be processed again. So we have an
+          // 80% efficiency (in the worst case). In practice we expect an
+          // 85% to 90% efficiency.
+        }
+      }
+      if(pos < size) {
+        size_t howmany  = scalar::utf8_to_latin1::convert(in + pos, size - pos, latin1_output);
+        if(howmany == 0) { return 0; }
+        latin1_output += howmany;
+      }
+      return latin1_output - start;
+    }
+
+  }; 
+}   // utf8_to_latin1 namespace
+}   // unnamed namespace
+}   // namespace SIMDUTF_IMPLEMENTATION
+ // namespace simdutf

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -529,9 +529,8 @@ simdutf_warn_unused size_t implementation::count_utf8(const char * input, size_t
   return utf8::count_code_points(input, length);
 }
 
-
 simdutf_warn_unused size_t implementation::latin1_length_from_utf8(const char* buf, size_t len) const noexcept {
-  return scalar::utf8::latin1_length_from_utf8(buf,len);
+  return count_utf8(buf,len);
 }
 
 simdutf_warn_unused size_t implementation::latin1_length_from_utf16(size_t length) const noexcept {
@@ -655,7 +654,7 @@ simdutf_warn_unused size_t implementation::utf16_length_from_utf32(const char32_
 }
 
 simdutf_warn_unused size_t implementation::utf32_length_from_utf8(const char * input, size_t length) const noexcept {
-  return scalar::utf8::count_code_points(input, length);
+  return utf8::count_code_points(input, length);
 }
 
 } // namespace SIMDUTF_IMPLEMENTATION

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -537,7 +537,7 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf16(size_t lengt
   return scalar::utf16::latin1_length_from_utf16(length);
 }
 
-simdutf_warn_unused size_t implementation::latin1_length_from_utf32( size_t length) const noexcept {
+simdutf_warn_unused size_t implementation::latin1_length_from_utf32(size_t length) const noexcept {
   return scalar::utf32::latin1_length_from_utf32(length);
 }
 

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -1125,7 +1125,7 @@ simdutf_warn_unused size_t implementation::count_utf8(const char * input, size_t
 }
 
 simdutf_warn_unused size_t implementation::latin1_length_from_utf8(const char* buf, size_t len) const noexcept {
-  return scalar::utf8::latin1_length_from_utf8(buf,len);
+  return count_utf8(buf,len);
 }
 
 simdutf_warn_unused size_t implementation::latin1_length_from_utf16(size_t length) const noexcept {

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -1132,7 +1132,7 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf16(size_t lengt
   return scalar::utf16::latin1_length_from_utf16(length);
 }
 
-simdutf_warn_unused size_t implementation::latin1_length_from_utf32( size_t length) const noexcept {
+simdutf_warn_unused size_t implementation::latin1_length_from_utf32(size_t length) const noexcept {
   return scalar::utf32::latin1_length_from_utf32(length);
 }
 

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -219,11 +219,11 @@ public:
     return set_best()->convert_valid_utf8_to_utf32(buf, len, utf32_output);
   }
 
-   simdutf_warn_unused size_t convert_utf16le_to_latin1(const char16_t * buf, size_t len, char* latin1_output) const noexcept final override {
+  simdutf_warn_unused size_t convert_utf16le_to_latin1(const char16_t * buf, size_t len, char* latin1_output) const noexcept final override {
     return set_best()->convert_utf16le_to_latin1(buf, len, latin1_output);
   }
 
-     simdutf_warn_unused size_t convert_utf16be_to_latin1(const char16_t * buf, size_t len, char* latin1_output) const noexcept final override {
+  simdutf_warn_unused size_t convert_utf16be_to_latin1(const char16_t * buf, size_t len, char* latin1_output) const noexcept final override {
     return set_best()->convert_utf16be_to_latin1(buf, len, latin1_output);
   }
 
@@ -830,6 +830,27 @@ simdutf_warn_unused size_t convert_utf8_to_utf16(const char * input, size_t leng
   return convert_utf8_to_utf16le(input, length, utf16_output);
   #endif
 }
+simdutf_warn_unused size_t convert_latin1_to_utf8(const char * buf, size_t len, char* utf8_output) noexcept {
+  return get_active_implementation()->convert_latin1_to_utf8(buf, len,utf8_output);
+}
+simdutf_warn_unused size_t convert_latin1_to_utf16le(const char * buf, size_t len, char16_t* utf16_output) noexcept {
+  return get_active_implementation()->convert_latin1_to_utf16le(buf, len, utf16_output);
+}
+simdutf_warn_unused size_t convert_latin1_to_utf16be(const char * buf, size_t len, char16_t* utf16_output) noexcept{
+  return get_active_implementation()->convert_latin1_to_utf16be(buf, len, utf16_output);
+}
+simdutf_warn_unused size_t convert_latin1_to_utf32(const char * buf, size_t len, char32_t * latin1_output) noexcept {
+  return get_active_implementation()->convert_latin1_to_utf32(buf, len,latin1_output);
+}
+simdutf_warn_unused size_t convert_utf8_to_latin1(const char * buf, size_t len, char* latin1_output) noexcept {
+  return get_active_implementation()->convert_utf8_to_latin1(buf, len,latin1_output);
+}
+simdutf_warn_unused result convert_utf8_to_latin1_with_errors(const char* buf, size_t len, char* latin1_output) noexcept {
+  return get_active_implementation()->convert_utf8_to_latin1_with_errors(buf, len, latin1_output);
+}
+simdutf_warn_unused size_t convert_valid_utf8_to_latin1(const char * buf, size_t len, char* latin1_output) noexcept {
+  return get_active_implementation()->convert_valid_utf8_to_latin1(buf, len,latin1_output);
+}
 simdutf_warn_unused size_t convert_utf8_to_utf16le(const char * input, size_t length, char16_t* utf16_output) noexcept {
   return get_active_implementation()->convert_utf8_to_utf16le(input, length, utf16_output);
 }
@@ -848,12 +869,6 @@ simdutf_warn_unused result convert_utf8_to_utf16le_with_errors(const char * inpu
 }
 simdutf_warn_unused result convert_utf8_to_utf16be_with_errors(const char * input, size_t length, char16_t* utf16_output) noexcept {
   return get_active_implementation()->convert_utf8_to_utf16be_with_errors(input, length, utf16_output);
-}
-simdutf_warn_unused size_t convert_latin1_to_utf16le(const char * input, size_t length, char16_t* utf16_output) noexcept {
-  return get_active_implementation()->convert_latin1_to_utf16le(input, length, utf16_output);
-}
-simdutf_warn_unused size_t convert_latin1_to_utf16be(const char * input, size_t length, char16_t* utf16_output) noexcept {
-  return get_active_implementation()->convert_latin1_to_utf16be(input, length, utf16_output);
 }
 simdutf_warn_unused size_t convert_utf8_to_utf32(const char * input, size_t length, char32_t* utf32_output) noexcept {
   return get_active_implementation()->convert_utf8_to_utf32(input, length, utf32_output);
@@ -1069,6 +1084,19 @@ simdutf_warn_unused size_t count_utf16be(const char16_t * input, size_t length) 
 simdutf_warn_unused size_t count_utf8(const char * input, size_t length) noexcept {
   return get_active_implementation()->count_utf8(input, length);
 }
+simdutf_warn_unused size_t latin1_length_from_utf8(const char * buf, size_t len) noexcept {
+  return get_active_implementation()->latin1_length_from_utf8(buf, len);
+}
+simdutf_warn_unused size_t latin1_length_from_utf16(size_t len) noexcept {
+  return get_active_implementation()->latin1_length_from_utf16(len);
+}
+simdutf_warn_unused size_t latin1_length_from_utf32(size_t len) noexcept {
+  return get_active_implementation()->latin1_length_from_utf32(len);
+}
+simdutf_warn_unused size_t utf8_length_from_latin1(const char * buf, size_t len) noexcept {
+  return get_active_implementation()->utf8_length_from_latin1(buf, len);
+}
+
 simdutf_warn_unused size_t utf8_length_from_utf16(const char16_t * input, size_t length) noexcept {
   #if SIMDUTF_IS_BIG_ENDIAN
   return utf8_length_from_utf16be(input, length);

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -699,7 +699,7 @@ public:
     return 0;
   }
 
-  simdutf_warn_unused size_t latin1_length_from_utf16( size_t) const noexcept override {
+  simdutf_warn_unused size_t latin1_length_from_utf16(size_t) const noexcept override {
     return 0;
   }
 

--- a/src/scalar/utf8.h
+++ b/src/scalar/utf8.h
@@ -190,7 +190,7 @@ inline size_t latin1_length_from_utf8(const char *buf, size_t len) {
 
     size_t answer = len;
     for(size_t i = 0; i < len; i++) {
-        if((c[i] & 0b11100000) == 0b11000000) { answer--;} //if we have a two-byte UTF8 character
+        if((c[i] & 0b11100000) == 0b11000000) { answer--; } // if we have a two-byte UTF8 character
     }
     return answer;
 }

--- a/src/scalar/utf8_to_latin1/utf8_to_latin1.h
+++ b/src/scalar/utf8_to_latin1/utf8_to_latin1.h
@@ -39,7 +39,8 @@ inline size_t convert(const char* buf, size_t len, char* latin_output) {
     } else if ((leading_byte & 0b11100000) == 0b11000000) { // the first three bits indicate:
       // We have a two-byte UTF-8
       if(pos + 1 >= len) {
-         return 0; } // minimal bound checking
+        return 0;
+      } // minimal bound checking
       if ((data[pos + 1] & 0b11000000) != 0b10000000) { return 0; } // checks if the next byte is a valid continuation byte in UTF-8. A valid continuation byte starts with 10.
       // range check -
       uint32_t code_point = (leading_byte & 0b00011111) << 6 | (data[pos + 1] & 0b00111111); // assembles the Unicode code point from the two bytes. It does this by discarding the leading 110 and 10 bits from the two bytes, shifting the remaining bits of the first byte, and then combining the results with a bitwise OR operation.
@@ -92,10 +93,11 @@ inline result convert_with_errors(const char* buf, size_t len, char* latin_outpu
       // range check -
       uint32_t code_point = (leading_byte & 0b00011111) << 6 | (data[pos + 1] & 0b00111111); // assembles the Unicode code point from the two bytes. It does this by discarding the leading 110 and 10 bits from the two bytes, shifting the remaining bits of the first byte, and then combining the results with a bitwise OR operation.
       if (code_point < 0x80) {
-        return result(error_code::OVERLONG, pos); }
-      if ( 0xFF < code_point) {
-          return result(error_code::TOO_LARGE, pos);
-          } // We only care about the range 129-255 which is Non-ASCII latin1 characters
+        return result(error_code::OVERLONG, pos);
+      }
+      if (0xFF < code_point) {
+        return result(error_code::TOO_LARGE, pos);
+      } // We only care about the range 129-255 which is Non-ASCII latin1 characters
       *latin_output++ = char(code_point);
       pos += 2;
     } else if ((leading_byte & 0b11110000) == 0b11100000) {
@@ -107,7 +109,8 @@ inline result convert_with_errors(const char* buf, size_t len, char* latin_outpu
     } else {
       // we either have too many continuation bytes or an invalid leading byte
       if ((leading_byte & 0b11000000) == 0b10000000) {
-                return result(error_code::TOO_LONG, pos); }
+        return result(error_code::TOO_LONG, pos);
+      }
 
       return result(error_code::HEADER_BITS, pos);
 

--- a/src/simdutf/arm64/implementation.h
+++ b/src/simdutf/arm64/implementation.h
@@ -85,7 +85,7 @@ public:
   simdutf_warn_unused size_t utf32_length_from_utf8(const char * input, size_t length) const noexcept;
   simdutf_warn_unused size_t latin1_length_from_utf8(const char * input, size_t length) const noexcept;
   simdutf_warn_unused size_t latin1_length_from_utf16(size_t length) const noexcept;
-  simdutf_warn_unused size_t latin1_length_from_utf32( size_t length) const noexcept;
+  simdutf_warn_unused size_t latin1_length_from_utf32(size_t length) const noexcept;
   simdutf_warn_unused size_t utf32_length_from_latin1(size_t length) const noexcept;
   simdutf_warn_unused size_t utf16_length_from_latin1(size_t length) const noexcept;
   simdutf_warn_unused size_t utf8_length_from_latin1(const char * input, size_t length) const noexcept;

--- a/src/simdutf/fallback/implementation.h
+++ b/src/simdutf/fallback/implementation.h
@@ -88,7 +88,7 @@ public:
   simdutf_warn_unused size_t utf32_length_from_utf8(const char * input, size_t length) const noexcept;
   simdutf_warn_unused size_t latin1_length_from_utf8(const char * input, size_t length) const noexcept;
   simdutf_warn_unused size_t latin1_length_from_utf16(size_t length) const noexcept;
-  simdutf_warn_unused size_t latin1_length_from_utf32( size_t length) const noexcept;
+  simdutf_warn_unused size_t latin1_length_from_utf32(size_t length) const noexcept;
   simdutf_warn_unused size_t utf32_length_from_latin1(size_t length) const noexcept;
   simdutf_warn_unused size_t utf16_length_from_latin1(size_t length) const noexcept;
   simdutf_warn_unused size_t utf8_length_from_latin1(const char * input, size_t length) const noexcept;};

--- a/src/simdutf/haswell/implementation.h
+++ b/src/simdutf/haswell/implementation.h
@@ -87,7 +87,7 @@ public:
   simdutf_warn_unused size_t utf32_length_from_utf8(const char * input, size_t length) const noexcept;
   simdutf_warn_unused size_t latin1_length_from_utf8(const char * input, size_t length) const noexcept;
   simdutf_warn_unused size_t latin1_length_from_utf16(size_t length) const noexcept;
-  simdutf_warn_unused size_t latin1_length_from_utf32( size_t length) const noexcept;
+  simdutf_warn_unused size_t latin1_length_from_utf32(size_t length) const noexcept;
   simdutf_warn_unused size_t utf32_length_from_latin1(size_t length) const noexcept;
   simdutf_warn_unused size_t utf16_length_from_latin1(size_t length) const noexcept;
   simdutf_warn_unused size_t utf8_length_from_latin1(const char * input, size_t length) const noexcept;

--- a/src/simdutf/icelake/implementation.h
+++ b/src/simdutf/icelake/implementation.h
@@ -87,7 +87,7 @@ public:
   simdutf_warn_unused size_t utf32_length_from_utf8(const char * input, size_t length) const noexcept;
   simdutf_warn_unused size_t latin1_length_from_utf8(const char * input, size_t length) const noexcept;
   simdutf_warn_unused size_t latin1_length_from_utf16(size_t length) const noexcept;
-  simdutf_warn_unused size_t latin1_length_from_utf32( size_t length) const noexcept;
+  simdutf_warn_unused size_t latin1_length_from_utf32(size_t length) const noexcept;
   simdutf_warn_unused size_t utf32_length_from_latin1(size_t length) const noexcept;
   simdutf_warn_unused size_t utf16_length_from_latin1(size_t length) const noexcept;
   simdutf_warn_unused size_t utf8_length_from_latin1(const char * input, size_t length) const noexcept;

--- a/src/simdutf/westmere/implementation.h
+++ b/src/simdutf/westmere/implementation.h
@@ -85,7 +85,7 @@ public:
   simdutf_warn_unused size_t utf32_length_from_utf8(const char * input, size_t length) const noexcept;
   simdutf_warn_unused size_t latin1_length_from_utf8(const char * input, size_t length) const noexcept;
   simdutf_warn_unused size_t latin1_length_from_utf16(size_t length) const noexcept;
-  simdutf_warn_unused size_t latin1_length_from_utf32( size_t length) const noexcept;
+  simdutf_warn_unused size_t latin1_length_from_utf32(size_t length) const noexcept;
   simdutf_warn_unused size_t utf32_length_from_latin1(size_t length) const noexcept;
   simdutf_warn_unused size_t utf16_length_from_latin1(size_t length) const noexcept;
   simdutf_warn_unused size_t utf8_length_from_latin1(const char * input, size_t length) const noexcept;

--- a/src/simdutf/westmere/simd.h
+++ b/src/simdutf/westmere/simd.h
@@ -344,10 +344,10 @@ namespace simd {
     }
 
     simdutf_really_inline uint64_t to_bitmask() const {
-      uint64_t r0 = uint32_t(this->chunks[0].to_bitmask() );
-      uint64_t r1 =          this->chunks[1].to_bitmask() ;
-      uint64_t r2 =          this->chunks[2].to_bitmask() ;
-      uint64_t r3 =          this->chunks[3].to_bitmask() ;
+      uint64_t r0 = uint32_t(this->chunks[0].to_bitmask());
+      uint64_t r1 =          this->chunks[1].to_bitmask();
+      uint64_t r2 =          this->chunks[2].to_bitmask();
+      uint64_t r3 =          this->chunks[3].to_bitmask();
       return r0 | (r1 << 16) | (r2 << 32) | (r3 << 48);
     }
 

--- a/src/simdutf/westmere/simd16-inl.h
+++ b/src/simdutf/westmere/simd16-inl.h
@@ -189,10 +189,10 @@ template<typename T>
     }
 
     simdutf_really_inline uint64_t to_bitmask() const {
-      uint64_t r0 = uint32_t(this->chunks[0].to_bitmask() );
-      uint64_t r1 =          this->chunks[1].to_bitmask() ;
-      uint64_t r2 =          this->chunks[2].to_bitmask() ;
-      uint64_t r3 =          this->chunks[3].to_bitmask() ;
+      uint64_t r0 = uint32_t(this->chunks[0].to_bitmask());
+      uint64_t r1 =          this->chunks[1].to_bitmask();
+      uint64_t r2 =          this->chunks[2].to_bitmask();
+      uint64_t r3 =          this->chunks[3].to_bitmask();
       return r0 | (r1 << 16) | (r2 << 32) | (r3 << 48);
     }
 

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -199,7 +199,6 @@ simdutf_warn_unused result implementation::convert_utf8_to_latin1_with_errors(co
 
 simdutf_warn_unused size_t implementation::convert_valid_utf8_to_latin1(const char* buf, size_t len, char* latin1_output) const noexcept {
   return westmere::utf8_to_latin1::convert_valid(buf,len,latin1_output);
-  //return scalar::utf8_to_latin1::convert_valid(buf, len, latin1_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_utf8_to_utf16le(const char* buf, size_t len, char16_t* utf16_output) const noexcept {
@@ -543,7 +542,7 @@ simdutf_warn_unused size_t implementation::count_utf8(const char * input, size_t
 }
 
 simdutf_warn_unused size_t implementation::latin1_length_from_utf8(const char* buf, size_t len) const noexcept {
-  return scalar::utf8::latin1_length_from_utf8(buf,len);
+  return count_utf8(buf,len);
 }
 
 simdutf_warn_unused size_t implementation::latin1_length_from_utf16(size_t length) const noexcept {
@@ -671,7 +670,7 @@ simdutf_warn_unused size_t implementation::utf16_length_from_utf32(const char32_
 }
 
 simdutf_warn_unused size_t implementation::utf32_length_from_utf8(const char * input, size_t length) const noexcept {
-  return scalar::utf8::count_code_points(input, length);
+  return utf8::count_code_points(input, length);
 }
 
 } // namespace SIMDUTF_IMPLEMENTATION

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -36,6 +36,7 @@ simdutf_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> 
 
 #include "westmere/sse_convert_utf8_to_utf16.cpp"
 #include "westmere/sse_convert_utf8_to_utf32.cpp"
+#include "westmere/sse_convert_utf8_to_latin1.cpp"
 
 #include "westmere/sse_convert_utf16_to_utf8.cpp"
 #include "westmere/sse_convert_utf16_to_utf32.cpp"
@@ -59,6 +60,11 @@ simdutf_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> 
 // other functions
 #include "generic/utf8.h"
 #include "generic/utf16.h"
+// transcoding from UTF-8 to Latin 1
+#include "generic/utf8_to_latin1/utf8_to_latin1.h"
+#include "generic/utf8_to_latin1/valid_utf8_to_latin1.h"
+
+
 //
 // Implementation-specific overrides
 //
@@ -182,15 +188,18 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf32(const char* b
 
 
 simdutf_warn_unused size_t implementation::convert_utf8_to_latin1(const char* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf8_to_latin1::convert(buf, len, latin1_output);
+  utf8_to_latin1::validating_transcoder converter;
+  return converter.convert(buf, len, latin1_output);
 }
 
 simdutf_warn_unused result implementation::convert_utf8_to_latin1_with_errors(const char* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf8_to_latin1::convert_with_errors(buf, len, latin1_output);
+  utf8_to_latin1::validating_transcoder converter;
+  return converter.convert_with_errors(buf, len, latin1_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf8_to_latin1(const char* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf8_to_latin1::convert_valid(buf, len, latin1_output);
+  return westmere::utf8_to_latin1::convert_valid(buf,len,latin1_output);
+  //return scalar::utf8_to_latin1::convert_valid(buf, len, latin1_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_utf8_to_utf16le(const char* buf, size_t len, char16_t* utf16_output) const noexcept {

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -549,7 +549,7 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf16(size_t lengt
   return scalar::utf16::latin1_length_from_utf16(length);
 }
 
-simdutf_warn_unused size_t implementation::latin1_length_from_utf32( size_t length) const noexcept {
+simdutf_warn_unused size_t implementation::latin1_length_from_utf32(size_t length) const noexcept {
   return scalar::utf32::latin1_length_from_utf32(length);
 }
 

--- a/src/westmere/sse_convert_utf8_to_latin1.cpp
+++ b/src/westmere/sse_convert_utf8_to_latin1.cpp
@@ -1,0 +1,54 @@
+// depends on "tables/utf8_to_utf16_tables.h"
+
+
+// Convert up to 12 bytes from utf8 to latin1 using a mask indicating the
+// end of the code points. Only the least significant 12 bits of the mask
+// are accessed.
+// It returns how many bytes were consumed (up to 12).
+size_t convert_masked_utf8_to_latin1(const char *input,
+                           uint64_t utf8_end_of_code_point_mask,
+                           char *&latin1_output) {
+  // we use an approach where we try to process up to 12 input bytes.
+  // Why 12 input bytes and not 16? Because we are concerned with the size of
+  // the lookup tables. Also 12 is nicely divisible by two and three.
+  //
+  //
+  // Optimization note: our main path below is load-latency dependent. Thus it is maybe
+  // beneficial to have fast paths that depend on branch prediction but have less latency.
+  // This results in more instructions but, potentially, also higher speeds.
+  //
+  const __m128i in = _mm_loadu_si128((__m128i *)input);
+  const uint16_t input_utf8_end_of_code_point_mask =
+      utf8_end_of_code_point_mask & 0xfff; //we're only processing 12 bytes in case it`s not all ASCII
+  if(((utf8_end_of_code_point_mask & 0xffff) == 0xffff)) {
+    // We process the data in chunks of 16 bytes.
+    _mm_storeu_si128(reinterpret_cast<__m128i *>(latin1_output), in);
+    latin1_output += 16; // We wrote 16 characters.
+    return 16; // We consumed 16 bytes.
+  }
+  /// We do not have a fast path available, so we fallback.
+  const uint8_t idx =
+      tables::utf8_to_utf16::utf8bigindex[input_utf8_end_of_code_point_mask][0];
+  const uint8_t consumed =
+      tables::utf8_to_utf16::utf8bigindex[input_utf8_end_of_code_point_mask][1];
+  // this indicates an invalid input:
+  if(idx >= 64) { return consumed; }
+  // Here we should have (idx < 64), if not, there is a bug in the validation or elsewhere.
+  // SIX (6) input code-words
+  // this is a relatively easy scenario
+  // we process SIX (6) input code-words. The max length in bytes of six code
+  // words spanning between 1 and 2 bytes each is 12 bytes. On processors
+  // where pdep/pext is fast, we might be able to use a small lookup table.
+  const __m128i sh =
+        _mm_loadu_si128((const __m128i *)tables::utf8_to_utf16::shufutf8[idx]);
+  const __m128i perm = _mm_shuffle_epi8(in, sh);
+  const __m128i ascii = _mm_and_si128(perm, _mm_set1_epi16(0x7f));
+  const __m128i highbyte = _mm_and_si128(perm, _mm_set1_epi16(0x1f00));
+  __m128i composed = _mm_or_si128(ascii, _mm_srli_epi16(highbyte, 2));
+  const __m128i latin1_packed = _mm_packus_epi16(composed,composed);
+  // writing 8 bytes even though we only care about the first 6 bytes.
+  // performance note: it would be faster to use _mm_storeu_si128, we should investigate.
+  _mm_storel_epi64((__m128i *)latin1_output, latin1_packed);
+  latin1_output += 6; // We wrote 6 bytes.
+  return consumed;
+}

--- a/tests/convert_utf8_to_latin1_tests.cpp
+++ b/tests/convert_utf8_to_latin1_tests.cpp
@@ -35,7 +35,7 @@ TEST(convert_random_inputs) {
       std::vector<char> latin1(buffer_size);
       size_t actual_size = implementation.convert_utf8_to_latin1(utf8.data(), size, latin1.data());
       if(simdutf::tests::reference::validate_utf8_to_latin1(utf8.data(), size)) {
-          ASSERT_EQUAL(actual_size,buffer_size) ;
+        ASSERT_EQUAL(actual_size,buffer_size);
       } else {
         ASSERT_EQUAL(actual_size,0);
       }

--- a/tests/random_fuzzer.cpp
+++ b/tests/random_fuzzer.cpp
@@ -8,7 +8,18 @@
 
 #include "simdutf.h"
 
-std::vector<char> input;
+std::string input;
+
+// useful for debugging
+static void print_input(const std::string& s, const simdutf::implementation *const e) {
+  printf("We are about to abort on the following input: ");
+  for (auto c : s) {
+    printf("%02x ", (unsigned char)c);
+  }
+  printf("\n");
+  std::cout << "string length : " << s.size() << " bytes" << std::endl;
+  std::cout << "implementation->name() = " << e->name() << std::endl;
+}
 
 extern "C" {
 void dump_case() {
@@ -42,15 +53,15 @@ void __asan_on_error() { dump_case(); }
 }
 
 size_t valid_utf8 = 0;
-size_t valid_utf16 = 0;
+size_t valid_utf16le = 0;
+size_t valid_utf16be = 0;
 
 /**
  * Returns false on error.
  */
 bool fuzz_this(const char *data, size_t size) {
-  valid_utf8 += simdutf::validate_utf8(data, size);
-  valid_utf16 += simdutf::validate_utf16((const char16_t *)data, size / 2);
-
+  std::string source(data, size);
+  input = source;
   for (auto &e : simdutf::get_available_implementations()) {
     if (!e->supported_by_runtime_system()) {
       continue;
@@ -58,43 +69,104 @@ bool fuzz_this(const char *data, size_t size) {
     /**
      * Transcoding from UTF-8 to UTF-16LE.
      */
-    bool validutf8 = e->validate_utf8(data, size);
+    bool validutf8 = e->validate_utf8(source.c_str(), source.size());
+    auto rutf8 = e->validate_utf8_with_errors(source.c_str(), source.size());
+    if(validutf8 != (rutf8.error == simdutf::SUCCESS)) { // they should agree
+      print_input(source, e);
+      return false;
+    }
     if (validutf8) {
+      valid_utf8++;
       // We need a buffer of size where to write the UTF-16LE words.
-      size_t expected_utf16words = e->utf16_length_from_utf8(data, size);
+      size_t expected_utf16words =
+          e->utf16_length_from_utf8(source.c_str(), source.size());
       std::unique_ptr<char16_t[]> utf16_output{
-          new char16_t[expected_utf16words]};
+        new char16_t[expected_utf16words]
+      };
       // convert to UTF-16LE
-      size_t utf16words =
-          e->convert_utf8_to_utf16le(data, size, utf16_output.get());
+      size_t utf16words = e->convert_utf8_to_utf16le(
+          source.c_str(), source.size(), utf16_output.get());
       // It wrote utf16words * sizeof(char16_t) bytes.
       bool validutf16 = e->validate_utf16le(utf16_output.get(), utf16words);
       if (!validutf16) {
+        print_input(source, e);
         return false;
       }
       // convert it back:
       // We need a buffer of size where to write the UTF-8 words.
       size_t expected_utf8words =
           e->utf8_length_from_utf16le(utf16_output.get(), utf16words);
-      std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
+      std::unique_ptr<char[]> utf8_output{ new char[expected_utf8words] };
       // convert to UTF-8
       size_t utf8words = e->convert_utf16le_to_utf8(
           utf16_output.get(), utf16words, utf8_output.get());
-      for (size_t k = 0; k < utf8words; k++) {
-        if (data[k] != utf8_output.get()[k]) {
-          return false;
-        }
+      std::string final_string(utf8_output.get(), utf8words);
+      if (final_string != source) {
+        print_input(source, e);
+        return false;
       }
     } else {
       // invalid input!!!
       // We need a buffer of size where to write the UTF-16LE words.
-      size_t expected_utf16words = e->utf16_length_from_utf8(data, size);
+      size_t expected_utf16words =
+          e->utf16_length_from_utf8(source.c_str(), source.size());
       std::unique_ptr<char16_t[]> utf16_output{
-          new char16_t[expected_utf16words]};
+        new char16_t[expected_utf16words]
+      };
       // convert to UTF-16LE
-      size_t utf16words =
-          e->convert_utf8_to_utf16le(data, size, utf16_output.get());
+      size_t utf16words = e->convert_utf8_to_utf16le(
+          source.c_str(), source.size(), utf16_output.get());
       if (utf16words != 0) {
+        print_input(source, e);
+        return false;
+      }
+    }
+
+    /**
+     * Transcoding from UTF-8 to UTF-16BE.
+     */
+    if (validutf8) {
+      // We need a buffer of size where to write the UTF-16BE words.
+      size_t expected_utf16words =
+          e->utf16_length_from_utf8(source.c_str(), source.size());
+      std::unique_ptr<char16_t[]> utf16_output{
+        new char16_t[expected_utf16words]
+      };
+      // convert to UTF-16BE
+      size_t utf16words = e->convert_utf8_to_utf16be(
+          source.c_str(), source.size(), utf16_output.get());
+      // It wrote utf16words * sizeof(char16_t) bytes.
+      bool validutf16 = e->validate_utf16be(utf16_output.get(), utf16words);
+      if (!validutf16) {
+        print_input(source, e);
+        return false;
+      }
+      // convert it back:
+      // We need a buffer of size where to write the UTF-8 words.
+      size_t expected_utf8words =
+          e->utf8_length_from_utf16be(utf16_output.get(), utf16words);
+      std::unique_ptr<char[]> utf8_output{ new char[expected_utf8words] };
+      // convert to UTF-8
+      size_t utf8words = e->convert_utf16be_to_utf8(
+          utf16_output.get(), utf16words, utf8_output.get());
+      std::string final_string(utf8_output.get(), utf8words);
+      if (final_string != source) {
+        print_input(source, e);
+        return false;
+      }
+    } else {
+      // invalid input!!!
+      // We need a buffer of size where to write the UTF-16BE words.
+      size_t expected_utf16words =
+          e->utf16_length_from_utf8(source.c_str(), source.size());
+      std::unique_ptr<char16_t[]> utf16_output{
+        new char16_t[expected_utf16words]
+      };
+      // convert to UTF-16BE
+      size_t utf16words = e->convert_utf8_to_utf16be(
+          source.c_str(), source.size(), utf16_output.get());
+      if (utf16words != 0) {
+        print_input(source, e);
         return false;
       }
     }
@@ -103,56 +175,114 @@ bool fuzz_this(const char *data, size_t size) {
      */
     if (validutf8) {
       // We need a buffer of size where to write the UTF-32 words.
-      size_t expected_utf32words = e->utf32_length_from_utf8(data, size);
+      size_t expected_utf32words =
+          e->utf32_length_from_utf8(source.c_str(), source.size());
       std::unique_ptr<char32_t[]> utf32_output{
-          new char32_t[expected_utf32words]};
+        new char32_t[expected_utf32words]
+      };
       // convert to UTF-32
-      size_t utf32words =
-          e->convert_utf8_to_utf32(data, size, utf32_output.get());
+      size_t utf32words = e->convert_utf8_to_utf32(
+          source.c_str(), source.size(), utf32_output.get());
       // It wrote utf32words * sizeof(char32_t) bytes.
       bool validutf32 = e->validate_utf32(utf32_output.get(), utf32words);
       if (!validutf32) {
-        return false;
+        return -1;
       }
       // convert it back:
       // We need a buffer of size where to write the UTF-8 words.
       size_t expected_utf8words =
           e->utf8_length_from_utf32(utf32_output.get(), utf32words);
-      std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
+      std::unique_ptr<char[]> utf8_output{ new char[expected_utf8words] };
       // convert to UTF-8
       size_t utf8words = e->convert_utf32_to_utf8(
           utf32_output.get(), utf32words, utf8_output.get());
-      for (size_t k = 0; k < utf8words; k++) {
-        if (data[k] != utf8_output.get()[k]) {
+      std::string final_string(utf8_output.get(), utf8words);
+      if (source != final_string) {
+        print_input(source, e);
+        return false;
+      }
+    } else {
+      // invalid input!!!
+      size_t expected_utf32words =
+          e->utf32_length_from_utf8(source.c_str(), source.size());
+      std::unique_ptr<char32_t[]> utf32_output{
+        new char32_t[expected_utf32words]
+      };
+      // convert to UTF-32
+      size_t utf32words = e->convert_utf8_to_utf32(
+          source.c_str(), source.size(), utf32_output.get());
+      if (utf32words != 0) {
+        print_input(source, e);
+        return false;
+      }
+    }
+
+    /**
+     * Transcoding from UTF-8 to Latin 1
+     */
+    if (validutf8) {
+      // We need a buffer of size where to write the UTF-16LE words.
+      size_t expected_latin1words =
+          e->latin1_length_from_utf8(source.c_str(), source.size());
+      std::unique_ptr<char[]> latin1_output{
+        new char[expected_latin1words]
+      };
+      // convert to latin1
+      size_t latin1words = e->convert_utf8_to_latin1(
+          source.c_str(), source.size(), latin1_output.get());
+      if(latin1words != 0) {
+        // convert it back:
+        // We need a buffer of size where to write the UTF-8 words.
+        size_t expected_utf8words =
+            e->utf8_length_from_latin1(latin1_output.get(), latin1words);
+        std::unique_ptr<char[]> utf8_output{ new char[expected_utf8words] };
+        // convert to UTF-8
+        size_t utf8words = e->convert_latin1_to_utf8(
+            latin1_output.get(), latin1words, utf8_output.get());
+        std::string final_string(utf8_output.get(), utf8words);
+        if (final_string != source) {
+          print_input(source, e);
           return false;
         }
       }
     } else {
       // invalid input!!!
-      size_t expected_utf32words = e->utf32_length_from_utf8(data, size);
-      std::unique_ptr<char32_t[]> utf32_output{
-          new char32_t[expected_utf32words]};
-      // convert to UTF-32
-      size_t utf32words =
-          e->convert_utf8_to_utf32(data, size, utf32_output.get());
-      if (utf32words != 0) {
+      // We need a buffer of size where to write the Latin 1 words.
+      size_t expected_latin1words =
+          e->latin1_length_from_utf8(source.c_str(), source.size());
+      std::unique_ptr<char[]> latin1_output{
+        new char[expected_latin1words]
+      };
+      // convert to Latin 1
+      size_t latin1words = e->convert_utf8_to_latin1(
+          source.c_str(), source.size(), latin1_output.get());
+      if (latin1words != 0) {
+        print_input(source, e);
         return false;
       }
     }
     /**
-     * Transcoding from UTF-16 to UTF-8.
+     * Transcoding from UTF-16LE to UTF-8.
      */
-    bool validutf16 = e->validate_utf16le((char16_t *)data, size / 2);
-    if (validutf16) {
+    bool validutf16le =
+        e->validate_utf16le((char16_t *)source.c_str(), source.size() / 2);
+    auto rutf16le = e->validate_utf16le_with_errors((char16_t *)source.c_str(), source.size() / 2);
+    if(validutf16le != (rutf16le.error == simdutf::SUCCESS)) { // they should agree
+      print_input(source, e);
+      return false;
+    }
+    if (validutf16le) {
+      valid_utf16le++;
       // We need a buffer of size where to write the UTF-16 words.
-      size_t expected_utf8words =
-          e->utf8_length_from_utf16le((char16_t *)data, size / 2);
-      std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
-      size_t utf8words = e->convert_utf16le_to_utf8((char16_t *)data, size / 2,
-                                                    utf8_output.get());
+      size_t expected_utf8words = e->utf8_length_from_utf16le(
+          (char16_t *)source.c_str(), source.size() / 2);
+      std::unique_ptr<char[]> utf8_output{ new char[expected_utf8words] };
+      size_t utf8words = e->convert_utf16le_to_utf8(
+          (char16_t *)source.c_str(), source.size() / 2, utf8_output.get());
       // It wrote utf16words * sizeof(char16_t) bytes.
       bool validutf8 = e->validate_utf8(utf8_output.get(), utf8words);
       if (!validutf8) {
+        print_input(source, e);
         return false;
       }
       // convert it back:
@@ -160,32 +290,214 @@ bool fuzz_this(const char *data, size_t size) {
       size_t expected_utf16words =
           e->utf16_length_from_utf8(utf8_output.get(), utf8words);
       std::unique_ptr<char16_t[]> utf16_output{
-          new char16_t[expected_utf16words]};
+        new char16_t[expected_utf16words]
+      };
       // convert to UTF-8
       size_t utf16words = e->convert_utf8_to_utf16le(
           utf8_output.get(), utf8words, utf16_output.get());
-      if(utf16words != size / 2) { return false; }
-      for (size_t i = 0; i < size / 2; i++) {
-        if (utf16_output.get()[i] != ((char16_t *)data)[i]) {
+      for (size_t i = 0; i < source.size() / 2; i++) {
+        if (utf16_output.get()[i] != ((char16_t *)source.c_str())[i]) {
+          print_input(source, e);
           return false;
         }
       }
     } else {
       // invalid input!!!
       // We need a buffer of size where to write the UTF-16 words.
-      size_t expected_utf8words =
-          e->utf8_length_from_utf16le((char16_t *)data, size / 2);
-      std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
-      size_t utf8words = e->convert_utf16le_to_utf8((char16_t *)data, size / 2,
-                                                    utf8_output.get());
+      size_t expected_utf8words = e->utf8_length_from_utf16le(
+          (char16_t *)source.c_str(), source.size() / 2);
+      std::unique_ptr<char[]> utf8_output{ new char[expected_utf8words] };
+      size_t utf8words = e->convert_utf16le_to_utf8(
+          (char16_t *)source.c_str(), source.size() / 2, utf8_output.get());
       if (utf8words != 0) {
+        print_input(source, e);
         return false;
+      }
+    }
+
+    /**
+     * Transcoding from UTF-16BE to UTF-8.
+     */
+    bool validutf16be =
+        e->validate_utf16be((char16_t *)source.c_str(), source.size() / 2);
+    auto rutf16be = e->validate_utf16be_with_errors((char16_t *)source.c_str(), source.size() / 2);
+    if(validutf16be != (rutf16be.error == simdutf::SUCCESS)) { // they should agree
+      print_input(source, e);
+      return false;
+    }
+    if (validutf16be) {
+      valid_utf16be++;
+      // We need a buffer of size where to write the UTF-16 words.
+      size_t expected_utf8words = e->utf8_length_from_utf16be(
+          (char16_t *)source.c_str(), source.size() / 2);
+      std::unique_ptr<char[]> utf8_output{ new char[expected_utf8words] };
+      size_t utf8words = e->convert_utf16be_to_utf8(
+          (char16_t *)source.c_str(), source.size() / 2, utf8_output.get());
+      // It wrote utf16words * sizeof(char16_t) bytes.
+      bool validutf8 = e->validate_utf8(utf8_output.get(), utf8words);
+      if (!validutf8) {
+        print_input(source, e);
+        return false;
+      }
+      // convert it back:
+      // We need a buffer of size where to write the UTF-16 words.
+      size_t expected_utf16words =
+          e->utf16_length_from_utf8(utf8_output.get(), utf8words);
+      std::unique_ptr<char16_t[]> utf16_output{
+        new char16_t[expected_utf16words]
+      };
+      // convert to UTF-8
+      size_t utf16words = e->convert_utf8_to_utf16be(
+          utf8_output.get(), utf8words, utf16_output.get());
+      for (size_t i = 0; i < source.size() / 2; i++) {
+        if (utf16_output.get()[i] != ((char16_t *)source.c_str())[i]) {
+          print_input(source, e);
+          return false;
+        }
+      }
+    } else {
+      // invalid input!!!
+      // We need a buffer of size where to write the UTF-16 words.
+      size_t expected_utf8words = e->utf8_length_from_utf16be(
+          (char16_t *)source.c_str(), source.size() / 2);
+      std::unique_ptr<char[]> utf8_output{ new char[expected_utf8words] };
+      size_t utf8words = e->convert_utf16be_to_utf8(
+          (char16_t *)source.c_str(), source.size() / 2, utf8_output.get());
+      if (utf8words != 0) {
+        print_input(source, e);
+        return false;
+      }
+    }
+
+
+    /**
+     * Transcoding from latin1 to UTF-8.
+     */
+    bool validlatin1 = true; // has to be
+    if (validlatin1) {
+      // We need a buffer of size where to write the UTF-8 words.
+      size_t expected_utf8words = e->utf8_length_from_latin1(
+          source.c_str(), source.size());
+      std::unique_ptr<char[]> utf8_output{ new char[expected_utf8words] };
+      size_t utf8words = e->convert_latin1_to_utf8(
+          source.c_str(), source.size(), utf8_output.get());
+      // It wrote utf8words * sizeof(char) bytes.
+      bool validutf8 = e->validate_utf8(utf8_output.get(), utf8words);
+      if (!validutf8) {
+        print_input(source, e);
+        return false;
+      }
+      // convert it back:
+      // We need a buffer of size where to write the latin1 words.
+      size_t expected_latin1words =
+          e->latin1_length_from_utf8(utf8_output.get(), utf8words);
+      std::unique_ptr<char[]> latin1_output{
+        new char[expected_latin1words]
+      };
+      // convert to latin1
+      size_t latin1words = e->convert_utf8_to_latin1(
+          utf8_output.get(), utf8words, latin1_output.get());
+      for (size_t i = 0; i < source.size(); i++) {
+        if (latin1_output.get()[i] != (source.c_str())[i]) {
+          print_input(source, e);
+          return false;
+        }
+      }
+    }
+    if (validlatin1) {
+      // We need a buffer of size where to write the UTF-16 words.
+      size_t expected_utf16words = e->utf16_length_from_latin1(
+          source.size());
+      std::unique_ptr<char16_t[]> utf16_output{ new char16_t[expected_utf16words] };
+      size_t utf16words = e->convert_latin1_to_utf16le(
+          source.c_str(), source.size(), utf16_output.get());
+      // It wrote utf16words * sizeof(char16_t) bytes.
+      bool validutf16 = e->validate_utf16le(utf16_output.get(), utf16words);
+      if (!validutf16) {
+        print_input(source, e);
+        return false;
+      }
+      // convert it back:
+      // We need a buffer of size where to write the latin1 words.
+      size_t expected_latin1words =
+          e->latin1_length_from_utf16(utf16words);
+      std::unique_ptr<char[]> latin1_output{
+        new char[expected_latin1words]
+      };
+      // convert to latin1
+      size_t latin1words = e->convert_utf16le_to_latin1(
+          utf16_output.get(), utf16words, latin1_output.get());
+      for (size_t i = 0; i < source.size(); i++) {
+        if (latin1_output.get()[i] != (source.c_str())[i]) {
+          print_input(source, e);
+          return false;
+        }
+      }
+    }
+    if (validlatin1) {
+      // We need a buffer of size where to write the UTF-16 words.
+      size_t expected_utf16words = e->utf16_length_from_latin1(
+          source.size());
+      std::unique_ptr<char16_t[]> utf16_output{ new char16_t[expected_utf16words] };
+      size_t utf16words = e->convert_latin1_to_utf16be(
+          source.c_str(), source.size(), utf16_output.get());
+      // It wrote utf16words * sizeof(char16_t) bytes.
+      bool validutf16 = e->validate_utf16be(utf16_output.get(), utf16words);
+      if (!validutf16) {
+        print_input(source, e);
+        return false;
+      }
+      // convert it back:
+      // We need a buffer of size where to write the latin1 words.
+      size_t expected_latin1words =
+          e->latin1_length_from_utf16(utf16words);
+      std::unique_ptr<char[]> latin1_output{
+        new char[expected_latin1words]
+      };
+      // convert to latin1
+      size_t latin1words = e->convert_utf16be_to_latin1(
+          utf16_output.get(), utf16words, latin1_output.get());
+      for (size_t i = 0; i < source.size(); i++) {
+        if (latin1_output.get()[i] != (source.c_str())[i]) {
+          print_input(source, e);
+          return false;
+        }
+      }
+    }
+
+    if (validlatin1) {
+      // We need a buffer of size where to write the UTF-16 words.
+      size_t expected_utf32words = e->utf32_length_from_latin1(source.size());
+      std::unique_ptr<char32_t[]> utf32_output{ new char32_t[expected_utf32words] };
+      size_t utf32words = e->convert_latin1_to_utf32(
+          source.c_str(), source.size(), utf32_output.get());
+      // It wrote utf16words * sizeof(char16_t) bytes.
+      bool validutf32 = e->validate_utf32(utf32_output.get(), utf32words);
+      if (!validutf32) {
+        print_input(source, e);
+        return false;
+      }
+      // convert it back:
+      // We need a buffer of size where to write the latin1 words.
+      size_t expected_latin1words =
+          e->latin1_length_from_utf32(utf32words);
+      std::unique_ptr<char[]> latin1_output{
+        new char[expected_latin1words]
+      };
+      // convert to latin1
+      size_t latin1words = e->convert_utf32_to_latin1(
+          utf32_output.get(), utf32words, latin1_output.get());
+      for (size_t i = 0; i < source.size(); i++) {
+        if (latin1_output.get()[i] != (source.c_str())[i]) {
+          print_input(source, e);
+          return false;
+        }
       }
     }
   } // for (auto &e : simdutf::get_available_implementations()) {
 
   return true;
-}
+} // extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
 bool fuzz_running(size_t N) {
   std::mt19937 generator{std::random_device{}()};
@@ -231,7 +543,8 @@ int main(int argc, char*argv[]) {
   std::cout << "Number of strings: " << N << std::endl;
   if (fuzz_running(N)) {
     std::cout << "valid UTF8 = " << valid_utf8 << std::endl;
-    std::cout << "valid UTF16 = " << valid_utf16 << std::endl;
+    std::cout << "valid UTF16-BE = " << valid_utf16be << std::endl;
+    std::cout << "valid UTF16-LE = " << valid_utf16be << std::endl;
     return EXIT_SUCCESS;
   } else {
     return EXIT_FAILURE;

--- a/tests/special_tests.cpp
+++ b/tests/special_tests.cpp
@@ -332,6 +332,13 @@ TEST(special_cases_utf8_utf16_invalid) {
     size_t utf16words = simdutf::convert_utf8_to_utf16le(
         source.c_str(), source.size(), utf16_output.get());
     ASSERT_TRUE(utf16words == 0);
+
+    size_t expected_latin1words =
+        simdutf::latin1_length_from_utf8(source.c_str(), source.size());
+    std::unique_ptr<char[]> latin1_output{new char[expected_latin1words]};
+    size_t latin1words = simdutf::convert_utf8_to_latin1(
+          source.c_str(), source.size(), latin1_output.get());
+    ASSERT_TRUE(latin1words == 0);
   }
 }
 
@@ -402,8 +409,16 @@ TEST(special_cases_utf8_utf32_invalid) {
     size_t utf32words = simdutf::convert_utf8_to_utf32(
         source.c_str(), source.size(), utf32_output.get());
     ASSERT_TRUE(utf32words == 0);
+
+    size_t expected_latin1words =
+        simdutf::latin1_length_from_utf8(source.c_str(), source.size());
+    std::unique_ptr<char[]> latin1_output{new char[expected_latin1words]};
+    size_t latin1words = simdutf::convert_utf8_to_latin1(
+          source.c_str(), source.size(), latin1_output.get());
+    ASSERT_TRUE(latin1words == 0);
   }
 }
+
 
 
 TEST(special_cases_utf16_utf8_roundtrip) {


### PR DESCRIPTION
This is a version with minor fixes from https://github.com/simdutf/simdutf/pull/263 by @Nick-Nuon 

It adds new tests. Furthermore, the latin1_length_from_utf8 is already accelerated: it is just the count function, so I did that.

Fix https://github.com/simdutf/simdutf/issues/292