### PR TITLE
SSE is always little endian: removing unnecessary code path

### DIFF
--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -163,12 +163,8 @@ simdutf_warn_unused result implementation::validate_utf32_with_errors(const char
 }
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(const char * buf, size_t len, char* utf8_output) const noexcept {
-  #if SIMDUTF_IS_BIG_ENDIAN
-  std::pair<const char*, char*> ret = sse_convert_latin1_to_utf8<endianness::BIG>(buf, len, utf8_output);
-  #else
-  std::pair<const char*, char*> ret = sse_convert_latin1_to_utf8<endianness::LITTLE>(buf, len, utf8_output);
-  #endif
-  
+
+  std::pair<const char*, char*> ret = sse_convert_latin1_to_utf8(buf, len, utf8_output);
   size_t converted_chars = ret.second - utf8_output;
 
   if (ret.first != buf + len) {

--- a/src/westmere/sse_convert_latin1_to_utf8.cpp
+++ b/src/westmere/sse_convert_latin1_to_utf8.cpp
@@ -1,4 +1,3 @@
-template <endianness big_endian>
 std::pair<const char* const, char* const> sse_convert_latin1_to_utf8(
   const char* latin_input,
   const size_t latin_input_length,
@@ -11,18 +10,7 @@ std::pair<const char* const, char* const> sse_convert_latin1_to_utf8(
   // 0b1111_1111_1000_0000
   const __m128i v_ff80 = _mm_set1_epi16((uint16_t)0xff80);
 
-  const __m128i latin_1_half_into_u16_byte_mask = big_endian
-    ? _mm_setr_epi8(
-      '\x80', 0,
-      '\x80', 1,
-      '\x80', 2,
-      '\x80', 3,
-      '\x80', 4,
-      '\x80', 5,
-      '\x80', 6,
-      '\x80', 7
-    )
-    : _mm_setr_epi8(
+  const __m128i latin_1_half_into_u16_byte_mask = _mm_setr_epi8(
       0, '\x80',
       1, '\x80',
       2, '\x80',
@@ -33,18 +21,7 @@ std::pair<const char* const, char* const> sse_convert_latin1_to_utf8(
       7, '\x80'
     );
 
-  const __m128i latin_2_half_into_u16_byte_mask = big_endian
-    ? _mm_setr_epi8(
-      '\x80', 8,
-      '\x80', 9,
-      '\x80', 10,
-      '\x80', 11,
-      '\x80', 12,
-      '\x80', 13,
-      '\x80', 14,
-      '\x80', 15
-    )
-    : _mm_setr_epi8(
+  const __m128i latin_2_half_into_u16_byte_mask = _mm_setr_epi8(
       8, '\x80',
       9, '\x80',
       10, '\x80',


### PR DESCRIPTION
It is not possible for SSE to be used on a big endian system.