### PR TITLE
AVX2 Latin1 => UTF16

### DIFF
--- a/src/haswell/avx2_convert_latin1_to_utf16.cpp
+++ b/src/haswell/avx2_convert_latin1_to_utf16.cpp
@@ -1,0 +1,112 @@
+template <endianness big_endian>
+std::pair<const char*, char16_t*> avx2_convert_latin1_to_utf16(const char *latin1_input, size_t len,
+                                    char16_t *utf16_output) {
+  size_t rounded_len = len & ~0xF; // Round down to nearest multiple of 16
+
+  __m256i byteflip = _mm256_setr_epi64x(0x0607040502030001, 0x0e0f0c0d0a0b0809,
+                                        0x0607040502030001, 0x0e0f0c0d0a0b0809);
+  
+  for (size_t i = 0; i < rounded_len; i += 16) {
+    // Load 16 Latin1 characters into a 128-bit register
+    __m128i in = _mm_loadu_si128((__m128i *)&latin1_input[i]);
+    // Zero extend each set of 8 Latin1 characters to 16 16-bit integers
+    __m256i out = _mm256_cvtepu8_epi16(in);
+    if (big_endian) {
+      out = _mm256_shuffle_epi8(out, byteflip);
+    }
+    // Store the results back to memory
+    _mm256_storeu_si256((__m256i *)&utf16_output[i], out);
+  }
+  
+/*   if (rounded_len != len) {
+    __m128i in = _mm_loadu_si128((__m128i *)&latin1_input[rounded_len]);
+    __m256i out = _mm256_cvtepu8_epi16(in);
+    if (big_endian) {
+      out = _mm256_shuffle_epi8(out, byteflip);
+    }
+    // Handle the mask store manually for epi16
+    __m256i orig = _mm256_loadu_si256((__m256i *)&utf16_output[rounded_len]);
+    __m256i mask_vec = _mm256_set1_epi16((1 << (len - rounded_len)) - 1);
+    __m256i blended = _mm256_blendv_epi8(orig, out, mask_vec);
+    _mm256_storeu_si256((__m256i *)&utf16_output[rounded_len], blended);
+  }
+
+  return len; */
+    // return pointers pointing to where we left off
+    return std::make_pair(latin1_input + rounded_len, utf16_output + rounded_len);
+
+}
+
+
+/* template <endianness big_endian>
+size_t avx2_convert_latin1_to_utf16(const char *latin1_input, size_t len,
+                                       char16_t *utf16_output) {
+  size_t rounded_len = len & ~0xF; // Round down to nearest multiple of 16
+
+  __m256i byteflip = _mm256_setr_epi64x(0x0607040502030001, 0x0e0f0c0d0a0b0809,
+                                        0x0607040502030001, 0x0e0f0c0d0a0b0809);
+  for (size_t i = 0; i < rounded_len; i += 16) {
+    // Load 16 Latin1 characters into a 128-bit register
+    __m128i in = _mm_loadu_si128((__m128i *)&latin1_input[i]);
+    // Zero extend each set of 8 Latin1 characters to 16 16-bit integers
+    __m256i out = _mm256_cvtepu8_epi16(in);
+    if (big_endian) {
+      out = _mm256_shuffle_epi8(out, byteflip);
+    }
+    // Store the results back to memory
+    _mm256_storeu_si256((__m256i *)&utf16_output[i], out);
+  }
+  
+  if (rounded_len != len) {
+    uint16_t mask = uint16_t(1 << (len - rounded_len)) - 1;
+    __m128i in = _mm_maskz_loadu_epi8(mask, latin1_input + rounded_len);
+    __m256i out = _mm256_cvtepu8_epi16(in);
+    if (big_endian) {
+      out = _mm256_shuffle_epi8(out, byteflip);
+    }
+    // Handle the mask store manually for epi16
+    __m256i orig = _mm256_loadu_si256((__m256i *)&utf16_output[rounded_len]);
+    __m256i blended = _mm256_blendv_epi8(orig, out, _mm256_cvtepi16_epi32(_mm_set1_epi16(mask)));
+    _mm256_storeu_si256((__m256i *)&utf16_output[rounded_len], blended);
+  }
+
+  return len;
+} */
+
+
+/* #include <immintrin.h>
+
+template <endianness big_endian>
+size_t icelake_convert_latin1_to_utf16(const char *latin1_input, size_t len,
+                                       char16_t *utf16_output) {
+  size_t rounded_len = len & ~0xF; // Round down to nearest multiple of 16
+
+  __m256i byteflip = _mm256_setr_epi64x(0x0607040502030001, 0x0e0f0c0d0a0b0809,
+                                        0x0607040502030001, 0x0e0f0c0d0a0b0809);
+  for (size_t i = 0; i < rounded_len; i += 16) {
+    // Load 16 Latin1 characters into a 128-bit register
+    __m128i in = _mm_loadu_si128((__m128i *)&latin1_input[i]);
+    // Zero extend each set of 8 Latin1 characters to 16 times 16-bit integers
+    __m256i out = _mm256_cvtepu8_epi16(in);
+    if (big_endian) {
+      out = _mm256_shuffle_epi8(out, byteflip);
+    }
+    // Store the results back to memory
+    _mm256_storeu_si256((__m256i *)&utf16_output[i], out);
+  }
+  if (rounded_len != len) {
+    uint16_t mask = uint16_t(1 << (len - rounded_len)) - 1;
+    __m128i in = _mm_maskz_loadu_epi8(mask, latin1_input + rounded_len);
+
+    // Zero extend each set of 8 Latin1 characters to 16 16-bit integers
+    __m256i out = _mm256_cvtepu8_epi16(in);
+    if (big_endian) {
+      out = _mm256_shuffle_epi8(out, byteflip);
+    }
+    // Store the results back to memory
+    _mm256_maskstore_epi16(reinterpret_cast<int16_t *>(utf16_output + rounded_len), _mm256_set1_epi16(mask), out);
+  }
+
+  return len;
+}
+ */


### PR DESCRIPTION
These are my benchmark on big1 and gcc 11.3.1:

```
convert_latin1_to_utf16+haswell, input size: 432305, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.latin1.txt
   0.313 ins/byte,    0.243 cycle/byte,   13.170 GB/s (5.2 %),     3.200 GHz,    1.289 ins/cycle 
   0.313 ins/char,    0.243 cycle/char,   13.170 Gc/s (5.2 %)     1.00 byte/char 
convert_latin1_to_utf16+icelake, input size: 432305, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.latin1.txt
   0.157 ins/byte,    0.215 cycle/byte,   14.432 GB/s (2.4 %),     3.103 GHz,    0.729 ins/cycle 
   0.157 ins/char,    0.215 cycle/char,   14.432 Gc/s (2.4 %)     1.00 byte/char 
convert_latin1_to_utf16+iconv, input size: 432305, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.latin1.txt
  31.022 ins/byte,    7.012 cycle/byte,    0.455 GB/s (0.3 %),     3.193 GHz,    4.424 ins/cycle 
  31.022 ins/char,    7.012 cycle/char,    0.455 Gc/s (0.3 %)     1.00 byte/char 
convert_latin1_to_utf16+icu, input size: 432305, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.latin1.txt
   2.505 ins/byte,    0.644 cycle/byte,    4.961 GB/s (0.7 %),     3.195 GHz,    3.890 ins/cycle 
   2.505 ins/char,    0.644 cycle/char,    4.961 Gc/s (0.7 %)     1.00 byte/char 
convert_latin1_to_utf16+westmere, input size: 432305, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.latin1.txt
   0.563 ins/byte,    0.184 cycle/byte,   17.360 GB/s (2.6 %),     3.201 GHz,    3.053 ins/cycle 
   0.563 ins/char,    0.184 cycle/char,   17.360 Gc/s (2.6 %)     1.00 byte/char 
```