### PR TITLE
Cleaned up version

### DIFF
--- a/src/haswell/avx2_convert_latin1_to_utf32.cpp
+++ b/src/haswell/avx2_convert_latin1_to_utf32.cpp
@@ -1,0 +1,29 @@
+
+std::pair<const char*, char32_t*> avx2_convert_latin1_to_utf32(const char* buf, size_t len, char32_t* utf32_output) {
+    const char* end = buf + len;
+
+    while (buf + 32 <= end) {  // Process 32 bytes at a time
+        // Load 8 Latin1 characters at a time into 128-bit registers
+        __m128i in1 = _mm_loadu_si128((__m128i*)buf);
+        __m128i in2 = _mm_loadu_si128((__m128i*)(buf + 8));
+        __m128i in3 = _mm_loadu_si128((__m128i*)(buf + 16));
+        __m128i in4 = _mm_loadu_si128((__m128i*)(buf + 24));
+
+        // Zero extend each set of 8 Latin1 characters to 8 32-bit integers
+        __m256i out1 = _mm256_cvtepu8_epi32(in1);
+        __m256i out2 = _mm256_cvtepu8_epi32(in2);
+        __m256i out3 = _mm256_cvtepu8_epi32(in3);
+        __m256i out4 = _mm256_cvtepu8_epi32(in4);
+
+        // Store the results back to memory
+        _mm256_storeu_si256((__m256i*)(utf32_output), out1);
+        _mm256_storeu_si256((__m256i*)(utf32_output + 8), out2);
+        _mm256_storeu_si256((__m256i*)(utf32_output + 16), out3);
+        _mm256_storeu_si256((__m256i*)(utf32_output + 24), out4);
+
+        utf32_output += 32;  // Updated 32 32-bit integers
+        buf += 32;           // Processed 32 bytes
+    }
+
+    return std::make_pair(buf, utf32_output);
+}


### PR DESCRIPTION
These are the benchmarks I get on my home PC:
convert_latin1_to_utf32+fallback, input size: 1739468, iterations: 30000, dataset: /unicode_lipsum/wikipedia_mars/french.utf32.txt
  16.341 GB/s (7.8 %)   16.341 Gc/s     1.00 byte/char 
convert_latin1_to_utf32+haswell, input size: 1739468, iterations: 30000, dataset:/unicode_lipsum/wikipedia_mars/french.utf32.txt
  20.860 GB/s (9.5 %)   20.860 Gc/s     1.00 byte/char 
convert_latin1_to_utf32+iconv, input size: 1739468, iterations: 30000, dataset:/unicode_lipsum/wikipedia_mars/french.utf32.txt
   0.957 GB/s (3.7 %)    0.957 Gc/s     1.00 byte/char 
convert_latin1_to_utf32+icu, input size: 1739468, iterations: 30000, dataset: /unicode_lipsum/wikipedia_mars/french.utf32.txt
   0.483 GB/s (5.4 %)    0.483 Gc/s     1.00 byte/char 
convert_latin1_to_utf32+westmere, input size: 1739468, iterations: 30000, dataset: /unicode_lipsum/wikipedia_mars/french.utf32.txt
  17.513 GB/s (10.5 %)   17.513 Gc/s     1.00 byte/char 

I will benchmark again once the TELUQ servers are back online