### PR TITLE
Implementing fast Latin1 to UTF functions for ARM.

### DIFF
--- a/src/arm64/arm_convert_latin1_to_utf16.cpp
+++ b/src/arm64/arm_convert_latin1_to_utf16.cpp
@@ -1,0 +1,18 @@
+template <endianness big_endian>
+std::pair<const char*, char16_t*> arm_convert_latin1_to_utf16(const char* buf, size_t len, char16_t* utf16_output) {
+    const char* end = buf + len;
+
+    while (buf + 16 <= end) {
+        uint8x16_t in8 = vld1q_u8(reinterpret_cast<const uint8_t *>(buf));
+        uint16x8_t inlow = vmovl_u8(vget_low_u8(in8));
+        if (!match_system(big_endian)) { inlow = vrev16q_u8(inlow); }
+        vst1q_u16(reinterpret_cast<uint16_t *>(utf16_output), inlow);
+        uint16x8_t inhigh = vmovl_u8(vget_high_u8(in8));
+        if (!match_system(big_endian)) { inhigh = vrev16q_u8(inhigh); }
+        vst1q_u16(reinterpret_cast<uint16_t *>(utf16_output+8), inhigh);
+        utf16_output += 16;
+        buf += 16;
+    }
+
+    return std::make_pair(buf, utf16_output);
+}

--- a/src/arm64/arm_convert_latin1_to_utf32.cpp
+++ b/src/arm64/arm_convert_latin1_to_utf32.cpp
@@ -1,0 +1,22 @@
+std::pair<const char*, char32_t*> arm_convert_latin1_to_utf32(const char* buf, size_t len, char32_t* utf32_output) {
+    const char* end = buf + len;
+
+    while (buf + 16 <= end) {
+        uint8x16_t in8 = vld1q_u8(reinterpret_cast<const uint8_t *>(buf));
+        uint16x8_t in8low = vmovl_u8(vget_low_u8(in8));
+        uint32x4_t in16lowlow = vmovl_u16(vget_low_u16(in8low));
+        uint32x4_t in16lowhigh = vmovl_u16(vget_high_u16(in8low));
+        uint16x8_t in8high = vmovl_u8(vget_high_u8(in8));
+        uint32x4_t in8highlow = vmovl_u16(vget_low_u16(in8high));
+        uint32x4_t in8highhigh = vmovl_u16(vget_high_u16(in8high));
+        vst1q_u32(reinterpret_cast<uint32_t *>(utf32_output), in16lowlow);
+        vst1q_u32(reinterpret_cast<uint32_t *>(utf32_output+4), in16lowhigh);
+        vst1q_u32(reinterpret_cast<uint32_t *>(utf32_output+8), in8highlow);
+        vst1q_u32(reinterpret_cast<uint32_t *>(utf32_output+12), in8highhigh);
+
+        utf32_output += 16;
+        buf += 16;
+    }
+
+    return std::make_pair(buf, utf32_output);
+}

--- a/src/arm64/arm_convert_latin1_to_utf8.cpp
+++ b/src/arm64/arm_convert_latin1_to_utf8.cpp
@@ -1,0 +1,68 @@
+/*
+  Returns a pair: the first unprocessed byte from buf and utf8_output
+  A scalar routing should carry on the conversion of the tail.
+*/
+std::pair<const char *, char *>
+arm_convert_latin1_to_utf8(const char *latin1_input, size_t len,
+                           char *utf8_out) {
+  uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
+  const char *end = latin1_input + len;
+  const uint16x8_t v_c080 = vmovq_n_u16((uint16_t)0xc080);
+  while (latin1_input + 16 <= end) {
+    uint8x16_t in8 = vld1q_u8(reinterpret_cast<const uint8_t *>(latin1_input));
+    if (vmaxvq_u8(in8) <= 0x7F) { // ASCII fast path!!!!
+      vst1q_u8(utf8_output, in8);
+      utf8_output += 16;
+      latin1_input += 16;
+      continue;
+    }
+
+    // We just fallback on UTF-16 code. This could be optimized/simplified
+    // further.
+    uint16x8_t in16 = vmovl_u8(vget_low_u8(in8));
+    // 1. prepare 2-byte values
+    // input 8-bit word : [aabb|bbbb] x 8
+    // expected output   : [1100|00aa|10bb|bbbb] x 8
+    const uint16x8_t v_1f00 = vmovq_n_u16((int16_t)0x1f00);
+    const uint16x8_t v_003f = vmovq_n_u16((int16_t)0x003f);
+
+    // t0 = [0000|00aa|bbbb|bb00]
+    const uint16x8_t t0 = vshlq_n_u16(in16, 2);
+    // t1 = [0000|00aa|0000|0000]
+    const uint16x8_t t1 = vandq_u16(t0, v_1f00);
+    // t2 = [0000|0000|00bb|bbbb]
+    const uint16x8_t t2 = vandq_u16(in16, v_003f);
+    // t3 = [0000|00aa|00bb|bbbb]
+    const uint16x8_t t3 = vorrq_u16(t1, t2);
+    // t4 = [1100|00aa|10bb|bbbb]
+    const uint16x8_t t4 = vorrq_u16(t3, v_c080);
+    // 2. merge ASCII and 2-byte codewords
+    const uint16x8_t v_007f = vmovq_n_u16((uint16_t)0x007F);
+    const uint16x8_t one_byte_bytemask = vcleq_u16(in16, v_007f);
+    const uint8x16_t utf8_unpacked =
+        vreinterpretq_u8_u16(vbslq_u16(one_byte_bytemask, in16, t4));
+    // 3. prepare bitmask for 8-bit lookup
+#ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
+    const uint16x8_t mask = make_uint16x8_t(0x0001, 0x0004, 0x0010, 0x0040,
+                                            0x0002, 0x0008, 0x0020, 0x0080);
+#else
+    const uint16x8_t mask = {0x0001, 0x0004, 0x0010, 0x0040,
+                             0x0002, 0x0008, 0x0020, 0x0080};
+#endif
+    uint16_t m2 = vaddvq_u16(vandq_u16(one_byte_bytemask, mask));
+    // 4. pack the bytes
+    const uint8_t *row =
+        &simdutf::tables::utf16_to_utf8::pack_1_2_utf8_bytes[m2][0];
+    const uint8x16_t shuffle = vld1q_u8(row + 1);
+    const uint8x16_t utf8_packed = vqtbl1q_u8(utf8_unpacked, shuffle);
+
+    // 5. store bytes
+    vst1q_u8(utf8_output, utf8_packed);
+    // 6. adjust pointers
+    latin1_input += 8;
+    utf8_output += row[0];
+
+  } // while
+
+  return std::make_pair(latin1_input, reinterpret_cast<char *>(utf8_output));
+}


### PR DESCRIPTION
This PR provides fast function (with ARM NEON) for Latin 1 transcoding to Unicode formats.

Here are some benchmarks on an M2 processor with LLVM 14. I use the french.latin1 file from the wikipedia mars dataset.

The performance is good.

## to UTF-8

```
$ ./benchmarks/benchmark -P convert_latin1_to_utf8 -F ../unicode_lipsum/wikipedia_mars/french.latin1.txt -I 3000
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
===========================
Using ICU version 73.2
Using iconv version 267
testcases: 1
input detected as unknown
current system detected as arm64
===========================
convert_latin1_to_utf8+arm64, input size: 432305, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/french.latin1.txt
   6.963 GB/s (3.4 %)    6.963 Gc/s     1.00 byte/char 
convert_latin1_to_utf8+iconv, input size: 432305, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/french.latin1.txt
   0.322 GB/s (6.0 %)    0.322 Gc/s     1.00 byte/char 
convert_latin1_to_utf8+icu, input size: 432305, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/french.latin1.txt
   1.328 GB/s (4.7 %)    1.328 Gc/s     1.00 byte/char 
```

## to UTF-16

```
$ ./benchmarks/benchmark -P convert_latin1_to_utf16 -F ../unicode_lipsum/wikipedia_mars/french.latin1.txt -I 3000
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
===========================
Using ICU version 73.2
Using iconv version 267
testcases: 1
input detected as unknown
current system detected as arm64
===========================
convert_latin1_to_utf16+arm64, input size: 432305, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/french.latin1.txt
  35.053 GB/s (7.6 %)   35.053 Gc/s     1.00 byte/char 
convert_latin1_to_utf16+iconv, input size: 432305, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/french.latin1.txt
   0.343 GB/s (4.3 %)    0.343 Gc/s     1.00 byte/char 
convert_latin1_to_utf16+icu, input size: 432305, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/french.latin1.txt
   6.389 GB/s (4.5 %)    6.389 Gc/s     1.00 byte/char 
```

## to UTF-32

```
$ ./benchmarks/benchmark -P convert_latin1_to_utf32 -F ../unicode_lipsum/wikipedia_mars/french.latin1.txt -I 3000
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
===========================
Using ICU version 73.2
Using iconv version 267
testcases: 1
input detected as unknown
current system detected as arm64
===========================
convert_latin1_to_utf32+arm64, input size: 432305, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/french.latin1.txt
  18.235 GB/s (6.9 %)   18.235 Gc/s     1.00 byte/char 
convert_latin1_to_utf32+iconv, input size: 432305, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/french.latin1.txt
   0.380 GB/s (4.7 %)    0.380 Gc/s     1.00 byte/char 
convert_latin1_to_utf32+icu, input size: 432305, iterations: 3000, dataset: ../unicode_lipsum/wikipedia_mars/french.latin1.txt
   0.292 GB/s (4.8 %)    0.292 Gc/s     1.00 byte/char 
```

Should fix... https://github.com/simdutf/simdutf/issues/276 https://github.com/simdutf/simdutf/issues/278 https://github.com/simdutf/simdutf/issues/280

