### PR TITLE
investigate loop unrolling 

### DIFF
--- a/src/westmere/sse_convert_latin1_to_utf8.cpp
+++ b/src/westmere/sse_convert_latin1_to_utf8.cpp
@@ -1,35 +1,20 @@
-inline void _sse_convert_latin1_to_utf8(
-  const char*& latin_input,
-  char*& utf8_output,
-  const __m128i v_latin,
-  const __m128i latin_1_half_into_u16_byte_mask,
-  const __m128i latin_2_half_into_u16_byte_mask,
-  const __m128i v_80,
-  const __m128i v_0000,
-  const __m128i v_ff80
-) {
-  if (_mm_testz_si128(v_latin, v_80)) {// ASCII fast path!!!!
-    _mm_storeu_si128((__m128i*)utf8_output, v_latin);
-    latin_input += 16;
-    utf8_output += 16;
-    return;
-  }
+#define EAT_LATIN_(n) \
+if (_mm_testz_si128(v_latin_##n, v_80)) {/* ASCII fast path!!!! */                                       \
+  _mm_storeu_si128((__m128i*)utf8_output, v_latin_##n);                                                  \
+  utf8_output += 16;                                                                                     \
+}                                                                                                        \
+else {                                                                                                   \
+  /* assuming a/b are bytes and A/B are uint16 of the same value*/                                       \
+  /* aaaa_aaaa_bbbb_bbbb -> AAAA_AAAA  */                                                                \
+  const __m128i v_u16_latin_1_half_##n = _mm_shuffle_epi8(v_latin_##n, latin_1_half_into_u16_byte_mask); \
+  /* aaaa_aaaa_bbbb_bbbb -> BBBB_BBBB */                                                                 \
+  const __m128i v_u16_latin_2_half_##n = _mm_shuffle_epi8(v_latin_##n, latin_2_half_into_u16_byte_mask); \
+                                                                                                         \
+  internal::westmere::write_v_u16_11bits_to_utf8(v_u16_latin_1_half_##n, utf8_output, v_0000, v_ff80);   \
+  internal::westmere::write_v_u16_11bits_to_utf8(v_u16_latin_2_half_##n, utf8_output, v_0000, v_ff80);   \
+}
 
-
-  // assuming a/b are bytes and A/B are uint16 of the same value
-  // aaaa_aaaa_bbbb_bbbb -> AAAA_AAAA
-  const __m128i v_u16_latin_1_half = _mm_shuffle_epi8(v_latin, latin_1_half_into_u16_byte_mask);
-  // aaaa_aaaa_bbbb_bbbb -> BBBB_BBBB
-  const __m128i v_u16_latin_2_half = _mm_shuffle_epi8(v_latin, latin_2_half_into_u16_byte_mask);
-
-
-  internal::westmere::write_v_u16_11bits_to_utf8(v_u16_latin_1_half, utf8_output, v_0000, v_ff80);
-  internal::westmere::write_v_u16_11bits_to_utf8(v_u16_latin_2_half, utf8_output, v_0000, v_ff80);
-  latin_input += 16;
-};
-
-
-std::pair<const char* const, char* const> sse_convert_latin1_to_utf8(
+std::pair<const char*, char*> sse_convert_latin1_to_utf8(
   const char* latin_input,
   const size_t latin_input_length,
   char* utf8_output) {
@@ -68,40 +53,51 @@ std::pair<const char* const, char* const> sse_convert_latin1_to_utf8(
   // so the last write can exceed the utf8_output size by 8-1 bytes 
   // by reserving 8 extra input bytes, we expect the output to have 8-16 bytes free
 
-  // loop unroll depth 4
-  while (latin_input + 16 * 4 + 8 <= end) {
+  // loop unroll depth 6
+  while (latin_input + 16 * 6 + 8 <= end) {
     // Load 16 Latin1 characters (16 bytes) into a 128-bit register
     const __m128i v_latin_1 = _mm_loadu_si128((__m128i*)latin_input);
     const __m128i v_latin_2 = _mm_loadu_si128((__m128i*)latin_input + 1);
     const __m128i v_latin_3 = _mm_loadu_si128((__m128i*)latin_input + 2);
     const __m128i v_latin_4 = _mm_loadu_si128((__m128i*)latin_input + 3);
+    const __m128i v_latin_5 = _mm_loadu_si128((__m128i*)latin_input + 4);
+    const __m128i v_latin_6 = _mm_loadu_si128((__m128i*)latin_input + 5);
 
-    _sse_convert_latin1_to_utf8(latin_input, utf8_output, v_latin_1, latin_1_half_into_u16_byte_mask, latin_2_half_into_u16_byte_mask, v_80, v_0000, v_ff80);
-    _sse_convert_latin1_to_utf8(latin_input, utf8_output, v_latin_2, latin_1_half_into_u16_byte_mask, latin_2_half_into_u16_byte_mask, v_80, v_0000, v_ff80);
-    _sse_convert_latin1_to_utf8(latin_input, utf8_output, v_latin_3, latin_1_half_into_u16_byte_mask, latin_2_half_into_u16_byte_mask, v_80, v_0000, v_ff80);
-    _sse_convert_latin1_to_utf8(latin_input, utf8_output, v_latin_4, latin_1_half_into_u16_byte_mask, latin_2_half_into_u16_byte_mask, v_80, v_0000, v_ff80);
+    EAT_LATIN_(1);
+    EAT_LATIN_(2);
+    EAT_LATIN_(3);
+    EAT_LATIN_(4);
+    EAT_LATIN_(5);
+    EAT_LATIN_(6);
+
+    latin_input += 16 * 6;
   }
 
-  // loop unroll depth 2
-  while (latin_input + 16 * 2 + 8 <= end) {
+
+  // loop unroll depth 3
+  while (latin_input + 16 * 3 + 8 <= end) {
     // Load 16 Latin1 characters (16 bytes) into a 128-bit register
     const __m128i v_latin_1 = _mm_loadu_si128((__m128i*)latin_input);
     const __m128i v_latin_2 = _mm_loadu_si128((__m128i*)latin_input + 1);
+    const __m128i v_latin_3 = _mm_loadu_si128((__m128i*)latin_input + 2);
 
-    _sse_convert_latin1_to_utf8(latin_input, utf8_output, v_latin_1, latin_1_half_into_u16_byte_mask, latin_2_half_into_u16_byte_mask, v_80, v_0000, v_ff80);
-    _sse_convert_latin1_to_utf8(latin_input, utf8_output, v_latin_2, latin_1_half_into_u16_byte_mask, latin_2_half_into_u16_byte_mask, v_80, v_0000, v_ff80);
+    EAT_LATIN_(1);
+    EAT_LATIN_(2);
+    EAT_LATIN_(3);
+
+    latin_input += 16 * 3;
   }
 
-
-  // this loop always run just 1 iteration
-  // nevertheless it shouldn't be replaced with if statement
-  // it would significantly drop performance at least with MSVC 17.5.5
   while (latin_input + 16 + 8 <= end) {
     // Load 16 Latin1 characters (16 bytes) into a 128-bit register
-    const __m128i v_latin = _mm_loadu_si128((__m128i*)latin_input);
+    const __m128i v_latin_1 = _mm_loadu_si128((__m128i*)latin_input);
 
-    _sse_convert_latin1_to_utf8(latin_input, utf8_output, v_latin, latin_1_half_into_u16_byte_mask, latin_2_half_into_u16_byte_mask, v_80, v_0000, v_ff80);
+    EAT_LATIN_(1);
+
+    latin_input += 16;
   }
 
   return std::make_pair(latin_input, utf8_output);
 };
+
+#undef EAT_LATIN_

--- a/src/westmere/sse_convert_latin1_to_utf8.cpp
+++ b/src/westmere/sse_convert_latin1_to_utf8.cpp
@@ -1,3 +1,34 @@
+inline void _sse_convert_latin1_to_utf8(
+  const char*& latin_input,
+  char*& utf8_output,
+  const __m128i v_latin,
+  const __m128i latin_1_half_into_u16_byte_mask,
+  const __m128i latin_2_half_into_u16_byte_mask,
+  const __m128i v_80,
+  const __m128i v_0000,
+  const __m128i v_ff80
+) {
+  if (_mm_testz_si128(v_latin, v_80)) {// ASCII fast path!!!!
+    _mm_storeu_si128((__m128i*)utf8_output, v_latin);
+    latin_input += 16;
+    utf8_output += 16;
+    return;
+  }
+
+
+  // assuming a/b are bytes and A/B are uint16 of the same value
+  // aaaa_aaaa_bbbb_bbbb -> AAAA_AAAA
+  const __m128i v_u16_latin_1_half = _mm_shuffle_epi8(v_latin, latin_1_half_into_u16_byte_mask);
+  // aaaa_aaaa_bbbb_bbbb -> BBBB_BBBB
+  const __m128i v_u16_latin_2_half = _mm_shuffle_epi8(v_latin, latin_2_half_into_u16_byte_mask);
+
+
+  internal::westmere::write_v_u16_11bits_to_utf8(v_u16_latin_1_half, utf8_output, v_0000, v_ff80);
+  internal::westmere::write_v_u16_11bits_to_utf8(v_u16_latin_2_half, utf8_output, v_0000, v_ff80);
+  latin_input += 16;
+};
+
+
 std::pair<const char* const, char* const> sse_convert_latin1_to_utf8(
   const char* latin_input,
   const size_t latin_input_length,
@@ -11,71 +42,65 @@ std::pair<const char* const, char* const> sse_convert_latin1_to_utf8(
   const __m128i v_ff80 = _mm_set1_epi16((uint16_t)0xff80);
 
   const __m128i latin_1_half_into_u16_byte_mask = _mm_setr_epi8(
-      0, '\x80',
-      1, '\x80',
-      2, '\x80',
-      3, '\x80',
-      4, '\x80',
-      5, '\x80',
-      6, '\x80',
-      7, '\x80'
-    );
+    0, '\x80',
+    1, '\x80',
+    2, '\x80',
+    3, '\x80',
+    4, '\x80',
+    5, '\x80',
+    6, '\x80',
+    7, '\x80'
+  );
 
   const __m128i latin_2_half_into_u16_byte_mask = _mm_setr_epi8(
-      8, '\x80',
-      9, '\x80',
-      10, '\x80',
-      11, '\x80',
-      12, '\x80',
-      13, '\x80',
-      14, '\x80',
-      15, '\x80'
-    );
+    8, '\x80',
+    9, '\x80',
+    10, '\x80',
+    11, '\x80',
+    12, '\x80',
+    13, '\x80',
+    14, '\x80',
+    15, '\x80'
+  );
 
   // each latin1 takes 1-2 utf8 bytes
   // slow path writes useful 8-15 bytes twice (eagerly writes 16 bytes and then adjust the pointer)
   // so the last write can exceed the utf8_output size by 8-1 bytes 
   // by reserving 8 extra input bytes, we expect the output to have 8-16 bytes free
-  while (latin_input + 16 + 8 <= end) {
+
+  // loop unroll depth 4
+  while (latin_input + 16 * 4 + 8 <= end) {
     // Load 16 Latin1 characters (16 bytes) into a 128-bit register
-    __m128i v_latin = _mm_loadu_si128((__m128i*)latin_input);
+    const __m128i v_latin_1 = _mm_loadu_si128((__m128i*)latin_input);
+    const __m128i v_latin_2 = _mm_loadu_si128((__m128i*)latin_input + 1);
+    const __m128i v_latin_3 = _mm_loadu_si128((__m128i*)latin_input + 2);
+    const __m128i v_latin_4 = _mm_loadu_si128((__m128i*)latin_input + 3);
 
-
-    if (_mm_testz_si128(v_latin, v_80)) {// ASCII fast path!!!!
-      _mm_storeu_si128((__m128i*)utf8_output, v_latin);
-      latin_input += 16;
-      utf8_output += 16;
-      continue;
-    }
-    
-
-    // assuming a/b are bytes and A/B are uint16 of the same value
-    // aaaa_aaaa_bbbb_bbbb -> AAAA_AAAA
-    __m128i v_u16_latin_1_half = _mm_shuffle_epi8(v_latin, latin_1_half_into_u16_byte_mask);
-    // aaaa_aaaa_bbbb_bbbb -> BBBB_BBBB
-    __m128i v_u16_latin_2_half = _mm_shuffle_epi8(v_latin, latin_2_half_into_u16_byte_mask);
-
-
-    internal::westmere::write_v_u16_11bits_to_utf8(v_u16_latin_1_half, utf8_output, v_0000, v_ff80);
-    internal::westmere::write_v_u16_11bits_to_utf8(v_u16_latin_2_half, utf8_output, v_0000, v_ff80);
-    latin_input += 16;
+    _sse_convert_latin1_to_utf8(latin_input, utf8_output, v_latin_1, latin_1_half_into_u16_byte_mask, latin_2_half_into_u16_byte_mask, v_80, v_0000, v_ff80);
+    _sse_convert_latin1_to_utf8(latin_input, utf8_output, v_latin_2, latin_1_half_into_u16_byte_mask, latin_2_half_into_u16_byte_mask, v_80, v_0000, v_ff80);
+    _sse_convert_latin1_to_utf8(latin_input, utf8_output, v_latin_3, latin_1_half_into_u16_byte_mask, latin_2_half_into_u16_byte_mask, v_80, v_0000, v_ff80);
+    _sse_convert_latin1_to_utf8(latin_input, utf8_output, v_latin_4, latin_1_half_into_u16_byte_mask, latin_2_half_into_u16_byte_mask, v_80, v_0000, v_ff80);
   }
 
-  if (latin_input + 16 <= end) {
+  // loop unroll depth 2
+  while (latin_input + 16 * 2 + 8 <= end) {
     // Load 16 Latin1 characters (16 bytes) into a 128-bit register
-    __m128i v_latin = _mm_loadu_si128((__m128i*)latin_input);
+    const __m128i v_latin_1 = _mm_loadu_si128((__m128i*)latin_input);
+    const __m128i v_latin_2 = _mm_loadu_si128((__m128i*)latin_input + 1);
 
-    if (_mm_testz_si128(v_latin, v_80)) {// ASCII fast path!!!!
-      _mm_storeu_si128((__m128i*)utf8_output, v_latin);
-      latin_input += 16;
-      utf8_output += 16;
-    } else {
-      // assuming a/b are bytes and A/B are uint16 of the same value
-      // aaaa_aaaa_bbbb_bbbb -> AAAA_AAAA
-      __m128i v_u16_latin_1_half = _mm_shuffle_epi8(v_latin, latin_1_half_into_u16_byte_mask);
-      internal::westmere::write_v_u16_11bits_to_utf8(v_u16_latin_1_half, utf8_output, v_0000, v_ff80);
-      latin_input += 8;
-    }
+    _sse_convert_latin1_to_utf8(latin_input, utf8_output, v_latin_1, latin_1_half_into_u16_byte_mask, latin_2_half_into_u16_byte_mask, v_80, v_0000, v_ff80);
+    _sse_convert_latin1_to_utf8(latin_input, utf8_output, v_latin_2, latin_1_half_into_u16_byte_mask, latin_2_half_into_u16_byte_mask, v_80, v_0000, v_ff80);
+  }
+
+
+  // this loop always run just 1 iteration
+  // nevertheless it shouldn't be replaced with if statement
+  // it would significantly drop performance at least with MSVC 17.5.5
+  while (latin_input + 16 + 8 <= end) {
+    // Load 16 Latin1 characters (16 bytes) into a 128-bit register
+    const __m128i v_latin = _mm_loadu_si128((__m128i*)latin_input);
+
+    _sse_convert_latin1_to_utf8(latin_input, utf8_output, v_latin, latin_1_half_into_u16_byte_mask, latin_2_half_into_u16_byte_mask, v_80, v_0000, v_ff80);
   }
 
   return std::make_pair(latin_input, utf8_output);


### PR DESCRIPTION
Recently I've learned that all Intel processors since `Sandy Bridge` can do two `_mm_loadu_si128` at the same time with port 2 and 3. So I tried 2 sequential `_mm_loadu_si128` and it was a success. Then I also tried 4 and 8. 4 gave me an additional boost, but not 8.
Alas, when I pulled upstream commits, I got a significant performance penalty for the `esperanto` file with `msvc`. So I dropped them and started adding one by one. And I found which one causes it.
7761599262953df2a1d9c3427d0d27d1cb044615 SSE UTF16 => latin1 (#311)
It seems there's nothing special here. It just added a new dependency with 2 other `sse` implementations.
So I also checked with `gcc` and there was no penalty.
Could it be a `msvc` bug?


<details>
  <summary> inlined version</summary>
======================================================================

"the commit" is 7761599262953df2a1d9c3427d0d27d1cb044615, 
current branch is [sse_convert_latin1_to_utf8_perf](https://github.com/aspic-fish/simdutf/tree/sse_convert_latin1_to_utf8_perf)
command `benchmark -P convert_latin1_to_utf8+westmere -F *.latin1.txt`
arch: `Sandy Bridge`

======================================================================

## windows 10

### msvc VS 17.5.5
|                                     | esperanto    | french              |  german    | portuguese  |
| -------------                 | -------------   | -------------   | -------------   | ------------- |
|   master  branch        | 12.641 GB/s  | 3.714 GB/s      | 5.845 GB/s    | 4.246 GB/s   |
| current branch before  the commit      | 16.111 GB/s  | 4.638 GB/s      | 8.743 GB/s    | 5.972 GB/s    |
| current branch after  the commit       | 12.450 GB/s  | 4.522 GB/s      | 8.237 GB/s     | 5.869 GB/s   |

### msvc VS 17.7.4
|                                     | esperanto    | french              |  german    | portuguese  |
| -------------                 | -------------   | -------------   | -------------   | ------------- |
|   master  branch        | 13.043 GB/s  | 3.670 GB/s      | 6.059 GB/s    | 4.233 GB/s   |
| current branch before  the commit      | 13.927 GB/s  | 4.546 GB/s      | 8.518 GB/s    | 5.895 GB/s    |
| current branch after  the commit       | 12.450 GB/s  | 4.570 GB/s      | 8.667 GB/s     | 5.986 GB/s   |

### LLVM(clang-cl) 16.0.5
|                                     | esperanto    | french              |  german    | portuguese  |
| -------------                 | -------------   | -------------   | -------------   | ------------- |
|   master  branch        | 11.738 GB/s  | 3.648 GB/s      | 6.535 GB/s    | 4.462 GB/s   |
| current branch before  the commit      | 6.178 GB/s  | 3.015 GB/s      | 4.625 GB/s    | 3.648 GB/s    |
| current branch after  the commit       | 6.178 GB/s  | 3.019 GB/s      | 4.657 GB/s     | 3.657 GB/s   |

### Intel(R) oneAPI DPC++/C++ Compiler 2023.2.0 (2023.2.0.20230627)
|                                     | esperanto    | french              |  german    | portuguese  |
| -------------                 | -------------   | -------------   | -------------   | ------------- |
|   master  branch        | 11.738 GB/s  | 3.660 GB/s      | 6.826 GB/s    | 4.477 GB/s   |
| current branch before  the commit      | 16.111 GB/s  | 4.986 GB/s      | 9.144 GB/s    | 6.693 GB/s    |
| current branch after  the commit       | 16.111 GB/s  | 4.980 GB/s      | 9.102 GB/s     | 6.710 GB/s   |

## mingw-w64-ucrt-x86_64-gcc 13.1.0-7
build error. 

======================================================================
## wsl2 ubuntu 22.04
### gcc 11.4.0 
|                                     | esperanto    | french              |  german    | portuguese  |
| -------------                 | -------------   | -------------   | -------------   | ------------- |
| master branch             | 12.839 GB/s   | 3.717 GB/s     | 6.921 GB/s      | 4.583 GB/s   |
| current branch before the commit    | 14.673 GB/s    | 4.384 GB/s     | 8.704 GB/s      | 5.920 GB/s   |
| current branch after  the commit      | 14.673 GB/s   | 4.389 GB/s     | 8.667 GB/s      | 5.920 GB/s   |

### clang 14.0.0-1ubuntu1.1
|                                     | esperanto    | french              |  german    | portuguese  |
| -------------                 | -------------   | -------------   | -------------   | ------------- |
| master branch             | 11.104 GB/s   | 3.624 GB/s     | 6.622 GB/s      | 4.376 GB/s   |
| current branch before the commit    | 5.954 GB/s    | 3.006 GB/s     | 4.646 GB/s      | 3.652 GB/s   |
| current branch after  the commit      | 5.911 GB/s   | 3.010 GB/s     | 4.657 GB/s      | 3.662 GB/s   |

### Intel(R) oneAPI DPC++/C++ Compiler 2023.2.0 (2023.2.0.20230721)
|                                     | esperanto    | french              |  german    | portuguese  |
| -------------                 | -------------   | -------------   | -------------   | ------------- |
| master branch             | 11.256 GB/s   | 3.743 GB/s     | 6.780 GB/s      | 4.590 GB/s   |
| current branch before the commit    | 13.927 GB/s    | 4.963 GB/s     | 9.315 GB/s      | 7.170 GB/s   |
| current branch after  the commit      | 13.695 GB/s   | 4.975 GB/s     | 9.358 GB/s      | 7.246 GB/s   |


The situation got even funnier when I removed all the loops except [this one](https://github.com/simdutf/simdutf/compare/master...aspic-fish:simdutf:sse_convert_latin1_to_utf8_perf#diff-2032dccf513eb16b21de09f8f901e889a0042a2e6e894a0d03a3f1766161ebf8R86), and got the opposite result. And it's quite consistent between benchmarks.
msvc VS 17.5.5
|                                     | esperanto    | french              |  german    | portuguese  |
| -------------                 | -------------   | -------------   | -------------   | ------------- |
|           msvc                  |                      |                        |                        |                    |
| before the commit      | 14.673 GB/s  | 4.102 GB/s      | 7.144 GB/s     | 4.896 GB/s    |
| after  the commit        | 15.503 GB/s   |  4.205 GB/s     | 7.608 GB/s     | 5.108 GB/s   |

</details>

<details>
  <summary> macros version</summary>
======================================================================

"the commit" is 7761599262953df2a1d9c3427d0d27d1cb044615, 
current branch is [sse_convert_latin1_to_utf8_perf](https://github.com/aspic-fish/simdutf/tree/sse_convert_latin1_to_utf8_perf)
command `benchmark -P convert_latin1_to_utf8+westmere -F *.latin1.txt`
arch: `Sandy Bridge`

======================================================================

## windows 10

### msvc VS 17.7.4
|                                     | esperanto    | french              |  german    | portuguese  |
| -------------                 | -------------   | -------------   | -------------   | ------------- |
|   master  branch        | 13.043 GB/s  | 3.670 GB/s      | 6.059 GB/s    | 4.233 GB/s   |
| current branch before  the commit      | 13.695 GB/s  | 4.546 GB/s      | 8.555 GB/s    | 5.844 GB/s    |
| current branch after  the commit       | 13.043 GB/s  | 4.546 GB/s      | 8.446 GB/s     | 5.895 GB/s   |

### LLVM(clang-cl) 16.0.5
|                                     | esperanto    | french              |  german    | portuguese  |
| -------------                 | -------------   | -------------   | -------------   | ------------- |
|   master  branch        | 11.738 GB/s  | 3.648 GB/s      | 6.535 GB/s    | 4.462 GB/s   |
| current branch before  the commit      | 17.118 GB/s  | 5.253 GB/s      | 9.537 GB/s    | 7.548 GB/s    |
| current branch after  the commit       | 17.118 GB/s  | 5.259 GB/s      | 9.402 GB/s     | 7.548 GB/s   |

### Intel(R) oneAPI DPC++/C++ Compiler 2023.2.0 (2023.2.0.20230627)
|                                     | esperanto    | french              |  german    | portuguese  |
| -------------                 | -------------   | -------------   | -------------   | ------------- |
|   master  branch        | 11.738 GB/s  | 3.660 GB/s      | 6.826 GB/s    | 4.477 GB/s   |
| current branch before  the commit      | 17.118 GB/s  | 5.208 GB/s      | 9.402 GB/s    | 7.486 GB/s    |
| current branch after  the commit       | 17.118 GB/s  | 5.196 GB/s      | 9.228 GB/s     | 7.465 GB/s   |

## mingw-w64-ucrt-x86_64-gcc 13.1.0-7
build error. 

======================================================================
## wsl2 ubuntu 22.04
### gcc 11.4.0 
|                                     | esperanto    | french              |  german    | portuguese  |
| -------------                 | -------------   | -------------   | -------------   | ------------- |
| master branch             | 12.839 GB/s   | 3.717 GB/s     | 6.921 GB/s      | 4.583 GB/s   |
| current branch before the commit    | 14.940 GB/s    | 4.471 GB/s     | 8.704 GB/s      | 5.895 GB/s   |
| current branch after  the commit      | 14.673 GB/s   | 4.570 GB/s     | 8.743 GB/s      | 6.012 GB/s   |

### clang 14.0.0-1ubuntu1.1
|                                     | esperanto    | french              |  german    | portuguese  |
| -------------                 | -------------   | -------------   | -------------   | ------------- |
| master branch             | 11.104 GB/s   | 3.624 GB/s     | 6.622 GB/s      | 4.376 GB/s   |
| current branch before the commit    | 14.673 GB/s    | 4.929 GB/s     | 9.492 GB/s      | 7.022 GB/s   |
| current branch after  the commit      | 14.415 GB/s   |  4.924 GB/s     | 9.492 GB/s      | 7.040 GB/s   |

### Intel(R) oneAPI DPC++/C++ Compiler 2023.2.0 (2023.2.0.20230721)
|                                     | esperanto    | french              |  german    | portuguese  |
| -------------                 | -------------   | -------------   | -------------   | ------------- |
| master branch             | 11.256 GB/s   | 3.743 GB/s     | 6.780 GB/s      | 4.590 GB/s   |
| current branch before the commit    | 14.167 GB/s    | 5.110 GB/s     | 9.676 GB/s      | 7.445 GB/s   |
| current branch after  the commit      | 14.167 GB/s   | 5.092 GB/s     | 9.771 GB/s      | 7.486 GB/s   |

</details>

I'm going to continue the investigation in a couple of days.
plan: 
*~~I suspect that building it as a shared lib might help as it would prevent access of `msvc` to the rest of the code.
Supposedly, that wouldn't allow it to perform some smart optimisations and thus results should be more stable.~~
* try more compilers.
* check how adding/removing other `sse` implementations affects performance
* try unrolling other implementations as well


~~For now, I suggest considering unrolling as unstable.~~