### PR TITLE
SSE UTF16 => latin1

### DIFF
--- a/src/westmere/sse_convert_utf16_to_latin1.cpp
+++ b/src/westmere/sse_convert_utf16_to_latin1.cpp
@@ -1,0 +1,26 @@
+template <endianness big_endian>
+std::pair<const char16_t*, char*> sse_convert_utf16_to_latin1(const char16_t* buf, size_t len, char* latin1_output) {
+  const char16_t* end = buf + len;
+  while (buf + 8 <= end) {
+    // Load 8 UTF-16 characters into 128-bit SSE register
+    __m128i in = _mm_loadu_si128(reinterpret_cast<const __m128i*>(buf));
+
+    if (!match_system(big_endian)) {
+      const __m128i swap = _mm_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
+      in = _mm_shuffle_epi8(in, swap);
+    }
+
+    __m128i high_byte_mask = _mm_set1_epi16(0xFF00);
+    if (_mm_testz_si128(in, high_byte_mask)) {
+      // Pack 16-bit characters into 8-bit and store in latin1_output
+      __m128i latin1_packed = _mm_packus_epi16(in, in);
+      _mm_storel_epi64(reinterpret_cast<__m128i*>(latin1_output), latin1_packed);
+      // Adjust pointers for next iteration
+      buf += 8;
+      latin1_output += 8;
+    } else {
+      return std::make_pair(nullptr, reinterpret_cast<char*>(latin1_output));
+    }
+  } // while
+  return std::make_pair(buf, latin1_output);
+}

--- a/src/westmere/sse_convert_utf16_to_latin1.cpp
+++ b/src/westmere/sse_convert_utf16_to_latin1.cpp
@@ -10,7 +10,7 @@ std::pair<const char16_t*, char*> sse_convert_utf16_to_latin1(const char16_t* bu
       in = _mm_shuffle_epi8(in, swap);
     }
 
-    __m128i high_byte_mask = _mm_set1_epi16(0xFF00);
+    __m128i high_byte_mask = _mm_set1_epi16((int16_t)0xFF00);
     if (_mm_testz_si128(in, high_byte_mask)) {
       // Pack 16-bit characters into 8-bit and store in latin1_output
       __m128i latin1_packed = _mm_packus_epi16(in, in);

--- a/src/westmere/sse_convert_utf16_to_latin1.cpp
+++ b/src/westmere/sse_convert_utf16_to_latin1.cpp
@@ -24,3 +24,37 @@ std::pair<const char16_t*, char*> sse_convert_utf16_to_latin1(const char16_t* bu
   } // while
   return std::make_pair(buf, latin1_output);
 }
+
+template <endianness big_endian>
+std::pair<result, char*> sse_convert_utf16_to_latin1_with_errors(const char16_t* buf, size_t len, char* latin1_output) {
+  const char16_t* start = buf;
+  const char16_t* end = buf + len;
+  while (buf + 8 <= end) {
+    __m128i in = _mm_loadu_si128(reinterpret_cast<const __m128i*>(buf));
+
+    if (!big_endian) {
+      const __m128i swap = _mm_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
+      in = _mm_shuffle_epi8(in, swap);
+    }
+
+    __m128i high_byte_mask = _mm_set1_epi16((int16_t)0xFF00);
+    if (_mm_testz_si128(in, high_byte_mask)) {
+      __m128i latin1_packed = _mm_packus_epi16(in, in);
+      _mm_storel_epi64(reinterpret_cast<__m128i*>(latin1_output), latin1_packed);
+      buf += 8;
+      latin1_output += 8;
+    } else {
+      // Fallback to scalar code for handling errors
+      for(int k = 0; k < 8; k++) {
+        uint16_t word = !match_system(big_endian) ? scalar::utf16::swap_bytes(buf[k]) : buf[k];
+        if(word <= 0xff) {
+          *latin1_output++ = char(word);
+        } else {
+          return std::make_pair(result(error_code::TOO_LARGE, buf - start + k), latin1_output);
+        }
+      }
+      buf += 8;
+    }
+  } // while
+  return std::make_pair(result(error_code::SUCCESS, buf - start), latin1_output);
+}


### PR DESCRIPTION
EDIT: Benchmarks for lastest commits: 

```
convert_utf16_to_latin1+haswell, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   0.345 ins/byte,    0.407 cycle/byte,    7.853 GB/s (1.3 %),     3.198 GHz,    0.848 ins/cycle 
   0.345 ins/char,    0.407 cycle/char,    7.853 Gc/s (1.3 %)     1.00 byte/char 
convert_utf16_to_latin1+icelake, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   0.143 ins/byte,    0.448 cycle/byte,    6.909 GB/s (1.2 %),     3.097 GHz,    0.318 ins/cycle 
   0.143 ins/char,    0.448 cycle/char,    6.909 Gc/s (1.2 %)     1.00 byte/char 
convert_utf16_to_latin1+iconv, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
  17.011 ins/byte,    3.024 cycle/byte,    1.056 GB/s (29.1 %),     3.193 GHz,    5.625 ins/cycle 
  34.022 ins/char,    6.048 cycle/char,    0.528 Gc/s (29.1 %)     2.00 byte/char 
WARNING: Measurements are noisy, try increasing iteration count (-I).
convert_utf16_to_latin1+icu, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   3.444 ins/byte,    0.763 cycle/byte,    4.187 GB/s (1.1 %),     3.195 GHz,    4.513 ins/cycle 
   3.444 ins/char,    0.763 cycle/char,    4.187 Gc/s (1.1 %)     1.00 byte/char 
convert_utf16_to_latin1+westmere, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   1.251 ins/byte,    0.269 cycle/byte,   11.889 GB/s (1.3 %),     3.199 GHz,    4.649 ins/cycle 
   1.251 ins/char,    0.269 cycle/char,   11.889 Gc/s (1.3 %)     1.00 byte/char 


convert_utf16_to_latin1_with_errors+haswell, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   3.251 ins/byte,    0.743 cycle/byte,    4.300 GB/s (1.2 %),     3.195 GHz,    4.375 ins/cycle 
   3.251 ins/char,    0.743 cycle/char,    4.300 Gc/s (1.2 %)     1.00 byte/char 
convert_utf16_to_latin1_with_errors+icelake, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   3.251 ins/byte,    0.738 cycle/byte,    4.326 GB/s (1.1 %),     3.195 GHz,    4.402 ins/cycle 
   3.251 ins/char,    0.738 cycle/char,    4.326 Gc/s (1.1 %)     1.00 byte/char 
convert_utf16_to_latin1_with_errors+westmere, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   5.376 ins/byte,    0.907 cycle/byte,    3.523 GB/s (1.8 %),     3.194 GHz,    5.928 ins/cycle 
   5.376 ins/char,    0.907 cycle/char,    3.523 Gc/s (1.8 %)     1.00 byte/char  ```

