### PR TITLE
This introduces fast UTF16/UTF32 to Latin 1 to our arm kernel

### DIFF
--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -708,7 +708,7 @@ void Benchmark::run_validate_utf16(const simdutf::implementation& implementation
     const auto result = count_events(proc, iterations);
     if((sink == false) && (iterations > 0)) { std::cerr << "The input was declared invalid.\n"; }
     size_t char_count = get_active_implementation()->count_utf16le(data, size);
-    print_summary(result, size, char_count);
+    print_summary(result, input_data.size(), char_count);
 }
 
 void Benchmark::run_validate_utf16_with_errors(const simdutf::implementation& implementation, size_t iterations) {
@@ -733,7 +733,7 @@ void Benchmark::run_validate_utf16_with_errors(const simdutf::implementation& im
     const auto result = count_events(proc, iterations);
     if((sink == false) && (iterations > 0)) { std::cerr << "The input was declared invalid.\n"; }
     size_t char_count = get_active_implementation()->count_utf16le(data, size);
-    print_summary(result, size, char_count);
+    print_summary(result, input_data.size(), char_count);
 }
 
 void Benchmark::run_validate_utf32(const simdutf::implementation& implementation, size_t iterations) {
@@ -757,7 +757,7 @@ void Benchmark::run_validate_utf32(const simdutf::implementation& implementation
     const auto result = count_events(proc, iterations);
     if((sink == false) && (iterations > 0)) { std::cerr << "The input was declared invalid.\n"; }
     size_t char_count = size;
-    print_summary(result, size, char_count);
+    print_summary(result, input_data.size(), char_count);
 }
 
 void Benchmark::run_validate_utf32_with_errors(const simdutf::implementation& implementation, size_t iterations) {
@@ -782,7 +782,7 @@ void Benchmark::run_validate_utf32_with_errors(const simdutf::implementation& im
     const auto result = count_events(proc, iterations);
     if((sink == false) && (iterations > 0)) { std::cerr << "The input was declared invalid.\n"; }
     size_t char_count = size;
-    print_summary(result, size, char_count);
+    print_summary(result, input_data.size(), char_count);
 }
 
 void Benchmark::run_convert_latin1_to_utf8(const simdutf::implementation& implementation, size_t iterations) {
@@ -1308,7 +1308,7 @@ void Benchmark::run_convert_utf16_to_latin1_icu(size_t iterations) {
         for(size_t i=0; i<20; i++) { std::cout << std::hex << static_cast<int>(output_buffer[i]) << " "; }
     }
 
-    print_summary(result, size, char_count);
+    print_summary(result, input_data.size(), char_count);
 }
 
 void Benchmark::run_convert_utf32_to_latin1_icu(size_t iterations) {
@@ -1372,7 +1372,7 @@ void Benchmark::run_convert_utf32_to_latin1_icu(size_t iterations) {
         for(size_t i=0; i<20; i++) { std::cout << std::hex << static_cast<int>(output_buffer[i]) << " "; }
     }
 
-    print_summary(result, size, char_count);
+    print_summary(result, input_data.size(), char_count);
 }
 
 
@@ -1447,7 +1447,7 @@ void Benchmark::run_convert_latin1_to_utf16_iconv(size_t iterations) {
 }
 
 void Benchmark::run_convert_latin1_to_utf32_iconv(size_t iterations) {
-    iconv_t cv = iconv_open("UTF-32", "ISO-8859-1");
+    iconv_t cv = iconv_open("UTF-32LE", "ISO-8859-1");
     if (cv == (iconv_t)(-1)) {
         fprintf( stderr,"[iconv] cannot initialize ISO-8859-1 to UTF-32 converter\n");
         return;
@@ -1653,7 +1653,7 @@ void Benchmark::run_convert_utf16_to_utf8_iconv(size_t iterations) {
 }
 
 void Benchmark::run_convert_utf32_to_latin1_iconv(size_t iterations) {
-    iconv_t cv = iconv_open("ISO-8859-1", "UTF-32");
+    iconv_t cv = iconv_open("ISO-8859-1", "UTF-32LE");
     if (cv == (iconv_t)(-1)) {
         fprintf( stderr,"[iconv] cannot initialize the UTF-32 to ISO-8859-1 converter\n");
         return;
@@ -1688,6 +1688,7 @@ void Benchmark::run_convert_utf32_to_latin1_iconv(size_t iterations) {
         size_t result = iconv(cv, &inptr, &inbytes, &outptr, &outbytes);
         if (result == static_cast<size_t>(-1)) {
             sink = 0;
+            abort();
         } else {
             sink = ( size - outbytes) / sizeof(char32_t);
         }
@@ -2192,7 +2193,7 @@ void Benchmark::run_convert_utf16_to_latin1(const simdutf::implementation& imple
     const auto result = count_events(proc, iterations);
     if((sink == 0) && (size != 0) && (iterations > 0)) { std::cerr << "The output is zero which might indicate an error.\n"; }
     size_t char_count = get_active_implementation()->count_utf16le(data, size);
-    print_summary(result, size, char_count);
+    print_summary(result, input_data.size(), char_count);
 }
 
 void Benchmark::run_convert_utf16_to_latin1_with_errors(const simdutf::implementation& implementation, size_t iterations) {
@@ -2216,7 +2217,7 @@ void Benchmark::run_convert_utf16_to_latin1_with_errors(const simdutf::implement
     const auto result = count_events(proc, iterations);
     if((sink == false) && (iterations > 0)) { std::cerr << "The input was declared invalid.\n"; }
     size_t char_count = get_active_implementation()->count_utf16le(data, size);
-    print_summary(result, size, char_count);
+    print_summary(result, input_data.size(), char_count);
 }
 
 void Benchmark::run_convert_valid_utf16_to_latin1(const simdutf::implementation& implementation, size_t iterations) {
@@ -2239,7 +2240,7 @@ void Benchmark::run_convert_valid_utf16_to_latin1(const simdutf::implementation&
     const auto result = count_events(proc, iterations);
     if((sink == 0) && (size != 0) && (iterations > 0)) { std::cerr << "The output is zero which might indicate an error.\n"; }
     size_t char_count = get_active_implementation()->count_utf16le(data, size);
-    print_summary(result, size, char_count);
+    print_summary(result, input_data.size(), char_count);
 }
 
 void Benchmark::run_convert_utf16_to_utf8(const simdutf::implementation& implementation, size_t iterations) {
@@ -2468,7 +2469,7 @@ void Benchmark::run_convert_utf32_to_latin1(const simdutf::implementation& imple
     const auto result = count_events(proc, iterations);
     if((sink == 0) && (size != 0) && (iterations > 0)) { std::cerr << "The output is zero which might indicate an error.\n"; }
     size_t char_count = size;
-    print_summary(result, size, char_count);
+    print_summary(result, input_data.size(), char_count);
 }
 void Benchmark::run_convert_utf32_to_latin1_with_errors(const simdutf::implementation& implementation, size_t iterations) {
     const simdutf::encoding_type bom  = BOM::check_bom(input_data.data(), input_data.size());
@@ -2492,7 +2493,7 @@ void Benchmark::run_convert_utf32_to_latin1_with_errors(const simdutf::implement
     const auto result = count_events(proc, iterations);
     if((sink == false) && (iterations > 0)) { std::cerr << "The input was declared invalid.\n"; }
     size_t char_count = size;
-    print_summary(result, size, char_count);
+    print_summary(result, input_data.size(), char_count);
 }
 void Benchmark::run_convert_valid_utf32_to_latin1(const simdutf::implementation& implementation, size_t iterations) {
     const simdutf::encoding_type bom  = BOM::check_bom(input_data.data(), input_data.size());
@@ -2515,7 +2516,7 @@ void Benchmark::run_convert_valid_utf32_to_latin1(const simdutf::implementation&
     const auto result = count_events(proc, iterations);
     if((sink == 0) && (size != 0) && (iterations > 0)) { std::cerr << "The output is zero which might indicate an error.\n"; }
     size_t char_count = size;
-    print_summary(result, size, char_count);
+    print_summary(result, input_data.size(), char_count);
 }
 
 void Benchmark::run_convert_utf32_to_utf8(const simdutf::implementation& implementation, size_t iterations) {

--- a/src/arm64/arm_convert_utf16_to_latin1.cpp
+++ b/src/arm64/arm_convert_utf16_to_latin1.cpp
@@ -1,0 +1,65 @@
+
+template <endianness big_endian>
+std::pair<const char16_t*, char*> arm_convert_utf16_to_latin1(const char16_t* buf, size_t len, char* latin1_output) {
+  const char16_t* end = buf + len;
+  while (buf + 8 <= end) {
+    uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
+    if (!match_system(big_endian)) {
+      #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
+      const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
+      #else
+      const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
+      #endif
+      in = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(in), swap));
+    }
+    if (vmaxvq_u16(in) <= 0xff) {
+        // 1. pack the bytes
+        uint8x8_t latin1_packed = vmovn_u16(in);
+        // 2. store (8 bytes)
+        vst1_u8(reinterpret_cast<uint8_t*>(latin1_output), latin1_packed);
+        // 3. adjust pointers
+        buf += 8;
+        latin1_output += 8;
+    } else {
+      return std::make_pair(nullptr, reinterpret_cast<char*>(latin1_output));
+    }
+  } // while
+  return std::make_pair(buf, latin1_output);
+}
+
+template <endianness big_endian>
+std::pair<result, char*> arm_convert_utf16_to_latin1_with_errors(const char16_t* buf, size_t len, char* latin1_output) {
+  const char16_t* start = buf;
+  const char16_t* end = buf + len;
+  while (buf + 8 <= end) {
+    uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
+    if (!match_system(big_endian)) {
+      #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
+      const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
+      #else
+      const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
+      #endif
+      in = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(in), swap));
+    }
+    if (vmaxvq_u16(in) <= 0xff) {
+        // 1. pack the bytes
+        uint8x8_t latin1_packed = vmovn_u16(in);
+        // 2. store (8 bytes)
+        vst1_u8(reinterpret_cast<uint8_t*>(latin1_output), latin1_packed);
+        // 3. adjust pointers
+        buf += 8;
+        latin1_output += 8;
+    } else {
+      // Let us do a scalar fallback.
+      for(int k = 0; k < 8; k++) {
+        uint16_t word = !match_system(big_endian) ? scalar::utf16::swap_bytes(buf[k]) : buf[k];
+        if(word <= 0xff) {
+          *latin1_output++ = char(word);
+        } else {
+          return std::make_pair(result(error_code::TOO_LARGE, buf - start + k), latin1_output);
+        }
+      }
+    }
+  } // while
+  return std::make_pair(result(error_code::SUCCESS, buf - start), latin1_output);
+}

--- a/src/arm64/arm_convert_utf16_to_latin1.cpp
+++ b/src/arm64/arm_convert_utf16_to_latin1.cpp
@@ -4,14 +4,7 @@ std::pair<const char16_t*, char*> arm_convert_utf16_to_latin1(const char16_t* bu
   const char16_t* end = buf + len;
   while (buf + 8 <= end) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
-    if (!match_system(big_endian)) {
-      #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-      const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-      #else
-      const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
-      #endif
-      in = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(in), swap));
-    }
+    if (!match_system(big_endian)) { in = vrev16q_u8(in); }
     if (vmaxvq_u16(in) <= 0xff) {
         // 1. pack the bytes
         uint8x8_t latin1_packed = vmovn_u16(in);
@@ -33,14 +26,7 @@ std::pair<result, char*> arm_convert_utf16_to_latin1_with_errors(const char16_t*
   const char16_t* end = buf + len;
   while (buf + 8 <= end) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
-    if (!match_system(big_endian)) {
-      #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-      const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-      #else
-      const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
-      #endif
-      in = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(in), swap));
-    }
+    if (!match_system(big_endian)) { in = vrev16q_u8(in); }
     if (vmaxvq_u16(in) <= 0xff) {
         // 1. pack the bytes
         uint8x8_t latin1_packed = vmovn_u16(in);

--- a/src/arm64/arm_convert_utf16_to_utf32.cpp
+++ b/src/arm64/arm_convert_utf16_to_utf32.cpp
@@ -60,14 +60,7 @@ std::pair<const char16_t*, char32_t*> arm_convert_utf16_to_utf32(const char16_t*
 
   while (buf + 8 <= end) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
-    if (!match_system(big_endian)) {
-      #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-      const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-      #else
-      const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
-      #endif
-      in = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(in), swap));
-    }
+    if (!match_system(big_endian)) { in = vrev16q_u8(in); }
 
     const uint16x8_t surrogates_bytemask = vceqq_u16(vandq_u16(in, v_f800), v_d800);
     // It might seem like checking for surrogates_bitmask == 0xc000 could help. However,
@@ -125,14 +118,7 @@ std::pair<result, char32_t*> arm_convert_utf16_to_utf32_with_errors(const char16
 
   while (buf + 8 <= end) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
-    if (!match_system(big_endian)) {
-      #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-      const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-      #else
-      const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
-      #endif
-      in = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(in), swap));
-    }
+    if (!match_system(big_endian)) { in = vrev16q_u8(in); }
 
     const uint16x8_t surrogates_bytemask = vceqq_u16(vandq_u16(in, v_f800), v_d800);
     // It might seem like checking for surrogates_bitmask == 0xc000 could help. However,

--- a/src/arm64/arm_convert_utf16_to_utf32.cpp
+++ b/src/arm64/arm_convert_utf16_to_utf32.cpp
@@ -58,7 +58,7 @@ std::pair<const char16_t*, char32_t*> arm_convert_utf16_to_utf32(const char16_t*
   const uint16x8_t v_f800 = vmovq_n_u16((uint16_t)0xf800);
   const uint16x8_t v_d800 = vmovq_n_u16((uint16_t)0xd800);
 
-  while (buf + 16 <= end) {
+  while (buf + 8 <= end) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
     if (!match_system(big_endian)) {
       #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
@@ -72,7 +72,7 @@ std::pair<const char16_t*, char32_t*> arm_convert_utf16_to_utf32(const char16_t*
     const uint16x8_t surrogates_bytemask = vceqq_u16(vandq_u16(in, v_f800), v_d800);
     // It might seem like checking for surrogates_bitmask == 0xc000 could help. However,
     // it is likely an uncommon occurrence.
-      if (vmaxvq_u16(surrogates_bytemask) == 0) {
+    if (vmaxvq_u16(surrogates_bytemask) == 0) {
       // case: no surrogate pairs, extend all 16-bit code units to 32-bit code units
       vst1q_u32(utf32_output,  vmovl_u16(vget_low_u16(in)));
       vst1q_u32(utf32_output+4,  vmovl_high_u16(in));
@@ -123,7 +123,7 @@ std::pair<result, char32_t*> arm_convert_utf16_to_utf32_with_errors(const char16
   const uint16x8_t v_f800 = vmovq_n_u16((uint16_t)0xf800);
   const uint16x8_t v_d800 = vmovq_n_u16((uint16_t)0xd800);
 
-  while (buf + 16 <= end) {
+  while (buf + 8 <= end) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
     if (!match_system(big_endian)) {
       #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
@@ -137,7 +137,7 @@ std::pair<result, char32_t*> arm_convert_utf16_to_utf32_with_errors(const char16
     const uint16x8_t surrogates_bytemask = vceqq_u16(vandq_u16(in, v_f800), v_d800);
     // It might seem like checking for surrogates_bitmask == 0xc000 could help. However,
     // it is likely an uncommon occurrence.
-      if (vmaxvq_u16(surrogates_bytemask) == 0) {
+    if (vmaxvq_u16(surrogates_bytemask) == 0) {
       // case: no surrogate pairs, extend all 16-bit code units to 32-bit code units
       vst1q_u32(utf32_output,  vmovl_u16(vget_low_u16(in)));
       vst1q_u32(utf32_output+4,  vmovl_high_u16(in));

--- a/src/arm64/arm_convert_utf16_to_utf8.cpp
+++ b/src/arm64/arm_convert_utf16_to_utf8.cpp
@@ -154,8 +154,8 @@ std::pair<const char16_t*, char*> arm_convert_utf16_to_utf8(const char16_t* buf,
     const uint16x8_t surrogates_bytemask = vceqq_u16(vandq_u16(in, v_f800), v_d800);
     // It might seem like checking for surrogates_bitmask == 0xc000 could help. However,
     // it is likely an uncommon occurrence.
-      if (vmaxvq_u16(surrogates_bytemask) == 0) {
-      // case: code units from register produce either 1, 2 or 3 UTF-8 bytes
+    if (vmaxvq_u16(surrogates_bytemask) == 0) {
+        // case: code units from register produce either 1, 2 or 3 UTF-8 bytes
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
         const uint16x8_t dup_even = make_uint16x8_t(0x0000, 0x0202, 0x0404, 0x0606,
                                      0x0808, 0x0a0a, 0x0c0c, 0x0e0e);
@@ -421,8 +421,8 @@ std::pair<result, char*> arm_convert_utf16_to_utf8_with_errors(const char16_t* b
     const uint16x8_t surrogates_bytemask = vceqq_u16(vandq_u16(in, v_f800), v_d800);
     // It might seem like checking for surrogates_bitmask == 0xc000 could help. However,
     // it is likely an uncommon occurrence.
-      if (vmaxvq_u16(surrogates_bytemask) == 0) {
-      // case: code units from register produce either 1, 2 or 3 UTF-8 bytes
+    if (vmaxvq_u16(surrogates_bytemask) == 0) {
+        // case: code units from register produce either 1, 2 or 3 UTF-8 bytes
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
         const uint16x8_t dup_even = make_uint16x8_t(0x0000, 0x0202, 0x0404, 0x0606,
                                      0x0808, 0x0a0a, 0x0c0c, 0x0e0e);

--- a/src/arm64/arm_convert_utf16_to_utf8.cpp
+++ b/src/arm64/arm_convert_utf16_to_utf8.cpp
@@ -61,25 +61,11 @@ std::pair<const char16_t*, char*> arm_convert_utf16_to_utf8(const char16_t* buf,
 
   while (buf + 16 <= end) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
-    if (!match_system(big_endian)) {
-      #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-      const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-      #else
-      const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
-      #endif
-      in = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(in), swap));
-    }
+    if (!match_system(big_endian)) { in = vrev16q_u8(in); }
     if(vmaxvq_u16(in) <= 0x7F) { // ASCII fast path!!!!
         // It is common enough that we have sequences of 16 consecutive ASCII characters.
         uint16x8_t nextin = vld1q_u16(reinterpret_cast<const uint16_t *>(buf) + 8);
-        if (!match_system(big_endian)) {
-          #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-          const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-          #else
-          const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
-          #endif
-          nextin = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(nextin), swap));
-        }
+        if (!match_system(big_endian)) { nextin = vrev16q_u8(nextin); }
         if(vmaxvq_u16(nextin) > 0x7F) {
           // 1. pack the bytes
           // obviously suboptimal.
@@ -328,25 +314,11 @@ std::pair<result, char*> arm_convert_utf16_to_utf8_with_errors(const char16_t* b
 
   while (buf + 16 <= end) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
-    if (!match_system(big_endian)) {
-      #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-      const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-      #else
-      const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
-      #endif
-      in = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(in), swap));
-    }
+    if (!match_system(big_endian)) { in = vrev16q_u8(in); }
     if(vmaxvq_u16(in) <= 0x7F) { // ASCII fast path!!!!
         // It is common enough that we have sequences of 16 consecutive ASCII characters.
         uint16x8_t nextin = vld1q_u16(reinterpret_cast<const uint16_t *>(buf) + 8);
-        if (!match_system(big_endian)) {
-          #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-          const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-          #else
-          const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
-          #endif
-          nextin = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(nextin), swap));
-        }
+        if (!match_system(big_endian)) { nextin = vrev16q_u8(nextin); }
         if(vmaxvq_u16(nextin) > 0x7F) {
           // 1. pack the bytes
           // obviously suboptimal.

--- a/src/arm64/arm_convert_utf32_to_latin1.cpp
+++ b/src/arm64/arm_convert_utf32_to_latin1.cpp
@@ -1,0 +1,55 @@
+std::pair<const char32_t*, char*> arm_convert_utf32_to_latin1(const char32_t* buf, size_t len, char* latin1_output) {
+  const char32_t* end = buf + len;
+  while (buf + 8 <= end) {
+    uint32x4_t in1 = vld1q_u32(reinterpret_cast<const uint32_t *>(buf));
+    uint32x4_t in2 = vld1q_u32(reinterpret_cast<const uint32_t *>(buf+4));
+
+    uint16x8_t utf16_packed = vcombine_u16(vqmovn_u32(in1), vqmovn_u32(in2));
+    if (vmaxvq_u16(utf16_packed) <= 0xff) {
+        // 1. pack the bytes
+        uint8x8_t latin1_packed = vmovn_u16(utf16_packed);
+        // 2. store (8 bytes)
+        vst1_u8(reinterpret_cast<uint8_t*>(latin1_output), latin1_packed);
+        // 3. adjust pointers
+        buf += 8;
+        latin1_output += 8;
+    } else {
+      return std::make_pair(nullptr, reinterpret_cast<char*>(latin1_output));
+    }
+  } // while
+  return std::make_pair(buf, latin1_output);
+}
+
+
+std::pair<result, char*> arm_convert_utf32_to_latin1_with_errors(const char32_t* buf, size_t len, char* latin1_output) {
+  const char32_t* start = buf;
+  const char32_t* end = buf + len;
+
+  while (buf + 8 <= end) {
+    uint32x4_t in1 = vld1q_u32(reinterpret_cast<const uint32_t *>(buf));
+    uint32x4_t in2 = vld1q_u32(reinterpret_cast<const uint32_t *>(buf+4));
+
+    uint16x8_t utf16_packed = vcombine_u16(vqmovn_u32(in1), vqmovn_u32(in2));
+
+    if (vmaxvq_u16(utf16_packed) <= 0xff) {
+        // 1. pack the bytes
+        uint8x8_t latin1_packed = vmovn_u16(utf16_packed);
+        // 2. store (8 bytes)
+        vst1_u8(reinterpret_cast<uint8_t*>(latin1_output), latin1_packed);
+        // 3. adjust pointers
+        buf += 8;
+        latin1_output += 8;
+    } else {
+      // Let us do a scalar fallback.
+      for(int k = 0; k < 8; k++) {
+        uint32_t word = buf[k];
+        if(word <= 0xff) {
+          *latin1_output++ = char(word);
+        } else {
+          return std::make_pair(result(error_code::TOO_LARGE, buf - start + k), latin1_output);
+        }
+      }
+    }
+  } // while
+  return std::make_pair(result(error_code::SUCCESS, buf - start), latin1_output);
+}

--- a/src/arm64/arm_convert_utf32_to_utf16.cpp
+++ b/src/arm64/arm_convert_utf32_to_utf16.cpp
@@ -16,14 +16,7 @@ std::pair<const char32_t*, char16_t*> arm_convert_utf32_to_utf16(const char32_t*
       const uint16x4_t v_dfff = vmov_n_u16((uint16_t)0xdfff);
       forbidden_bytemask = vorr_u16(vand_u16(vcle_u16(utf16_packed, v_dfff), vcge_u16(utf16_packed, v_d800)), forbidden_bytemask);
 
-      if (!match_system(big_endian)) {
-        #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-        const uint8x8_t swap = make_uint8x8_t(1, 0, 3, 2, 5, 4, 7, 6);
-        #else
-        const uint8x8_t swap = {1, 0, 3, 2, 5, 4, 7, 6};
-        #endif
-        utf16_packed = vreinterpret_u16_u8(vtbl1_u8(vreinterpret_u8_u16(utf16_packed), swap));
-      }
+      if (!match_system(big_endian)) { utf16_packed = vrev16_u8(utf16_packed); }
       vst1_u16(utf16_output, utf16_packed);
       utf16_output += 4;
       buf += 4;
@@ -84,14 +77,7 @@ std::pair<result, char16_t*> arm_convert_utf32_to_utf16_with_errors(const char32
         return std::make_pair(result(error_code::SURROGATE, buf - start), reinterpret_cast<char16_t*>(utf16_output));
       }
 
-      if (!match_system(big_endian)) {
-        #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-        const uint8x8_t swap = make_uint8x8_t(1, 0, 3, 2, 5, 4, 7, 6);
-        #else
-        const uint8x8_t swap = {1, 0, 3, 2, 5, 4, 7, 6};
-        #endif
-        utf16_packed = vreinterpret_u16_u8(vtbl1_u8(vreinterpret_u8_u16(utf16_packed), swap));
-      }
+      if (!match_system(big_endian)) { utf16_packed = vrev16_u8(utf16_packed); }
       vst1_u16(utf16_output, utf16_packed);
       utf16_output += 4;
       buf += 4;

--- a/src/arm64/arm_validate_utf16.cpp
+++ b/src/arm64/arm_validate_utf16.cpp
@@ -12,13 +12,8 @@ const char16_t* arm_validate_utf16(const char16_t* input, size_t size) {
         auto in0 = simd16<uint16_t>(input);
         auto in1 = simd16<uint16_t>(input + simd16<uint16_t>::SIZE / sizeof(char16_t));
         if (!match_system(big_endian)) {
-            #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-            const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-            #else
-            const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
-            #endif
-            in0 = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(in0), swap));
-            in1 = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(in1), swap));
+            in0 = vrev16q_u8(in0);
+            in1 = vrev16q_u8(in1);
         }
         const auto t0 = in0.shr<8>();
         const auto t1 = in1.shr<8>();
@@ -88,13 +83,8 @@ const result arm_validate_utf16_with_errors(const char16_t* input, size_t size) 
         auto in1 = simd16<uint16_t>(input + simd16<uint16_t>::SIZE / sizeof(char16_t));
 
         if (!match_system(big_endian)) {
-            #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-            const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-            #else
-            const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
-            #endif
-            in0 = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(in0), swap));
-            in1 = vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(in1), swap));
+            in0 = vrev16q_u8(in0);
+            in1 = vrev16q_u8(in1);
         }
         const auto t0 = in0.shr<8>();
         const auto t1 = in1.shr<8>();

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -113,9 +113,11 @@ simdutf_really_inline uint16x8_t convert_utf8_1_to_2_byte_to_utf16(uint8x16_t in
 #include "arm64/arm_convert_utf8_to_utf32.cpp"
 #include "arm64/arm_convert_utf8_to_latin1.cpp"
 
+#include "arm64/arm_convert_utf16_to_latin1.cpp"
 #include "arm64/arm_convert_utf16_to_utf8.cpp"
 #include "arm64/arm_convert_utf16_to_utf32.cpp"
 
+#include "arm64/arm_convert_utf32_to_latin1.cpp"
 #include "arm64/arm_convert_utf32_to_utf8.cpp"
 #include "arm64/arm_convert_utf32_to_utf16.cpp"
 } // unnamed namespace
@@ -312,19 +314,65 @@ simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf32(const cha
 }
 
 simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf16_to_latin1::convert<endianness::LITTLE>(buf, len, latin1_output);
+  std::pair<const char16_t*, char*> ret = arm_convert_utf16_to_latin1<endianness::LITTLE>(buf, len, latin1_output);
+  if (ret.first == nullptr) { return 0; }
+  size_t saved_bytes = ret.second - latin1_output;
+
+  if (ret.first != buf + len) {
+    const size_t scalar_saved_bytes = scalar::utf16_to_latin1::convert<endianness::LITTLE>(
+                                        ret.first, len - (ret.first - buf), ret.second);
+    if (scalar_saved_bytes == 0) { return 0; }
+    saved_bytes += scalar_saved_bytes;
+  }
+  return saved_bytes;
 }
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf16_to_latin1::convert<endianness::BIG>(buf, len, latin1_output);
+  std::pair<const char16_t*, char*> ret = arm_convert_utf16_to_latin1<endianness::BIG>(buf, len, latin1_output);
+  if (ret.first == nullptr) { return 0; }
+  size_t saved_bytes = ret.second - latin1_output;
+
+  if (ret.first != buf + len) {
+    const size_t scalar_saved_bytes = scalar::utf16_to_latin1::convert<endianness::BIG>(
+                                        ret.first, len - (ret.first - buf), ret.second);
+    if (scalar_saved_bytes == 0) { return 0; }
+    saved_bytes += scalar_saved_bytes;
+  }
+  return saved_bytes;
 }
 
 simdutf_warn_unused result implementation::convert_utf16le_to_latin1_with_errors(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf16_to_latin1::convert_with_errors<endianness::LITTLE>(buf, len, latin1_output);
+  std::pair<result, char*> ret = arm_convert_utf16_to_latin1_with_errors<endianness::LITTLE>(buf, len, latin1_output);
+  if (ret.first.error) { return ret.first; }  // Can return directly since scalar fallback already found correct ret.first.count
+  if (ret.first.count != len) { // All good so far, but not finished
+    result scalar_res = scalar::utf16_to_latin1::convert_with_errors<endianness::LITTLE>(
+                                        buf + ret.first.count, len - ret.first.count, ret.second);
+    if (scalar_res.error) {
+      scalar_res.count += ret.first.count;
+      return scalar_res;
+    } else {
+      ret.second += scalar_res.count;
+    }
+  }
+  ret.first.count = ret.second - latin1_output;   // Set count to the number of 8-bit code units written
+  return ret.first;
 }
 
 simdutf_warn_unused result implementation::convert_utf16be_to_latin1_with_errors(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf16_to_latin1::convert_with_errors<endianness::BIG>(buf, len, latin1_output);
+  std::pair<result, char*> ret = arm_convert_utf16_to_latin1_with_errors<endianness::BIG>(buf, len, latin1_output);
+  if (ret.first.error) { return ret.first; }  // Can return directly since scalar fallback already found correct ret.first.count
+  if (ret.first.count != len) { // All good so far, but not finished
+    result scalar_res = scalar::utf16_to_latin1::convert_with_errors<endianness::BIG>(
+                                        buf + ret.first.count, len - ret.first.count, ret.second);
+    if (scalar_res.error) {
+      scalar_res.count += ret.first.count;
+      return scalar_res;
+    } else {
+      ret.second += scalar_res.count;
+    }
+  }
+  ret.first.count = ret.second - latin1_output;   // Set count to the number of 8-bit code units written
+  return ret.first;
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16be_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
@@ -498,11 +546,34 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf32_with_errors(
 }
 
 simdutf_warn_unused size_t implementation::convert_utf32_to_latin1(const char32_t* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf32_to_latin1::convert(buf,len,latin1_output);
+  std::pair<const char32_t*, char*> ret = arm_convert_utf32_to_latin1(buf, len, latin1_output);
+  if (ret.first == nullptr) { return 0; }
+  size_t saved_bytes = ret.second - latin1_output;
+
+  if (ret.first != buf + len) {
+    const size_t scalar_saved_bytes = scalar::utf32_to_latin1::convert(
+                                        ret.first, len - (ret.first - buf), ret.second);
+    if (scalar_saved_bytes == 0) { return 0; }
+    saved_bytes += scalar_saved_bytes;
+  }
+  return saved_bytes;
 }
 
 simdutf_warn_unused result implementation::convert_utf32_to_latin1_with_errors(const char32_t* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf32_to_latin1::convert_with_errors(buf,len,latin1_output);
+  std::pair<result, char*> ret = arm_convert_utf32_to_latin1_with_errors(buf, len, latin1_output);
+  if (ret.first.error) { return ret.first; }  // Can return directly since scalar fallback already found correct ret.first.count
+  if (ret.first.count != len) { // All good so far, but not finished
+    result scalar_res = scalar::utf32_to_latin1::convert_with_errors(
+                                        buf + ret.first.count, len - ret.first.count, ret.second);
+    if (scalar_res.error) {
+      scalar_res.count += ret.first.count;
+      return scalar_res;
+    } else {
+      ret.second += scalar_res.count;
+    }
+  }
+  ret.first.count = ret.second - latin1_output;   // Set count to the number of 8-bit code units written
+  return ret.first;
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf32_to_latin1(const char32_t* buf, size_t len, char* latin1_output) const noexcept {

--- a/src/simdutf/arm64/simd16-inl.h
+++ b/src/simdutf/arm64/simd16-inl.h
@@ -163,12 +163,7 @@ struct simd16<uint16_t>: base16_numeric<uint16_t>  {
 
   // Change the endianness
   simdutf_really_inline simd16<uint16_t> swap_bytes() const {
-    #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
-    const uint8x16_t swap = make_uint8x16_t(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-    #else
-    const uint8x16_t swap = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
-    #endif
-    return vreinterpretq_u16_u8(vqtbl1q_u8(vreinterpretq_u8_u16(*this), swap));
+    return vreinterpretq_u16_u8(vrev16q_u8((*this)));
   }
 };
 simdutf_really_inline simd16<int16_t>::operator simd16<uint16_t>() const { return this->value; }

--- a/src/westmere/sse_convert_utf16_to_utf32.cpp
+++ b/src/westmere/sse_convert_utf16_to_utf32.cpp
@@ -58,7 +58,7 @@ std::pair<const char16_t*, char32_t*> sse_convert_utf16_to_utf32(const char16_t*
   const __m128i v_f800 = _mm_set1_epi16((int16_t)0xf800);
   const __m128i v_d800 = _mm_set1_epi16((int16_t)0xd800);
 
-  while (buf + 16 <= end) {
+  while (buf + 8 <= end) {
     __m128i in = _mm_loadu_si128((__m128i*)buf);
 
     if (big_endian) {
@@ -126,7 +126,7 @@ std::pair<result, char32_t*> sse_convert_utf16_to_utf32_with_errors(const char16
   const __m128i v_f800 = _mm_set1_epi16((int16_t)0xf800);
   const __m128i v_d800 = _mm_set1_epi16((int16_t)0xd800);
 
-  while (buf + 16 <= end) {
+  while (buf + 8 <= end) {
     __m128i in = _mm_loadu_si128((__m128i*)buf);
 
     if (big_endian) {


### PR DESCRIPTION
LLVM 14/Apple M2


UTF-32 to Latin 1
```
convert_utf32_to_latin1+arm64, input size: 1729220, iterations: 3000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin32.txt
   0.446 ins/byte,    0.061 cycle/byte,   58.290 GB/s (1.2 %),     3.549 GHz,    7.323 ins/cycle 
   1.784 ins/char,    0.244 cycle/char,   14.572 Gc/s (1.2 %)     4.00 byte/char 
convert_utf32_to_latin1+iconv, input size: 1729220, iterations: 3000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin32.txt
  13.008 ins/byte,    2.089 cycle/byte,    1.634 GB/s (6.0 %),     3.413 GHz,    6.227 ins/cycle 
  52.034 ins/char,    8.356 cycle/char,    0.408 Gc/s (6.0 %)     4.00 byte/char 
convert_utf32_to_latin1+icu, input size: 1729220, iterations: 3000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin32.txt
  16.655 ins/byte,    2.239 cycle/byte,    1.524 GB/s (5.8 %),     3.412 GHz,    7.438 ins/cycle 
  66.618 ins/char,    8.957 cycle/char,    0.381 Gc/s (5.8 %)     4.00 byte/char 
convert_utf32_to_latin1_with_errors+arm64, input size: 1729220, iterations: 3000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin32.txt
   0.415 ins/byte,    0.057 cycle/byte,   62.314 GB/s (1.1 %),     3.548 GHz,    7.284 ins/cycle 
   1.659 ins/char,    0.228 cycle/char,   15.579 Gc/s (1.1 %)     4.00 byte/char 
```

UTF-16 to Latin 1
```
convert_utf16_to_latin1+arm64, input size: 864610, iterations: 3000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   0.767 ins/byte,    0.099 cycle/byte,   36.340 GB/s (1.5 %),     3.611 GHz,    7.722 ins/cycle 
   1.534 ins/char,    0.199 cycle/char,   18.170 Gc/s (1.5 %)     2.00 byte/char 
convert_utf16_to_latin1+iconv, input size: 864610, iterations: 3000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin16.txt
  26.517 ins/byte,    4.209 cycle/byte,    0.811 GB/s (1.0 %),     3.413 GHz,    6.300 ins/cycle 
  53.034 ins/char,    8.418 cycle/char,    0.405 Gc/s (1.0 %)     2.00 byte/char 
convert_utf16_to_latin1+icu, input size: 864610, iterations: 3000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   1.677 ins/byte,    0.270 cycle/byte,   12.793 GB/s (2.2 %),     3.460 GHz,    6.199 ins/cycle 
   3.354 ins/char,    0.541 cycle/char,    6.397 Gc/s (2.2 %)     2.00 byte/char 
convert_utf16_to_latin1_with_errors+arm64, input size: 864610, iterations: 3000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   0.704 ins/byte,    0.090 cycle/byte,   39.752 GB/s (1.0 %),     3.595 GHz,    7.788 ins/cycle 
   1.409 ins/char,    0.181 cycle/char,   19.876 Gc/s (1.0 %)     2.00 byte/char 
```