### PR TITLE
UTF-16 <=> Latin 1, icelake kernel

### DIFF
--- a/include/simdutf/encoding_types.h
+++ b/include/simdutf/encoding_types.h
@@ -14,8 +14,8 @@ enum encoding_type {
 };
 
 enum endianness {
-        LITTLE,
-        BIG
+        LITTLE = 0,
+        BIG = 1
 };
 
 bool match_system(endianness e);

--- a/src/icelake/icelake_convert_latin1_to_utf16.inl.cpp
+++ b/src/icelake/icelake_convert_latin1_to_utf16.inl.cpp
@@ -1,0 +1,36 @@
+// file included directly
+template <endianness big_endian>
+size_t icelake_convert_latin1_to_utf16(const char *latin1_input, size_t len,
+                                       char16_t *utf16_output) {
+  size_t rounded_len = len & ~0x1F; // Round down to nearest multiple of 32
+
+  __m512i byteflip = _mm512_setr_epi64(0x0607040502030001, 0x0e0f0c0d0a0b0809,
+                                       0x0607040502030001, 0x0e0f0c0d0a0b0809,
+                                       0x0607040502030001, 0x0e0f0c0d0a0b0809,
+                                       0x0607040502030001, 0x0e0f0c0d0a0b0809);
+  for (size_t i = 0; i < rounded_len; i += 32) {
+    // Load 32 Latin1 characters into a 256-bit register
+    __m256i in = _mm256_loadu_si256((__m256i *)&latin1_input[i]);
+    // Zero extend each set of 8 Latin1 characters to 32 16-bit integers
+    __m512i out = _mm512_cvtepu8_epi16(in);
+    if (big_endian) {
+      out = _mm512_shuffle_epi8(out, byteflip);
+    }
+    // Store the results back to memory
+    _mm512_storeu_si512((__m512i *)&utf16_output[i], out);
+  }
+  if (rounded_len != len) {
+    uint32_t mask = uint32_t(1 << (len - rounded_len)) - 1;
+    __m256i in = _mm256_maskz_loadu_epi8(mask, latin1_input + rounded_len);
+
+    // Zero extend each set of 8 Latin1 characters to 32 16-bit integers
+    __m512i out = _mm512_cvtepu8_epi16(in);
+    if (big_endian) {
+      out = _mm512_shuffle_epi8(out, byteflip);
+    }
+    // Store the results back to memory
+    _mm512_mask_storeu_epi16(utf16_output + rounded_len, mask, out);
+  }
+
+  return len;
+}

--- a/src/icelake/icelake_convert_utf16_to_latin1.inl.cpp
+++ b/src/icelake/icelake_convert_utf16_to_latin1.inl.cpp
@@ -1,0 +1,103 @@
+// file included directly
+template <endianness big_endian>
+size_t icelake_convert_utf16_to_latin1(const char16_t *buf, size_t len,
+                                       char *latin1_output) {
+  const char16_t *end = buf + len;
+  __m512i v_0xFF = _mm512_set1_epi16(0xff);
+  __m512i byteflip = _mm512_setr_epi64(0x0607040502030001, 0x0e0f0c0d0a0b0809,
+                                       0x0607040502030001, 0x0e0f0c0d0a0b0809,
+                                       0x0607040502030001, 0x0e0f0c0d0a0b0809,
+                                       0x0607040502030001, 0x0e0f0c0d0a0b0809);
+  __m512i shufmask = _mm512_set_epi8(
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38,
+      36, 34, 32, 30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0);
+  while (buf + 32 <= end) {
+    __m512i in = _mm512_loadu_si512((__m512i *)buf);
+    if (big_endian) {
+      in = _mm512_shuffle_epi8(in, byteflip);
+    }
+    if (_mm512_cmpgt_epu16_mask(in, v_0xFF)) {
+      return 0;
+    }
+    _mm256_storeu_si256(
+        (__m256i *)latin1_output,
+        _mm512_castsi512_si256(_mm512_permutexvar_epi8(shufmask, in)));
+    latin1_output += 32;
+    buf += 32;
+  }
+  if (buf < end) {
+    uint32_t mask(uint32_t(1 << (end - buf)) - 1);
+    __m512i in = _mm512_maskz_loadu_epi16(mask, buf);
+    if (big_endian) {
+      in = _mm512_shuffle_epi8(in, byteflip);
+    }
+    if (_mm512_cmpgt_epu16_mask(in, v_0xFF)) {
+      return 0;
+    }
+    _mm256_mask_storeu_epi8(
+        latin1_output, mask,
+        _mm512_castsi512_si256(_mm512_permutexvar_epi8(shufmask, in)));
+  }
+  return len;
+}
+
+template <endianness big_endian>
+std::pair<result, char *>
+icelake_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
+                                            char *latin1_output) {
+  const char16_t *end = buf + len;
+  const char16_t *start = buf;
+  __m512i byteflip = _mm512_setr_epi64(0x0607040502030001, 0x0e0f0c0d0a0b0809,
+                                       0x0607040502030001, 0x0e0f0c0d0a0b0809,
+                                       0x0607040502030001, 0x0e0f0c0d0a0b0809,
+                                       0x0607040502030001, 0x0e0f0c0d0a0b0809);
+  __m512i v_0xFF = _mm512_set1_epi16(0xff);
+  __m512i shufmask = _mm512_set_epi8(
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38,
+      36, 34, 32, 30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0);
+  while (buf + 32 <= end) {
+    __m512i in = _mm512_loadu_si512((__m512i *)buf);
+    if (big_endian) {
+      in = _mm512_shuffle_epi8(in, byteflip);
+    }
+    if (_mm512_cmpgt_epu16_mask(in, v_0xFF)) {
+      uint16_t word;
+      while ((word = (big_endian ? scalar::utf16::swap_bytes(uint16_t(*buf))
+                                 : uint16_t(*buf))) <= 0xff) {
+        *latin1_output++ = uint8_t(word);
+        buf++;
+      }
+      return std::make_pair(result(error_code::TOO_LARGE, buf - start),
+                            latin1_output);
+    }
+    _mm256_storeu_si256(
+        (__m256i *)latin1_output,
+        _mm512_castsi512_si256(_mm512_permutexvar_epi8(shufmask, in)));
+    latin1_output += 32;
+    buf += 32;
+  }
+  if (buf < end) {
+    uint32_t mask(uint32_t(1 << (end - buf)) - 1);
+    __m512i in = _mm512_maskz_loadu_epi16(mask, buf);
+    if (big_endian) {
+      in = _mm512_shuffle_epi8(in, byteflip);
+    }
+    if (_mm512_cmpgt_epu16_mask(in, v_0xFF)) {
+
+      uint16_t word;
+      while ((word = (big_endian ? scalar::utf16::swap_bytes(uint16_t(*buf))
+                                 : uint16_t(*buf))) <= 0xff) {
+        *latin1_output++ = uint8_t(word);
+        buf++;
+      }
+      return std::make_pair(result(error_code::TOO_LARGE, buf - start),
+                            latin1_output);
+    }
+    _mm256_mask_storeu_epi8(
+        latin1_output, mask,
+        _mm512_castsi512_si256(_mm512_permutexvar_epi8(shufmask, in)));
+  }
+  return std::make_pair(result(error_code::SUCCESS, len), latin1_output);
+}

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -24,13 +24,15 @@ namespace {
 #include "icelake/icelake_from_utf8.inl.cpp"
 #include "icelake/icelake_convert_utf8_to_latin1.inl.cpp"
 #include "icelake/icelake_convert_valid_utf8_to_latin1.inl.cpp"
+#include "icelake/icelake_convert_utf16_to_latin1.inl.cpp"
+#include "icelake/icelake_convert_utf16_to_utf8.inl.cpp"
 #include "icelake/icelake_convert_utf16_to_utf32.inl.cpp"
 #include "icelake/icelake_convert_utf32_to_utf8.inl.cpp"
 #include "icelake/icelake_convert_utf32_to_utf16.inl.cpp"
 #include "icelake/icelake_ascii_validation.inl.cpp"
 #include "icelake/icelake_utf32_validation.inl.cpp"
-#include "icelake/icelake_convert_utf16_to_utf8.inl.cpp"
 #include "icelake/icelake_convert_latin1_to_utf8.inl.cpp"
+#include "icelake/icelake_convert_latin1_to_utf16.inl.cpp"
 #include "icelake/icelake_convert_latin1_to_utf32.inl.cpp"
 
 
@@ -487,11 +489,11 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(const char * b
 }
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16le(const char* buf, size_t len, char16_t* utf16_output) const noexcept {
-  return scalar::latin1_to_utf16::convert<endianness::LITTLE>(buf, len, utf16_output);
+  return icelake_convert_latin1_to_utf16<endianness::LITTLE>(buf, len, utf16_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(const char* buf, size_t len, char16_t* utf16_output) const noexcept {
-  return scalar::latin1_to_utf16::convert<endianness::BIG>(buf, len, utf16_output);
+  return icelake_convert_latin1_to_utf16<endianness::BIG>(buf, len, utf16_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf32(const char* buf, size_t len, char32_t* utf32_output) const noexcept {
@@ -720,19 +722,19 @@ simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf32(const cha
 
 
 simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf16_to_latin1::convert<endianness::LITTLE>(buf, len, latin1_output);
+  return icelake_convert_utf16_to_latin1<endianness::LITTLE>(buf,len,latin1_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf16_to_latin1::convert<endianness::BIG>(buf, len, latin1_output);
+  return icelake_convert_utf16_to_latin1<endianness::BIG>(buf,len,latin1_output);
 }
 
 simdutf_warn_unused result implementation::convert_utf16le_to_latin1_with_errors(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf16_to_latin1::convert_with_errors<endianness::LITTLE>(buf, len, latin1_output);
+  return icelake_convert_utf16_to_latin1_with_errors<endianness::LITTLE>(buf,len,latin1_output).first;
 }
 
 simdutf_warn_unused result implementation::convert_utf16be_to_latin1_with_errors(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf16_to_latin1::convert_with_errors<endianness::BIG>(buf, len, latin1_output);
+  return icelake_convert_utf16_to_latin1_with_errors<endianness::BIG>(buf,len,latin1_output).first;
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16be_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {


### PR DESCRIPTION
The performance is decent and the implementation is relatively clean.

Ice Lake processor, GCC12... french data files...

```
$ ./build/benchmarks/benchmark -P convert_latin1_to_utf16 -F unicode_lipsum/wikipedia_mars/french.latin1.txt  -I 6000
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
===========================
Using ICU version 67.1
testcases: 1
input detected as unknown
current system detected as icelake
===========================
convert_latin1_to_utf16+haswell, input size: 432305, iterations: 6000, dataset: unicode_lipsum/wikipedia_mars/french.latin1.txt
   0.282 ins/byte,    0.206 cycle/byte,   15.534 GB/s (3.5 %),     3.203 GHz,    1.367 ins/cycle 
   0.282 ins/char,    0.206 cycle/char,   15.534 Gc/s (3.5 %)     1.00 byte/char 
convert_latin1_to_utf16+icelake, input size: 432305, iterations: 6000, dataset: unicode_lipsum/wikipedia_mars/french.latin1.txt
   0.157 ins/byte,    0.200 cycle/byte,   15.536 GB/s (2.1 %),     3.101 GHz,    0.786 ins/cycle 
   0.157 ins/char,    0.200 cycle/char,   15.536 Gc/s (2.1 %)     1.00 byte/char 
convert_latin1_to_utf16+iconv, input size: 432305, iterations: 6000, dataset: unicode_lipsum/wikipedia_mars/french.latin1.txt
  31.022 ins/byte,    7.012 cycle/byte,    0.455 GB/s (0.3 %),     3.193 GHz,    4.424 ins/cycle 
  31.022 ins/char,    7.012 cycle/char,    0.455 Gc/s (0.3 %)     1.00 byte/char 
convert_latin1_to_utf16+icu, input size: 432305, iterations: 6000, dataset: unicode_lipsum/wikipedia_mars/french.latin1.txt
   2.505 ins/byte,    0.637 cycle/byte,    5.017 GB/s (0.8 %),     3.195 GHz,    3.933 ins/cycle 
   2.505 ins/char,    0.637 cycle/char,    5.017 Gc/s (0.8 %)     1.00 byte/char 
convert_latin1_to_utf16+westmere, input size: 432305, iterations: 6000, dataset: unicode_lipsum/wikipedia_mars/french.latin1.txt
   0.563 ins/byte,    0.184 cycle/byte,   17.391 GB/s (2.7 %),     3.202 GHz,    3.058 ins/cycle 
   0.563 ins/char,    0.184 cycle/char,   17.391 Gc/s (2.7 %)     1.00 byte/char



$ ./build/benchmarks/benchmark -P convert_utf16_to_latin1 -F unico
de_lipsum/wikipedia_mars/french.utflatin16.txt  -I 6000
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
===========================
Using ICU version 67.1
testcases: 1
input detected as UTF16 little-endian
current system detected as icelake
===========================
convert_utf16_to_latin1+haswell, input size: 864610, iterations: 6000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   0.173 ins/byte,    0.204 cycle/byte,   15.677 GB/s (7.3 %),     3.197 GHz,    0.847 ins/cycle 
   0.345 ins/char,    0.408 cycle/char,    7.838 Gc/s (7.3 %)     2.00 byte/char 
convert_utf16_to_latin1+icelake, input size: 864610, iterations: 6000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   0.172 ins/byte,    0.103 cycle/byte,   29.973 GB/s (1.3 %),     3.102 GHz,    1.663 ins/cycle 
   0.344 ins/char,    0.207 cycle/char,   14.987 Gc/s (1.3 %)     2.00 byte/char 
convert_utf16_to_latin1+iconv, input size: 864610, iterations: 6000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin16.txt
  17.011 ins/byte,    3.028 cycle/byte,    1.053 GB/s (22.0 %),     3.187 GHz,    5.619 ins/cycle 
  34.022 ins/char,    6.055 cycle/char,    0.526 Gc/s (22.0 %)     2.00 byte/char 
WARNING: Measurements are noisy, try increasing iteration count (-I).
convert_utf16_to_latin1+icu, input size: 864610, iterations: 6000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   1.722 ins/byte,    0.387 cycle/byte,    8.264 GB/s (0.8 %),     3.196 GHz,    4.453 ins/cycle 
   3.444 ins/char,    0.773 cycle/char,    4.132 Gc/s (0.8 %)     2.00 byte/char 
convert_utf16_to_latin1+westmere, input size: 864610, iterations: 6000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   0.626 ins/byte,    0.157 cycle/byte,   20.378 GB/s (4.4 %),     3.199 GHz,    3.985 ins/cycle 
   1.251 ins/char,    0.314 cycle/char,   10.189 Gc/s (4.4 %)     2.00 byte/char 
convert_utf16_to_latin1_with_errors+haswell, input size: 864610, iterations: 6000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   1.625 ins/byte,    0.369 cycle/byte,    8.663 GB/s (1.2 %),     3.196 GHz,    4.406 ins/cycle 
   3.251 ins/char,    0.738 cycle/char,    4.332 Gc/s (1.2 %)     2.00 byte/char 
convert_utf16_to_latin1_with_errors+icelake, input size: 864610, iterations: 6000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   0.172 ins/byte,    0.106 cycle/byte,   29.131 GB/s (1.4 %),     3.100 GHz,    1.618 ins/cycle 
   0.344 ins/char,    0.213 cycle/char,   14.566 Gc/s (1.4 %)     2.00 byte/char 
convert_utf16_to_latin1_with_errors+westmere, input size: 864610, iterations: 6000, dataset: unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   2.625 ins/byte,    0.442 cycle/byte,    7.223 GB/s (0.5 %),     3.195 GHz,    5.935 ins/cycle 
   5.251 ins/char,    0.885 cycle/char,    3.612 Gc/s (0.5 %)     2.00 byte/char 
```

Fixes https://github.com/simdutf/simdutf/issues/308

Fixes https://github.com/simdutf/simdutf/issues/309