### PR TITLE
UTF-8 to Latin 1 (ARM)

### DIFF
--- a/benchmarks/src/apple_arm_events.h
+++ b/benchmarks/src/apple_arm_events.h
@@ -993,7 +993,6 @@ struct AppleEvents {
     // check permission
     int force_ctrs = 0;
     if (kpc_force_all_ctrs_get(&force_ctrs)) {
-      printf("Permission denied, xnu/kpc requires root privileges.\n");
       return (worked = false);
     }
     int ret;

--- a/src/arm64/arm_convert_utf8_to_latin1.cpp
+++ b/src/arm64/arm_convert_utf8_to_latin1.cpp
@@ -1,0 +1,67 @@
+// Convert up to 16 bytes from utf8 to utf16 using a mask indicating the
+// end of the code points. Only the least significant 12 bits of the mask
+// are accessed.
+// It returns how many bytes were consumed (up to 16, usually 12).
+size_t convert_masked_utf8_to_latin1(const char *input,
+                           uint64_t utf8_end_of_code_point_mask,
+                           char *&latin1_output) {
+  // we use an approach where we try to process up to 12 input bytes.
+  // Why 12 input bytes and not 16? Because we are concerned with the size of
+  // the lookup tables. Also 12 is nicely divisible by two and three.
+  //
+  uint8x16_t in = vld1q_u8(reinterpret_cast<const uint8_t*>(input));
+  const uint16_t input_utf8_end_of_code_point_mask =
+      utf8_end_of_code_point_mask & 0xfff;
+  //
+  // Optimization note: our main path below is load-latency dependent. Thus it is maybe
+  // beneficial to have fast paths that depend on branch prediction but have less latency.
+  // This results in more instructions but, potentially, also higher speeds.
+
+  // We first try a few fast paths.
+  // The obvious first test is ASCII, which actually consumes the full 16.
+  if((utf8_end_of_code_point_mask & 0xFFFF) == 0xffff) {
+    // We process in chunks of 16 bytes
+    vst1q_u8(reinterpret_cast<uint8_t*>(latin1_output), in);
+    latin1_output += 16; // We wrote 16 18-bit characters.
+    return 16; // We consumed 16 bytes.
+  }
+  /// We do not have a fast path available, or the fast path is unimportant, so we fallback.
+  const uint8_t idx =
+      simdutf::tables::utf8_to_utf16::utf8bigindex[input_utf8_end_of_code_point_mask][0];
+
+  const uint8_t consumed =
+      simdutf::tables::utf8_to_utf16::utf8bigindex[input_utf8_end_of_code_point_mask][1];
+  // this indicates an invalid input:
+  if(idx >= 64) { return consumed; }
+  // Here we should have (idx < 64), if not, there is a bug in the validation or elsewhere.
+  // SIX (6) input code-words
+  // this is a relatively easy scenario
+  // we process SIX (6) input code-words. The max length in bytes of six code
+  // words spanning between 1 and 2 bytes each is 12 bytes.
+  // Converts 6 1-2 byte UTF-8 characters to 6 UTF-16 characters.
+  // This is a relatively easy scenario
+  // we process SIX (6) input code-words. The max length in bytes of six code
+  // words spanning between 1 and 2 bytes each is 12 bytes.
+  uint8x16_t sh = vld1q_u8(reinterpret_cast<const uint8_t*>(simdutf::tables::utf8_to_utf16::shufutf8[idx]));
+  // Shuffle
+  // 1 byte: 00000000 0bbbbbbb
+  // 2 byte: 110aaaaa 10bbbbbb
+  uint16x8_t perm = vreinterpretq_u16_u8(vqtbl1q_u8(in, sh));
+  // Mask
+  // 1 byte: 00000000 0bbbbbbb
+  // 2 byte: 00000000 00bbbbbb
+  uint16x8_t ascii = vandq_u16(perm, vmovq_n_u16(0x7f)); // 6 or 7 bits
+  // 1 byte: 00000000 00000000
+  // 2 byte: 000aaaaa 00000000
+  uint16x8_t highbyte = vandq_u16(perm, vmovq_n_u16(0x1f00)); // 5 bits
+  // Combine with a shift right accumulate
+  // 1 byte: 00000000 0bbbbbbb
+  // 2 byte: 00000aaa aabbbbbb
+  uint16x8_t composed = vsraq_n_u16(ascii, highbyte, 2);
+  // writing 8 bytes even though we only care about the first 6 bytes.
+  uint8x8_t latin1_packed = vmovn_u16(composed);
+  vst1_u8(reinterpret_cast<uint8_t*>(latin1_output), latin1_packed);
+  latin1_output += 6; // We wrote 6 bytes.
+  return consumed;
+}
+

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -111,6 +111,7 @@ simdutf_really_inline uint16x8_t convert_utf8_1_to_2_byte_to_utf16(uint8x16_t in
 
 #include "arm64/arm_convert_utf8_to_utf16.cpp"
 #include "arm64/arm_convert_utf8_to_utf32.cpp"
+#include "arm64/arm_convert_utf8_to_latin1.cpp"
 
 #include "arm64/arm_convert_utf16_to_utf8.cpp"
 #include "arm64/arm_convert_utf16_to_utf32.cpp"
@@ -132,11 +133,14 @@ simdutf_really_inline uint16x8_t convert_utf8_1_to_2_byte_to_utf16(uint8x16_t in
 // other functions
 #include "generic/utf8.h"
 #include "generic/utf16.h"
+// transcoding from UTF-8 to Latin 1
+#include "generic/utf8_to_latin1/utf8_to_latin1.h"
+#include "generic/utf8_to_latin1/valid_utf8_to_latin1.h"
 
 // placeholder scalars
 #include "scalar/latin1.h"
-#include "scalar/utf8_to_latin1/valid_utf8_to_latin1.h"
-#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
+//#include "scalar/utf8_to_latin1/valid_utf8_to_latin1.h"
+//#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
 
 //
 // Implementation-specific overrides
@@ -249,15 +253,17 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf32(const char* b
 }
 
 simdutf_warn_unused size_t implementation::convert_utf8_to_latin1(const char* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf8_to_latin1::convert(buf, len, latin1_output);
+  utf8_to_latin1::validating_transcoder converter;
+  return converter.convert(buf, len, latin1_output);
 }
 
 simdutf_warn_unused result implementation::convert_utf8_to_latin1_with_errors(const char* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf8_to_latin1::convert_with_errors(buf, len, latin1_output);
+  utf8_to_latin1::validating_transcoder converter;
+  return converter.convert_with_errors(buf, len, latin1_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf8_to_latin1(const char* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf8_to_latin1::convert_valid(buf, len, latin1_output);
+  return arm64::utf8_to_latin1::convert_valid(buf,len,latin1_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_utf8_to_utf16le(const char* buf, size_t len, char16_t* utf16_output) const noexcept {


### PR DESCRIPTION
On Apple M2 (LLVM 14) with the `french.utflatin8.txt` file.

```
$ sudo ./benchmarks/benchmark -P convert_utf8_to_latin1 -F ../unicode_lipsum/wikipedia_mars/french.utflatin8.txt
Password:
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
===========================
Using ICU version 73.2
Using iconv version 267
testcases: 1
input detected as UTF8
current system detected as arm64
===========================
convert_utf8_to_latin1+arm64, input size: 440052, iterations: 30000, dataset: ../unicode_lipsum/wikipedia_mars/french.utflatin8.txt
   1.864 ins/byte,    1.005 cycle/byte,    3.420 GB/s (9.8 %),     3.439 GHz,    1.854 ins/cycle 
   1.897 ins/char,    1.023 cycle/char,    3.360 Gc/s (9.8 %)     1.02 byte/char 
convert_utf8_to_latin1+iconv, input size: 440052, iterations: 30000, dataset: ../unicode_lipsum/wikipedia_mars/french.utflatin8.txt
  45.452 ins/byte,    7.595 cycle/byte,    0.449 GB/s (2.4 %),     3.412 GHz,    5.984 ins/cycle 
  46.267 ins/char,    7.731 cycle/char,    0.441 Gc/s (2.4 %)     1.02 byte/char 
convert_utf8_to_latin1+icu, input size: 440052, iterations: 30000, dataset: ../unicode_lipsum/wikipedia_mars/french.utflatin8.txt
   9.061 ins/byte,    2.384 cycle/byte,    1.435 GB/s (1.8 %),     3.421 GHz,    3.801 ins/cycle 
   9.223 ins/char,    2.426 cycle/char,    1.410 Gc/s (1.8 %)     1.02 byte/char 
convert_utf8_to_latin1_with_errors+arm64, input size: 440052, iterations: 30000, dataset: ../unicode_lipsum/wikipedia_mars/french.utflatin8.txt
   1.897 ins/byte,    1.039 cycle/byte,    3.308 GB/s (2.8 %),     3.438 GHz,    1.825 ins/cycle 
   1.931 ins/char,    1.058 cycle/char,    3.249 Gc/s (2.8 %)     1.02 byte/char 
```

With pure ASCII:

```
$ sudo ./benchmarks/benchmark -P convert_utf8_to_latin1 -F ../unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt 
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
===========================
Using ICU version 73.2
Using iconv version 267
testcases: 1
input detected as UTF8
current system detected as arm64
===========================
convert_utf8_to_latin1+arm64, input size: 86940, iterations: 30000, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
   0.436 ins/byte,    0.081 cycle/byte,   83.516 GB/s (11.6 %),     6.755 GHz,    5.389 ins/cycle 
   0.436 ins/char,    0.081 cycle/char,   83.516 Gc/s (11.6 %)     1.00 byte/char 
WARNING: Measurements are noisy, try increasing iteration count (-I).
convert_utf8_to_latin1+iconv, input size: 86940, iterations: 30000, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
  46.167 ins/byte,    7.414 cycle/byte,    0.462 GB/s (0.6 %),     3.429 GHz,    6.227 ins/cycle 
  46.167 ins/char,    7.414 cycle/char,    0.462 Gc/s (0.6 %)     1.00 byte/char 
convert_utf8_to_latin1+icu, input size: 86940, iterations: 30000, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
   9.221 ins/byte,    2.050 cycle/byte,    1.698 GB/s (0.6 %),     3.481 GHz,    4.497 ins/cycle 
   9.221 ins/char,    2.050 cycle/char,    1.698 Gc/s (0.6 %)     1.00 byte/char 
convert_utf8_to_latin1_with_errors+arm64, input size: 86940, iterations: 30000, dataset: ../unicode_lipsum/lipsum/Latin-Lipsum.utf8.txt
   0.436 ins/byte,    0.082 cycle/byte,   80.277 GB/s (7.5 %),     6.556 GHz,    5.342 ins/cycle 
   0.436 ins/char,    0.082 cycle/char,   80.277 Gc/s (7.5 %)     1.00 byte/char 
```

Fixes https://github.com/simdutf/simdutf/issues/277