### PR TITLE
SSE Latin1 => UTF16

### DIFF
--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -33,6 +33,7 @@ simdutf_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> 
 #include "westmere/sse_validate_utf32le.cpp"
 
 #include "westmere/sse_convert_latin1_to_utf8.cpp"
+#include "westmere/sse_convert_latin1_to_utf16.cpp"
 #include "westmere/sse_convert_latin1_to_utf32.cpp"
 
 
@@ -178,13 +179,31 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(const char * b
 }
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16le(const char* buf, size_t len, char16_t* utf16_output) const noexcept {
-  return scalar::latin1_to_utf16::convert<endianness::LITTLE>(buf, len, utf16_output);
+    std::pair<const char*, char16_t*> ret = sse_convert_latin1_to_utf16<endianness::LITTLE>(buf, len, utf16_output);
+    if (ret.first == nullptr) { return 0; }
+    size_t converted_chars = ret.second - utf16_output;
+    if (ret.first != buf + len) {
+        const size_t scalar_converted_chars = scalar::latin1_to_utf16::convert<endianness::LITTLE>(
+                                              ret.first, len - (ret.first - buf), ret.second);
+        if (scalar_converted_chars == 0) { return 0; }
+        converted_chars += scalar_converted_chars;
+    }
+    return converted_chars;
 }
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(const char* buf, size_t len, char16_t* utf16_output) const noexcept {
   return scalar::latin1_to_utf16::convert<endianness::BIG>(buf, len, utf16_output);
+    std::pair<const char*, char16_t*> ret = sse_convert_latin1_to_utf16<endianness::BIG>(buf, len, utf16_output);
+    if (ret.first == nullptr) { return 0; }
+    size_t converted_chars = ret.second - utf16_output;
+    if (ret.first != buf + len) {
+        const size_t scalar_converted_chars = scalar::latin1_to_utf16::convert<endianness::BIG>(
+                                              ret.first, len - (ret.first - buf), ret.second);
+        if (scalar_converted_chars == 0) { return 0; }
+        converted_chars += scalar_converted_chars;
+    }
+    return converted_chars;
 }
-
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf32(const char* buf, size_t len, char32_t* utf32_output) const noexcept {
     std::pair<const char*, char32_t*> ret = sse_convert_latin1_to_utf32(buf, len, utf32_output);

--- a/src/westmere/sse_convert_latin1_to_utf16.cpp
+++ b/src/westmere/sse_convert_latin1_to_utf16.cpp
@@ -1,0 +1,26 @@
+template <endianness big_endian>
+std::pair<const char*, char16_t*> sse_convert_latin1_to_utf16(const char *latin1_input, size_t len,
+                                                              char16_t *utf16_output) {
+    size_t rounded_len = len & ~0xF; // Round down to nearest multiple of 16
+
+    __m128i swap;
+    if (big_endian) {
+        swap = _mm_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
+    }
+
+    for (size_t i = 0; i < rounded_len; i += 16) {
+        // Load 16 Latin1 characters into a 128-bit register
+        __m128i in = _mm_loadu_si128(reinterpret_cast<const __m128i*>(&latin1_input[i]));
+
+        if (big_endian) {
+            in = _mm_shuffle_epi8(in, swap);
+        }
+
+        // Zero extend each Latin1 character to 16-bit integers and store the results back to memory
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(&utf16_output[i]), _mm_unpacklo_epi8(in, _mm_setzero_si128()));
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(&utf16_output[i + 8]), _mm_unpackhi_epi8(in, _mm_setzero_si128()));
+    }
+
+    // return pointers pointing to where we left off
+    return std::make_pair(latin1_input + rounded_len, utf16_output + rounded_len);
+}


### PR DESCRIPTION
Wanted to work a bit on SSE latin1 => Utf16 to compare apple to apple as much as possible. Looks like it gives more or less the speeds. 

Coming back to the other PR later on today

```
convert_latin1_to_utf16+haswell, input size: 432305, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.latin1.txt
   0.282 ins/byte,    0.207 cycle/byte,   15.456 GB/s (3.1 %),     3.202 GHz,    1.361 ins/cycle 
   0.282 ins/char,    0.207 cycle/char,   15.456 Gc/s (3.1 %)     1.00 byte/char 
convert_latin1_to_utf16+icelake, input size: 432305, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.latin1.txt
   0.157 ins/byte,    0.214 cycle/byte,   14.472 GB/s (2.3 %),     3.103 GHz,    0.731 ins/cycle 
   0.157 ins/char,    0.214 cycle/char,   14.472 Gc/s (2.3 %)     1.00 byte/char 
convert_latin1_to_utf16+iconv, input size: 432305, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.latin1.txt
  31.022 ins/byte,    7.011 cycle/byte,    0.455 GB/s (0.2 %),     3.193 GHz,    4.424 ins/cycle 
  31.022 ins/char,    7.011 cycle/char,    0.455 Gc/s (0.2 %)     1.00 byte/char 
convert_latin1_to_utf16+icu, input size: 432305, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.latin1.txt
   2.505 ins/byte,    0.641 cycle/byte,    4.983 GB/s (0.8 %),     3.195 GHz,    3.907 ins/cycle 
   2.505 ins/char,    0.641 cycle/char,    4.983 Gc/s (0.8 %)     1.00 byte/char 
convert_latin1_to_utf16+westmere, input size: 432305, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.latin1.txt
   0.501 ins/byte,    0.179 cycle/byte,   17.888 GB/s (2.5 %),     3.204 GHz,    2.795 ins/cycle 
   0.501 ins/char,    0.179 cycle/char,   17.888 Gc/s (2.5 %)     1.00 byte/char 
```