### PR TITLE
Validating Unicode strings as Latin 1  [draft/hypothetical]

### DIFF
--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -193,6 +193,19 @@ simdutf_warn_unused result validate_utf16be_with_errors(const char16_t *buf, siz
 simdutf_warn_unused bool validate_utf32(const char32_t *buf, size_t len) noexcept;
 
 /**
+ * Validate the UTF-32 string as Latin 1: the string must be safely convertible to Latin 1.
+ *
+ * Overridden by each implementation.
+ *
+ * This function is not BOM-aware.
+ *
+ * @param buf the UTF-32 string to validate.
+ * @param len the length of the string in number of 4-byte words (char32_t).
+ * @return true if and only if the string is valid UTF-32 and can be safely converted to Latin 1.
+ */
+simdutf_warn_unused bool validate_utf32_as_latin1(const char32_t *buf, size_t len) noexcept;
+
+/**
  * Validate the UTF-32 string and stop on error. It might be faster than
  * validate_utf32 when an error is expected to occur early.
  *
@@ -1444,6 +1457,19 @@ public:
    * @return true if and only if the string is valid UTF-32.
    */
   simdutf_warn_unused virtual bool validate_utf32(const char32_t *buf, size_t len) const noexcept = 0;
+
+  /**
+   * Validate the UTF-32 string as Latin 1: the string must be safely convertible to Latin 1.
+   *
+   * Overridden by each implementation.
+   *
+   * This function is not BOM-aware.
+   *
+   * @param buf the UTF-32 string to validate.
+   * @param len the length of the string in number of 4-byte words (char32_t).
+   * @return true if and only if the string is valid UTF-32 and can be safely converted to Latin 1.
+   */
+  simdutf_warn_unused virtual bool validate_utf32_as_latin1(const char32_t *buf, size_t len) const noexcept = 0;
 
   /**
    * Validate the UTF-32 string and stop on error.

--- a/src/arm64/arm_validate_utf32le.cpp
+++ b/src/arm64/arm_validate_utf32le.cpp
@@ -59,3 +59,22 @@ const result arm_validate_utf32le_with_errors(const char32_t* input, size_t size
 
     return result(error_code::SUCCESS, input - start);
 }
+
+
+const const char32_t* arm_validate_utf32le_as_latin1(const char32_t* input, size_t size) {
+    const char32_t* start = input;
+    const char32_t* end = input + size;
+
+    const uint32x4_t standardmax = vmovq_n_u32(0x00ff);
+
+    while (input + 4 < end) {
+        const uint32x4_t in = vld1q_u32(reinterpret_cast<const uint32_t*>(input));
+        uint32x4_t is_zero = veorq_u32(vmaxq_u32(in,currentmax), standardmax);
+        if(vmaxvq_u32(is_zero) != 0) {
+            return nullptr;
+        }
+        input += 4;
+    }
+
+    return input;
+}

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -167,6 +167,10 @@ simdutf_warn_unused bool implementation::validate_utf8(const char *buf, size_t l
   return arm64::utf8_validation::generic_validate_utf8(buf,len);
 }
 
+simdutf_warn_unused size_t implementation::latin1_length_from_utf8_with_validation(const char *buf, size_t len) const noexcept {
+  return scalar::utf8::validate_as_latin1(buf,len);
+}
+
 simdutf_warn_unused result implementation::validate_utf8_with_errors(const char *buf, size_t len) const noexcept {
   return arm64::utf8_validation::generic_validate_utf8_with_errors(buf,len);
 }
@@ -195,6 +199,24 @@ simdutf_warn_unused bool implementation::validate_utf16be(const char16_t *buf, s
   } else {
     return false;
   }
+}
+
+
+simdutf_warn_unused bool implementation::validate_utf16le_as_latin1(const char16_t *buf, size_t len) const noexcept {
+  const char16_t* tail = arm_validate_utf16<endianness::LITTLE>(buf, len);
+  if (tail) {
+    return scalar::utf16::validate<endianness::LITTLE>(tail, len - (tail - buf));
+  } else {
+    return false;
+  }
+}
+
+simdutf_warn_unused bool implementation::validate_utf16le_as_latin1(const char16_t *buf, size_t len) const noexcept {
+  return scalar::utf16::validate_as_latin1<endianness::BIG>(buf, len);
+}
+
+simdutf_warn_unused bool implementation::validate_utf16be_as_latin1(const char16_t *buf, size_t len) const noexcept {
+  return scalar::utf16::validate_as_latin1<endianness::BIG>(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_utf16le_with_errors(const char16_t *buf, size_t len) const noexcept {
@@ -226,6 +248,10 @@ simdutf_warn_unused bool implementation::validate_utf32(const char32_t *buf, siz
   }
 }
 
+simdutf_warn_unused bool implementation::validate_utf32_as_latin1(const char32_t *buf, size_t len) const noexcept {
+  return scalar::utf32::validate_as_latin1(buf, len);
+}
+
 simdutf_warn_unused result implementation::validate_utf32_with_errors(const char32_t *buf, size_t len) const noexcept {
   result res = arm_validate_utf32le_with_errors(buf, len);
   if (res.count != len) {
@@ -233,6 +259,15 @@ simdutf_warn_unused result implementation::validate_utf32_with_errors(const char
     return result(scalar_res.error, res.count + scalar_res.count);
   } else {
     return res;
+  }
+}
+
+simdutf_warn_unused bool implementation::validate_utf32_as_latin1(const char32_t *buf, size_t len) const noexcept {
+  const char32_t * tail = arm_validate_utf32le_as_latin1(buf, len);
+  if (tail) {
+    return scalar::utf32::validate_with_errors(tail, buf + len - tail);
+  } else {
+    return false;
   }
 }
 

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -51,6 +51,10 @@ simdutf_warn_unused bool implementation::validate_utf8(const char *buf, size_t l
   return scalar::utf8::validate(buf, len);
 }
 
+simdutf_warn_unused size_t implementation::latin1_length_from_utf8_with_validation(const char *buf, size_t len) const noexcept {
+  return scalar::utf8::validate_as_latin1(buf,len);
+}
+
 simdutf_warn_unused result implementation::validate_utf8_with_errors(const char *buf, size_t len) const noexcept {
   return scalar::utf8::validate_with_errors(buf, len);
 }
@@ -71,6 +75,14 @@ simdutf_warn_unused bool implementation::validate_utf16be(const char16_t *buf, s
   return scalar::utf16::validate<endianness::BIG>(buf, len);
 }
 
+simdutf_warn_unused bool implementation::validate_utf16le_as_latin1(const char16_t *buf, size_t len) const noexcept {
+  return scalar::utf16::validate_as_latin1<endianness::BIG>(buf, len);
+}
+
+simdutf_warn_unused bool implementation::validate_utf16be_as_latin1(const char16_t *buf, size_t len) const noexcept {
+  return scalar::utf16::validate_as_latin1<endianness::BIG>(buf, len);
+}
+
 simdutf_warn_unused result implementation::validate_utf16le_with_errors(const char16_t *buf, size_t len) const noexcept {
   return scalar::utf16::validate_with_errors<endianness::LITTLE>(buf, len);
 }
@@ -81,6 +93,10 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(const ch
 
 simdutf_warn_unused bool implementation::validate_utf32(const char32_t *buf, size_t len) const noexcept {
   return scalar::utf32::validate(buf, len);
+}
+
+simdutf_warn_unused bool implementation::validate_utf32_as_latin1(const char32_t *buf, size_t len) const noexcept {
+  return scalar::utf32::validate_as_latin1(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_utf32_with_errors(const char32_t *buf, size_t len) const noexcept {

--- a/src/generic/utf16.h
+++ b/src/generic/utf16.h
@@ -18,6 +18,18 @@ simdutf_really_inline size_t count_code_points(const char16_t* in, size_t size) 
 }
 
 template <endianness big_endian>
+simdutf_really_inline bool latin1_range(const char16_t* in, size_t size) {
+    size_t pos = 0;
+    size_t count = 0;
+    for(;pos + 32 <= size; pos += 32) {
+      simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
+      if (!match_system(big_endian)) { input.swap_bytes(); }
+      if(input.gteq(0x100)) { return false; }
+    }
+    return return true;
+}
+
+template <endianness big_endian>
 simdutf_really_inline size_t utf8_length_from_utf16(const char16_t* in, size_t size) {
     size_t pos = 0;
     size_t count = 0;

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -92,6 +92,10 @@ simdutf_warn_unused bool implementation::validate_utf8(const char *buf, size_t l
   return haswell::utf8_validation::generic_validate_utf8(buf,len);
 }
 
+simdutf_warn_unused size_t implementation::latin1_length_from_utf8_with_validation(const char *buf, size_t len) const noexcept {
+  return scalar::utf8::validate_as_latin1(buf,len);
+}
+
 simdutf_warn_unused result implementation::validate_utf8_with_errors(const char *buf, size_t len) const noexcept {
   return haswell::utf8_validation::generic_validate_utf8_with_errors(buf,len);
 }
@@ -111,6 +115,14 @@ simdutf_warn_unused bool implementation::validate_utf16le(const char16_t *buf, s
   } else {
     return false;
   }
+}
+
+simdutf_warn_unused bool implementation::validate_utf16le_as_latin1(const char16_t *buf, size_t len) const noexcept {
+  return scalar::utf16::validate_as_latin1<endianness::BIG>(buf, len);
+}
+
+simdutf_warn_unused bool implementation::validate_utf16be_as_latin1(const char16_t *buf, size_t len) const noexcept {
+  return scalar::utf16::validate_as_latin1<endianness::BIG>(buf, len);
 }
 
 simdutf_warn_unused bool implementation::validate_utf16be(const char16_t *buf, size_t len) const noexcept {
@@ -149,6 +161,10 @@ simdutf_warn_unused bool implementation::validate_utf32(const char32_t *buf, siz
   } else {
     return false;
   }
+}
+
+simdutf_warn_unused bool implementation::validate_utf32_as_latin1(const char32_t *buf, size_t len) const noexcept {
+  return scalar::utf32::validate_as_latin1(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_utf32_with_errors(const char32_t *buf, size_t len) const noexcept {

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -190,6 +190,11 @@ simdutf_warn_unused bool implementation::validate_utf8(const char *buf, size_t l
     return ! checker.errors();
 }
 
+
+simdutf_warn_unused size_t implementation::latin1_length_from_utf8_with_validation(const char *buf, size_t len) const noexcept {
+  return scalar::utf8::validate_as_latin1(buf,len);
+}
+
 simdutf_warn_unused result implementation::validate_utf8_with_errors(const char *buf, size_t len) const noexcept {
     avx512_utf8_checker checker{};
     const char* ptr = buf;
@@ -334,6 +339,14 @@ simdutf_warn_unused bool implementation::validate_utf16be(const char16_t *buf, s
     return true;
 }
 
+simdutf_warn_unused bool implementation::validate_utf16le_as_latin1(const char16_t *buf, size_t len) const noexcept {
+  return scalar::utf16::validate_as_latin1<endianness::BIG>(buf, len);
+}
+
+simdutf_warn_unused bool implementation::validate_utf16be_as_latin1(const char16_t *buf, size_t len) const noexcept {
+  return scalar::utf16::validate_as_latin1<endianness::BIG>(buf, len);
+}
+
 simdutf_warn_unused result implementation::validate_utf16le_with_errors(const char16_t *buf, size_t len) const noexcept {
     const char16_t *start_buf = buf;
     const char16_t *end = buf + len;
@@ -439,6 +452,10 @@ simdutf_warn_unused bool implementation::validate_utf32(const char32_t *buf, siz
   } else {
     return false;
   }
+}
+
+simdutf_warn_unused bool implementation::validate_utf32_as_latin1(const char32_t *buf, size_t len) const noexcept {
+  return scalar::utf32::validate_as_latin1(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_utf32_with_errors(const char32_t *buf, size_t len) const noexcept {

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -89,6 +89,10 @@ simdutf_warn_unused bool implementation::validate_utf8(const char *buf, size_t l
   return ppc64::utf8_validation::generic_validate_utf8(buf,len);
 }
 
+simdutf_warn_unused size_t implementation::latin1_length_from_utf8_with_validation(const char *buf, size_t len) const noexcept {
+  return scalar::utf8::validate_as_latin1(buf,len);
+}
+
 simdutf_warn_unused result implementation::validate_utf8_with_errors(const char *buf, size_t len) const noexcept {
   return ppc64::utf8_validation::generic_validate_utf8_with_errors(buf,len);
 }
@@ -109,6 +113,14 @@ simdutf_warn_unused bool implementation::validate_utf16be(const char16_t *buf, s
   return scalar::utf16::validate<endianness::BIG>(buf, len);
 }
 
+simdutf_warn_unused bool implementation::validate_utf16le_as_latin1(const char16_t *buf, size_t len) const noexcept {
+  return scalar::utf16::validate_as_latin1<endianness::BIG>(buf, len);
+}
+
+simdutf_warn_unused bool implementation::validate_utf16be_as_latin1(const char16_t *buf, size_t len) const noexcept {
+  return scalar::utf16::validate_as_latin1<endianness::BIG>(buf, len);
+}
+
 simdutf_warn_unused result implementation::validate_utf16le_with_errors(const char16_t *buf, size_t len) const noexcept {
   return scalar::utf16::validate_with_errors<endianness::LITTLE>(buf, len);
 }
@@ -123,6 +135,10 @@ simdutf_warn_unused result implementation::validate_utf32_with_errors(const char
 
 simdutf_warn_unused bool implementation::validate_utf32(const char16_t *buf, size_t len) const noexcept {
   return scalar::utf32::validate(buf, len);
+}
+
+simdutf_warn_unused bool implementation::validate_utf32_as_latin1(const char32_t *buf, size_t len) const noexcept {
+  return scalar::utf32::validate_as_latin1(buf, len);
 }
 
 simdutf_warn_unused size_t implementation::convert_utf8_to_utf16le(const char* /*buf*/, size_t /*len*/, char16_t* /*utf16_output*/) const noexcept {

--- a/src/scalar/utf16.h
+++ b/src/scalar/utf16.h
@@ -32,6 +32,19 @@ inline simdutf_warn_unused bool validate(const char16_t *buf, size_t len) noexce
 }
 
 template <endianness big_endian>
+inline simdutf_warn_unused bool validate_as_latin1(const char32_t *buf, size_t len) noexcept {
+  const uint16_t *data = reinterpret_cast<const uint16_t *>(buf);
+  uint64_t pos = 0;
+  while (pos < len) {
+    uint16_t word = !match_system(big_endian) ? swap_bytes(data[pos]) : data[pos];
+    if(word > 0xFF) { return false; }
+    pos++;
+  }
+  return true;
+}
+
+
+template <endianness big_endian>
 inline simdutf_warn_unused result validate_with_errors(const char16_t *buf, size_t len) noexcept {
   const uint16_t *data = reinterpret_cast<const uint16_t *>(buf);
   size_t pos = 0;

--- a/src/scalar/utf32.h
+++ b/src/scalar/utf32.h
@@ -18,6 +18,18 @@ inline simdutf_warn_unused bool validate(const char32_t *buf, size_t len) noexce
   return true;
 }
 
+inline simdutf_warn_unused bool validate_as_latin1(const char32_t *buf, size_t len) noexcept {
+  const uint32_t *data = reinterpret_cast<const uint32_t *>(buf);
+  uint64_t pos = 0;
+  for(;pos < len; pos++) {
+    uint32_t word = data[pos];
+    if(word > 0xFF) {
+        return false;
+    }
+  }
+  return true;
+}
+
 inline simdutf_warn_unused result validate_with_errors(const char32_t *buf, size_t len) noexcept {
   const uint32_t *data = reinterpret_cast<const uint32_t *>(buf);
   size_t pos = 0;

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -93,6 +93,10 @@ simdutf_warn_unused bool implementation::validate_utf8(const char *buf, size_t l
   return westmere::utf8_validation::generic_validate_utf8(buf, len);
 }
 
+simdutf_warn_unused size_t implementation::latin1_length_from_utf8_with_validation(const char *buf, size_t len) const noexcept {
+  return scalar::utf8::validate_as_latin1(buf,len);
+}
+
 simdutf_warn_unused result implementation::validate_utf8_with_errors(const char *buf, size_t len) const noexcept {
   return westmere::utf8_validation::generic_validate_utf8_with_errors(buf, len);
 }
@@ -123,6 +127,14 @@ simdutf_warn_unused bool implementation::validate_utf16be(const char16_t *buf, s
   }
 }
 
+simdutf_warn_unused bool implementation::validate_utf16le_as_latin1(const char16_t *buf, size_t len) const noexcept {
+  return scalar::utf16::validate_as_latin1<endianness::BIG>(buf, len);
+}
+
+simdutf_warn_unused bool implementation::validate_utf16be_as_latin1(const char16_t *buf, size_t len) const noexcept {
+  return scalar::utf16::validate_as_latin1<endianness::BIG>(buf, len);
+}
+
 simdutf_warn_unused result implementation::validate_utf16le_with_errors(const char16_t *buf, size_t len) const noexcept {
   result res = sse_validate_utf16_with_errors<endianness::LITTLE>(buf, len);
   if (res.count != len) {
@@ -150,6 +162,10 @@ simdutf_warn_unused bool implementation::validate_utf32(const char32_t *buf, siz
   } else {
     return false;
   }
+}
+
+simdutf_warn_unused bool implementation::validate_utf32_as_latin1(const char32_t *buf, size_t len) const noexcept {
+  return scalar::utf32::validate_as_latin1(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_utf32_with_errors(const char32_t *buf, size_t len) const noexcept {


### PR DESCRIPTION
The general idea is that we should be able to validate UTF-32, UTF-16 and UTF-8 string 'as Latin 1' meaning that the string must be both in the expected format, and it must be safely convertible to Latin 1. In the UTF-16 and UTF-32 cases, validation is sufficient because if you are going to convert to Latin 1, you know the output size immediately. These cases are easy.

In the UTF-8 case, it is more complicated. Right now, I have a function called  `latin1_length_from_utf8_with_validation` so that when the input is both UTF-8 and convertible to Latin 1, you get the expected Latin 1, otherwise you get zero (indicating an error).

I have mixed feelings about this PR because it adds a whole lot of specialized functions. It increases the complexity of the library.

Fix  https://github.com/simdutf/simdutf/issues/300