### PR TITLE
Latin 1 => UTF 8 (SSE)

### DIFF
--- a/src/westmere/internal/loader.cpp
+++ b/src/westmere/internal/loader.cpp
@@ -1,0 +1,7 @@
+namespace internal {
+namespace westmere {
+
+#include "westmere/internal/write_v_u16_11bits_to_utf8.cpp"
+
+} // namespace westmere
+} // namespace internal

--- a/src/westmere/internal/write_v_u16_11bits_to_utf8.cpp
+++ b/src/westmere/internal/write_v_u16_11bits_to_utf8.cpp
@@ -1,0 +1,68 @@
+/*
+* reads a vector of uint16 values
+* bits after 11th are ignored
+* first 11 bits are encoded into utf8
+* !important! utf8_output must have at least 16 writable bytes
+*/
+
+inline void write_v_u16_11bits_to_utf8(
+  const __m128i v_u16,
+  char*& utf8_output,
+  const __m128i one_byte_bytemask,
+  const uint16_t one_byte_bitmask
+) {
+  // 0b1100_0000_1000_0000
+  const __m128i v_c080 = _mm_set1_epi16((int16_t)0xc080);
+  // 0b0001_1111_0000_0000
+  const __m128i v_1f00 = _mm_set1_epi16((int16_t)0x1f00);
+  // 0b0000_0000_0011_1111
+  const __m128i v_003f = _mm_set1_epi16((int16_t)0x003f);
+
+  // 1. prepare 2-byte values
+          // input 16-bit word : [0000|0aaa|aabb|bbbb] x 8
+          // expected output   : [110a|aaaa|10bb|bbbb] x 8
+
+  // t0 = [000a|aaaa|bbbb|bb00]
+  const __m128i t0 = _mm_slli_epi16(v_u16, 2);
+  // t1 = [000a|aaaa|0000|0000]
+  const __m128i t1 = _mm_and_si128(t0, v_1f00);
+  // t2 = [0000|0000|00bb|bbbb]
+  const __m128i t2 = _mm_and_si128(v_u16, v_003f);
+  // t3 = [000a|aaaa|00bb|bbbb]
+  const __m128i t3 = _mm_or_si128(t1, t2);
+  // t4 = [110a|aaaa|10bb|bbbb]
+  const __m128i t4 = _mm_or_si128(t3, v_c080);
+
+  // 2. merge ASCII and 2-byte codewords
+  const __m128i utf8_unpacked = _mm_blendv_epi8(t4, v_u16, one_byte_bytemask);
+
+  // 3. prepare bitmask for 8-bit lookup
+  //    one_byte_bitmask = hhggffeeddccbbaa -- the bits are doubled (h - MSB, a - LSB)
+  const uint16_t m0 = one_byte_bitmask & 0x5555;  // m0 = 0h0g0f0e0d0c0b0a
+  const uint16_t m1 = static_cast<uint16_t>(m0 >> 7);                    // m1 = 00000000h0g0f0e0
+  const uint8_t  m2 = static_cast<uint8_t>((m0 | m1) & 0xff);           // m2 =         hdgcfbea
+  // 4. pack the bytes
+  const uint8_t* row = &simdutf::tables::utf16_to_utf8::pack_1_2_utf8_bytes[m2][0];
+  const __m128i shuffle = _mm_loadu_si128((__m128i*)(row + 1));
+  const __m128i utf8_packed = _mm_shuffle_epi8(utf8_unpacked, shuffle);
+
+  // 5. store bytes
+  _mm_storeu_si128((__m128i*)utf8_output, utf8_packed);
+
+  // 6. adjust pointers
+  utf8_output += row[0];
+};
+
+inline void write_v_u16_11bits_to_utf8(
+  const __m128i v_u16,
+  char*& utf8_output,
+  const __m128i v_0000,
+  const __m128i v_ff80
+) {
+  // no bits set above 7th bit
+  const __m128i one_byte_bytemask = _mm_cmpeq_epi16(_mm_and_si128(v_u16, v_ff80), v_0000);
+  const uint16_t one_byte_bitmask = static_cast<uint16_t>(_mm_movemask_epi8(one_byte_bytemask));
+
+  write_v_u16_11bits_to_utf8(
+    v_u16, utf8_output, one_byte_bytemask, one_byte_bitmask);
+};

--- a/src/westmere/sse_convert_latin1_to_utf8.cpp
+++ b/src/westmere/sse_convert_latin1_to_utf8.cpp
@@ -1,0 +1,105 @@
+template <endianness big_endian>
+std::pair<const char* const, char* const> sse_convert_latin1_to_utf8(
+  const char* latin_input,
+  const size_t latin_input_length,
+  char* utf8_output) {
+  const char* end = latin_input + latin_input_length;
+
+  const __m128i v_0000 = _mm_setzero_si128();
+  // 0b1000_0000
+  const __m128i v_80 = _mm_set1_epi8((uint8_t)0x80);
+  // 0b1111_1111_1000_0000
+  const __m128i v_ff80 = _mm_set1_epi16((uint16_t)0xff80);
+
+  const __m128i latin_1_half_into_u16_byte_mask = big_endian
+    ? _mm_setr_epi8(
+      '\x80', 0,
+      '\x80', 1,
+      '\x80', 2,
+      '\x80', 3,
+      '\x80', 4,
+      '\x80', 5,
+      '\x80', 6,
+      '\x80', 7
+    )
+    : _mm_setr_epi8(
+      0, '\x80',
+      1, '\x80',
+      2, '\x80',
+      3, '\x80',
+      4, '\x80',
+      5, '\x80',
+      6, '\x80',
+      7, '\x80'
+    );
+
+  const __m128i latin_2_half_into_u16_byte_mask = big_endian
+    ? _mm_setr_epi8(
+      '\x80', 8,
+      '\x80', 9,
+      '\x80', 10,
+      '\x80', 11,
+      '\x80', 12,
+      '\x80', 13,
+      '\x80', 14,
+      '\x80', 15
+    )
+    : _mm_setr_epi8(
+      8, '\x80',
+      9, '\x80',
+      10, '\x80',
+      11, '\x80',
+      12, '\x80',
+      13, '\x80',
+      14, '\x80',
+      15, '\x80'
+    );
+
+  // each latin1 takes 1-2 utf8 bytes
+  // slow path writes useful 8-15 bytes twice (eagerly writes 16 bytes and then adjust the pointer)
+  // so the last write can exceed the utf8_output size by 8-1 bytes 
+  // by reserving 8 extra input bytes, we expect the output to have 8-16 bytes free
+  while (latin_input + 16 + 8 <= end) {
+    // Load 16 Latin1 characters (16 bytes) into a 128-bit register
+    __m128i v_latin = _mm_loadu_si128((__m128i*)latin_input);
+
+
+    if (_mm_testz_si128(v_latin, v_80)) {// ASCII fast path!!!!
+      _mm_storeu_si128((__m128i*)utf8_output, v_latin);
+      latin_input += 16;
+      utf8_output += 16;
+      continue;
+    }
+    
+
+    // assuming a/b are bytes and A/B are uint16 of the same value
+    // aaaa_aaaa_bbbb_bbbb -> AAAA_AAAA
+    __m128i v_u16_latin_1_half = _mm_shuffle_epi8(v_latin, latin_1_half_into_u16_byte_mask);
+    // aaaa_aaaa_bbbb_bbbb -> BBBB_BBBB
+    __m128i v_u16_latin_2_half = _mm_shuffle_epi8(v_latin, latin_2_half_into_u16_byte_mask);
+
+
+    internal::westmere::write_v_u16_11bits_to_utf8(v_u16_latin_1_half, utf8_output, v_0000, v_ff80);
+    internal::westmere::write_v_u16_11bits_to_utf8(v_u16_latin_2_half, utf8_output, v_0000, v_ff80);
+    latin_input += 16;
+  }
+
+  if (latin_input + 16 <= end) {
+    // Load 16 Latin1 characters (16 bytes) into a 128-bit register
+    __m128i v_latin = _mm_loadu_si128((__m128i*)latin_input);
+
+    if (_mm_testz_si128(v_latin, v_80)) {// ASCII fast path!!!!
+      _mm_storeu_si128((__m128i*)utf8_output, v_latin);
+      latin_input += 16;
+      utf8_output += 16;
+    } else {
+      // assuming a/b are bytes and A/B are uint16 of the same value
+      // aaaa_aaaa_bbbb_bbbb -> AAAA_AAAA
+      __m128i v_u16_latin_1_half = _mm_shuffle_epi8(v_latin, latin_1_half_into_u16_byte_mask);
+      internal::westmere::write_v_u16_11bits_to_utf8(v_u16_latin_1_half, utf8_output, v_0000, v_ff80);
+      latin_input += 8;
+    }
+  }
+
+  return std::make_pair(latin_input, utf8_output);
+};


### PR DESCRIPTION
On windows Sandy Bridge (msvc 17.5.5) with the `*.latin1.txt` files.
```
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
===========================
Using ICU version 71.1
Using iconv version 272
testcases: 4
input detected as UTF16 little-endian
current system detected as westmere
===========================
convert_latin1_to_utf8+fallback, input size: 82168, iterations: 30000, dataset: esperanto.latin1.txt
   0.951 GB/s (4.3 %)    0.951 Gc/s     1.00 byte/char 
convert_latin1_to_utf8+iconv, input size: 82168, iterations: 30000, dataset: esperanto.latin1.txt
   0.172 GB/s (3.7 %)    0.172 Gc/s     1.00 byte/char 
convert_latin1_to_utf8+icu, input size: 82168, iterations: 30000, dataset: esperanto.latin1.txt
   0.713 GB/s (3.9 %)    0.713 Gc/s     1.00 byte/char 
convert_latin1_to_utf8+westmere, input size: 82168, iterations: 30000, dataset: esperanto.latin1.txt
  13.695 GB/s (6.4 %)   13.695 Gc/s     1.00 byte/char 
input detected as unknown
current system detected as westmere
===========================
convert_latin1_to_utf8+fallback, input size: 432305, iterations: 30000, dataset: french.latin1.txt
   0.685 GB/s (4.0 %)    0.685 Gc/s     1.00 byte/char 
convert_latin1_to_utf8+iconv, input size: 432305, iterations: 30000, dataset: french.latin1.txt
   0.167 GB/s (3.6 %)    0.167 Gc/s     1.00 byte/char 
convert_latin1_to_utf8+icu, input size: 432305, iterations: 30000, dataset: french.latin1.txt
   0.662 GB/s (4.3 %)    0.662 Gc/s     1.00 byte/char 
convert_latin1_to_utf8+westmere, input size: 432305, iterations: 30000, dataset: french.latin1.txt
   3.829 GB/s (4.9 %)    3.829 Gc/s     1.00 byte/char 
input detected as unknown
current system detected as westmere
===========================
convert_latin1_to_utf8+fallback, input size: 199331, iterations: 30000, dataset: german.latin1.txt
   0.832 GB/s (3.8 %)    0.832 Gc/s     1.00 byte/char 
convert_latin1_to_utf8+iconv, input size: 199331, iterations: 30000, dataset: german.latin1.txt
   0.169 GB/s (3.3 %)    0.169 Gc/s     1.00 byte/char 
convert_latin1_to_utf8+icu, input size: 199331, iterations: 30000, dataset: german.latin1.txt
   0.694 GB/s (3.5 %)    0.694 Gc/s     1.00 byte/char 
convert_latin1_to_utf8+westmere, input size: 199331, iterations: 30000, dataset: german.latin1.txt
   6.493 GB/s (5.5 %)    6.493 Gc/s     1.00 byte/char 
input detected as unknown
current system detected as westmere
===========================
convert_latin1_to_utf8+fallback, input size: 271743, iterations: 30000, dataset: portuguese.latin1.txt
   0.729 GB/s (3.8 %)    0.729 Gc/s     1.00 byte/char 
convert_latin1_to_utf8+iconv, input size: 271743, iterations: 30000, dataset: portuguese.latin1.txt
   0.168 GB/s (3.6 %)    0.168 Gc/s     1.00 byte/char 
convert_latin1_to_utf8+icu, input size: 271743, iterations: 30000, dataset: portuguese.latin1.txt
   0.672 GB/s (4.2 %)    0.672 Gc/s     1.00 byte/char 
convert_latin1_to_utf8+westmere, input size: 271743, iterations: 30000, dataset: portuguese.latin1.txt
   4.484 GB/s (4.6 %)    4.484 Gc/s     1.00 byte/char 
```
I wasn't able to test it on big-endian os.