### PR TITLE
AVX2 UTF16 => Latin1

### DIFF
--- a/src/haswell/avx2_convert_utf16_to_latin1.cpp
+++ b/src/haswell/avx2_convert_utf16_to_latin1.cpp
@@ -1,0 +1,70 @@
+template <endianness big_endian>
+std::pair<const char16_t*, char*> avx2_convert_utf16_to_latin1(const char16_t* buf, size_t len, char* latin1_output) {
+  const char16_t* end = buf + len;
+  while (buf + 16 <= end) {
+    // Load 16 UTF-16 characters into 256-bit AVX2 register
+    __m256i in = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(buf));
+
+    if (!match_system(big_endian)) {
+      const __m256i swap = _mm256_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14,
+                                            17, 16, 19, 18, 21, 20, 23, 22, 25, 24, 27, 26, 29, 28, 31, 30);
+      in = _mm256_shuffle_epi8(in, swap);
+    }
+
+    __m256i high_byte_mask = _mm256_set1_epi16((int16_t)0xFF00);
+    if (_mm256_testz_si256(in, high_byte_mask)) {
+      // Pack 16-bit characters into 8-bit and store in latin1_output
+      __m128i lo = _mm256_extractf128_si256(in, 0);
+      __m128i hi = _mm256_extractf128_si256(in, 1);
+      __m128i latin1_packed_lo = _mm_packus_epi16(lo, lo);
+      __m128i latin1_packed_hi = _mm_packus_epi16(hi, hi);
+      _mm_storel_epi64(reinterpret_cast<__m128i*>(latin1_output), latin1_packed_lo);
+      _mm_storel_epi64(reinterpret_cast<__m128i*>(latin1_output + 8), latin1_packed_hi);
+      // Adjust pointers for next iteration
+      buf += 16;
+      latin1_output += 16;
+    } else {
+      return std::make_pair(nullptr, reinterpret_cast<char*>(latin1_output));
+    }
+  } // while
+  return std::make_pair(buf, latin1_output);
+}
+
+template <endianness big_endian>
+std::pair<result, char*> avx2_convert_utf16_to_latin1_with_errors(const char16_t* buf, size_t len, char* latin1_output) {
+    const char16_t* start = buf;
+    const char16_t* end = buf + len;
+    while (buf + 16 <= end) {
+        __m256i in = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(buf));
+
+        if (!big_endian) {
+            const __m256i swap = _mm256_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14,
+                                                  17, 16, 19, 18, 21, 20, 23, 22, 25, 24, 27, 26, 29, 28, 31, 30);
+            in = _mm256_shuffle_epi8(in, swap);
+        }
+
+        __m256i high_byte_mask = _mm256_set1_epi16((int16_t)0xFF00);
+        if (_mm256_testz_si256(in, high_byte_mask)) {
+            __m128i lo = _mm256_extractf128_si256(in, 0);
+            __m128i hi = _mm256_extractf128_si256(in, 1);
+            __m128i latin1_packed_lo = _mm_packus_epi16(lo, lo);
+            __m128i latin1_packed_hi = _mm_packus_epi16(hi, hi);
+            _mm_storel_epi64(reinterpret_cast<__m128i*>(latin1_output), latin1_packed_lo);
+            _mm_storel_epi64(reinterpret_cast<__m128i*>(latin1_output + 8), latin1_packed_hi);
+            buf += 16;
+            latin1_output += 16;
+        } else {
+            // Fallback to scalar code for handling errors
+            for(int k = 0; k < 16; k++) {
+                uint16_t word = !match_system(big_endian) ? scalar::utf16::swap_bytes(buf[k]) : buf[k];
+                if(word <= 0xff) {
+                    *latin1_output++ = char(word);
+                } else {
+                    return std::make_pair(result{error_code::TOO_LARGE, buf - start + k}, latin1_output);
+                }
+            }
+            buf += 16;
+        }
+    } // while
+    return std::make_pair(result{error_code::SUCCESS, buf - start}, latin1_output);
+}

--- a/src/haswell/avx2_convert_utf16_to_latin1.cpp
+++ b/src/haswell/avx2_convert_utf16_to_latin1.cpp
@@ -66,5 +66,5 @@ std::pair<result, char*> avx2_convert_utf16_to_latin1_with_errors(const char16_t
             buf += 16;
         }
     } // while
-    return std::make_pair(result{error_code::SUCCESS, buf - start}, latin1_output);
+    return std::make_pair(result{error_code::SUCCESS, (size_t)(buf - start)}, latin1_output);
 }

--- a/src/haswell/avx2_convert_utf16_to_latin1.cpp
+++ b/src/haswell/avx2_convert_utf16_to_latin1.cpp
@@ -1,13 +1,16 @@
 template <endianness big_endian>
-std::pair<const char16_t*, char*> avx2_convert_utf16_to_latin1(const char16_t* buf, size_t len, char* latin1_output) {
-  const char16_t* end = buf + len;
+std::pair<const char16_t *, char *>
+avx2_convert_utf16_to_latin1(const char16_t *buf, size_t len,
+                             char *latin1_output) {
+  const char16_t *end = buf + len;
   while (buf + 16 <= end) {
     // Load 16 UTF-16 characters into 256-bit AVX2 register
-    __m256i in = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(buf));
+    __m256i in = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf));
 
     if (!match_system(big_endian)) {
-      const __m256i swap = _mm256_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14,
-                                            17, 16, 19, 18, 21, 20, 23, 22, 25, 24, 27, 26, 29, 28, 31, 30);
+      const __m256i swap = _mm256_setr_epi8(
+          1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14, 17, 16, 19, 18,
+          21, 20, 23, 22, 25, 24, 27, 26, 29, 28, 31, 30);
       in = _mm256_shuffle_epi8(in, swap);
     }
 
@@ -18,53 +21,65 @@ std::pair<const char16_t*, char*> avx2_convert_utf16_to_latin1(const char16_t* b
       __m128i hi = _mm256_extractf128_si256(in, 1);
       __m128i latin1_packed_lo = _mm_packus_epi16(lo, lo);
       __m128i latin1_packed_hi = _mm_packus_epi16(hi, hi);
-      _mm_storel_epi64(reinterpret_cast<__m128i*>(latin1_output), latin1_packed_lo);
-      _mm_storel_epi64(reinterpret_cast<__m128i*>(latin1_output + 8), latin1_packed_hi);
+      _mm_storel_epi64(reinterpret_cast<__m128i *>(latin1_output),
+                       latin1_packed_lo);
+      _mm_storel_epi64(reinterpret_cast<__m128i *>(latin1_output + 8),
+                       latin1_packed_hi);
       // Adjust pointers for next iteration
       buf += 16;
       latin1_output += 16;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char*>(latin1_output));
+      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
     }
   } // while
   return std::make_pair(buf, latin1_output);
 }
 
 template <endianness big_endian>
-std::pair<result, char*> avx2_convert_utf16_to_latin1_with_errors(const char16_t* buf, size_t len, char* latin1_output) {
-    const char16_t* start = buf;
-    const char16_t* end = buf + len;
-    while (buf + 16 <= end) {
-        __m256i in = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(buf));
+std::pair<result, char *>
+avx2_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
+                                         char *latin1_output) {
+  const char16_t *start = buf;
+  const char16_t *end = buf + len;
+  while (buf + 16 <= end) {
+    __m256i in = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf));
 
-        if (!big_endian) {
-            const __m256i swap = _mm256_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14,
-                                                  17, 16, 19, 18, 21, 20, 23, 22, 25, 24, 27, 26, 29, 28, 31, 30);
-            in = _mm256_shuffle_epi8(in, swap);
-        }
+    if (!big_endian) {
+      const __m256i swap = _mm256_setr_epi8(
+          1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14, 17, 16, 19, 18,
+          21, 20, 23, 22, 25, 24, 27, 26, 29, 28, 31, 30);
+      in = _mm256_shuffle_epi8(in, swap);
+    }
 
-        __m256i high_byte_mask = _mm256_set1_epi16((int16_t)0xFF00);
-        if (_mm256_testz_si256(in, high_byte_mask)) {
-            __m128i lo = _mm256_extractf128_si256(in, 0);
-            __m128i hi = _mm256_extractf128_si256(in, 1);
-            __m128i latin1_packed_lo = _mm_packus_epi16(lo, lo);
-            __m128i latin1_packed_hi = _mm_packus_epi16(hi, hi);
-            _mm_storel_epi64(reinterpret_cast<__m128i*>(latin1_output), latin1_packed_lo);
-            _mm_storel_epi64(reinterpret_cast<__m128i*>(latin1_output + 8), latin1_packed_hi);
-            buf += 16;
-            latin1_output += 16;
+    __m256i high_byte_mask = _mm256_set1_epi16((int16_t)0xFF00);
+    if (_mm256_testz_si256(in, high_byte_mask)) {
+      __m128i lo = _mm256_extractf128_si256(in, 0);
+      __m128i hi = _mm256_extractf128_si256(in, 1);
+      __m128i latin1_packed_lo = _mm_packus_epi16(lo, lo);
+      __m128i latin1_packed_hi = _mm_packus_epi16(hi, hi);
+      _mm_storel_epi64(reinterpret_cast<__m128i *>(latin1_output),
+                       latin1_packed_lo);
+      _mm_storel_epi64(reinterpret_cast<__m128i *>(latin1_output + 8),
+                       latin1_packed_hi);
+      buf += 16;
+      latin1_output += 16;
+    } else {
+      // Fallback to scalar code for handling errors
+      for (int k = 0; k < 16; k++) {
+        uint16_t word = !match_system(big_endian)
+                            ? scalar::utf16::swap_bytes(buf[k])
+                            : buf[k];
+        if (word <= 0xff) {
+          *latin1_output++ = char(word);
         } else {
-            // Fallback to scalar code for handling errors
-            for(int k = 0; k < 16; k++) {
-                uint16_t word = !match_system(big_endian) ? scalar::utf16::swap_bytes(buf[k]) : buf[k];
-                if(word <= 0xff) {
-                    *latin1_output++ = char(word);
-                } else {
-                    return std::make_pair(result{error_code::TOO_LARGE, (size_t)(buf - start + k)}, latin1_output);
-                }
-            }
-            buf += 16;
+          return std::make_pair(
+              result{error_code::TOO_LARGE, (size_t)(buf - start + k)},
+              latin1_output);
         }
-    } // while
-    return std::make_pair(result{error_code::SUCCESS, (size_t)(buf - start)}, latin1_output);
+      }
+      buf += 16;
+    }
+  } // while
+  return std::make_pair(result{error_code::SUCCESS, (size_t)(buf - start)},
+                        latin1_output);
 }

--- a/src/haswell/avx2_convert_utf16_to_latin1.cpp
+++ b/src/haswell/avx2_convert_utf16_to_latin1.cpp
@@ -60,7 +60,7 @@ std::pair<result, char*> avx2_convert_utf16_to_latin1_with_errors(const char16_t
                 if(word <= 0xff) {
                     *latin1_output++ = char(word);
                 } else {
-                    return std::make_pair(result{error_code::TOO_LARGE, buf - start + k}, latin1_output);
+                    return std::make_pair(result{error_code::TOO_LARGE, (size_t)(buf - start + k)}, latin1_output);
                 }
             }
             buf += 16;

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -51,6 +51,7 @@ simdutf_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> 
 #include "haswell/avx2_convert_utf8_to_utf16.cpp"
 #include "haswell/avx2_convert_utf8_to_utf32.cpp"
 
+#include "haswell/avx2_convert_utf16_to_latin1.cpp"
 #include "haswell/avx2_convert_utf16_to_utf8.cpp"
 #include "haswell/avx2_convert_utf16_to_utf32.cpp"
 
@@ -286,19 +287,67 @@ simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf32(const cha
 
 
 simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf16_to_latin1::convert<endianness::LITTLE>(buf, len, latin1_output);
+  std::pair<const char16_t*, char*> ret = haswell::avx2_convert_utf16_to_latin1<endianness::LITTLE>(buf, len, latin1_output);
+  if (ret.first == nullptr) { return 0; }
+  size_t saved_bytes = ret.second - latin1_output;
+  if (ret.first != buf + len) {
+    const size_t scalar_saved_bytes = scalar::utf16_to_latin1::convert<endianness::LITTLE>(
+                                        ret.first, len - (ret.first - buf), ret.second);
+    if (scalar_saved_bytes == 0) { return 0; }
+    saved_bytes += scalar_saved_bytes;
+  }
+  return saved_bytes;
 }
 
-simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
+/* simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
   return scalar::utf16_to_latin1::convert<endianness::BIG>(buf, len, latin1_output);
+} */
+
+simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
+  std::pair<const char16_t*, char*> ret = haswell::avx2_convert_utf16_to_latin1<endianness::BIG>(buf, len, latin1_output);
+  if (ret.first == nullptr) { return 0; }
+  size_t saved_bytes = ret.second - latin1_output;
+  if (ret.first != buf + len) {
+    const size_t scalar_saved_bytes = scalar::utf16_to_latin1::convert<endianness::BIG>(
+                                        ret.first, len - (ret.first - buf), ret.second);
+    if (scalar_saved_bytes == 0) { return 0; }
+    saved_bytes += scalar_saved_bytes;
+  }
+  return saved_bytes;
 }
 
 simdutf_warn_unused result implementation::convert_utf16le_to_latin1_with_errors(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf16_to_latin1::convert_with_errors<endianness::LITTLE>(buf, len, latin1_output);
+  std::pair<result, char*> ret = avx2_convert_utf16_to_latin1_with_errors<endianness::LITTLE>(buf, len, latin1_output);
+  if (ret.first.error) { return ret.first; }  // Can return directly since scalar fallback already found correct ret.first.count
+  if (ret.first.count != len) { // All good so far, but not finished
+    result scalar_res = scalar::utf16_to_latin1::convert_with_errors<endianness::LITTLE>(
+                                        buf + ret.first.count, len - ret.first.count, ret.second);
+    if (scalar_res.error) {
+      scalar_res.count += ret.first.count;
+      return scalar_res;
+    } else {
+      ret.second += scalar_res.count;
+    }
+  }
+  ret.first.count = ret.second - latin1_output;   // Set count to the number of 8-bit code units written
+  return ret.first;
 }
 
 simdutf_warn_unused result implementation::convert_utf16be_to_latin1_with_errors(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf16_to_latin1::convert_with_errors<endianness::BIG>(buf, len, latin1_output);
+  std::pair<result, char*> ret = avx2_convert_utf16_to_latin1_with_errors<endianness::BIG>(buf, len, latin1_output);
+  if (ret.first.error) { return ret.first; }  // Can return directly since scalar fallback already found correct ret.first.count
+  if (ret.first.count != len) { // All good so far, but not finished
+    result scalar_res = scalar::utf16_to_latin1::convert_with_errors<endianness::BIG>(
+                                        buf + ret.first.count, len - ret.first.count, ret.second);
+    if (scalar_res.error) {
+      scalar_res.count += ret.first.count;
+      return scalar_res;
+    } else {
+      ret.second += scalar_res.count;
+    }
+  }
+  ret.first.count = ret.second - latin1_output;   // Set count to the number of 8-bit code units written
+  return ret.first;
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16be_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -299,10 +299,6 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(const char1
   return saved_bytes;
 }
 
-/* simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
-  return scalar::utf16_to_latin1::convert<endianness::BIG>(buf, len, latin1_output);
-} */
-
 simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(const char16_t* buf, size_t len, char* latin1_output) const noexcept {
   std::pair<const char16_t*, char*> ret = haswell::avx2_convert_utf16_to_latin1<endianness::BIG>(buf, len, latin1_output);
   if (ret.first == nullptr) { return 0; }


### PR DESCRIPTION
These are my benchmarks for this PR:

```
convert_utf16_to_latin1+haswell, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   0.438 ins/byte,    0.133 cycle/byte,   24.034 GB/s (1.2 %),     3.199 GHz,    3.291 ins/cycle 
   0.876 ins/char,    0.266 cycle/char,   12.017 Gc/s (1.2 %)     2.00 byte/char 
convert_utf16_to_latin1+icelake, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   0.172 ins/byte,    0.103 cycle/byte,   30.166 GB/s (1.7 %),     3.101 GHz,    1.675 ins/cycle 
   0.344 ins/char,    0.206 cycle/char,   15.083 Gc/s (1.7 %)     2.00 byte/char 
convert_utf16_to_latin1+iconv, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
  17.011 ins/byte,    3.024 cycle/byte,    1.056 GB/s (23.6 %),     3.193 GHz,    5.626 ins/cycle 
  34.022 ins/char,    6.047 cycle/char,    0.528 Gc/s (23.6 %)     2.00 byte/char 
WARNING: Measurements are noisy, try increasing iteration count (-I).
convert_utf16_to_latin1+icu, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   1.722 ins/byte,    0.384 cycle/byte,    8.327 GB/s (0.8 %),     3.195 GHz,    4.487 ins/cycle 
   3.444 ins/char,    0.767 cycle/char,    4.163 Gc/s (0.8 %)     2.00 byte/char 
convert_utf16_to_latin1+westmere, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   0.626 ins/byte,    0.137 cycle/byte,   23.383 GB/s (1.5 %),     3.199 GHz,    4.572 ins/cycle 
   1.251 ins/char,    0.274 cycle/char,   11.692 Gc/s (1.5 %)     2.00 byte/char 
convert_utf16_to_latin1_with_errors+haswell, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   2.344 ins/byte,    0.386 cycle/byte,    8.273 GB/s (0.8 %),     3.195 GHz,    6.070 ins/cycle 
   4.688 ins/char,    0.772 cycle/char,    4.137 Gc/s (0.8 %)     2.00 byte/char 
convert_utf16_to_latin1_with_errors+icelake, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   0.188 ins/byte,    0.100 cycle/byte,   30.994 GB/s (1.5 %),     3.101 GHz,    1.877 ins/cycle 
   0.376 ins/char,    0.200 cycle/char,   15.497 Gc/s (1.5 %)     2.00 byte/char 
convert_utf16_to_latin1_with_errors+westmere, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   2.688 ins/byte,    0.442 cycle/byte,    7.224 GB/s (0.5 %),     3.194 GHz,    6.078 ins/cycle 
   5.376 ins/char,    0.884 cycle/char,    3.612 Gc/s (0.5 %)     2.00 byte/char 
convert_valid_utf16_to_latin1+haswell, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   0.125 ins/byte,    0.084 cycle/byte,   37.953 GB/s (1.8 %),     3.203 GHz,    1.485 ins/cycle 
   0.251 ins/char,    0.169 cycle/char,   18.977 Gc/s (1.8 %)     2.00 byte/char 
convert_valid_utf16_to_latin1+icelake, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   0.047 ins/byte,    0.103 cycle/byte,   30.037 GB/s (1.6 %),     3.101 GHz,    0.458 ins/cycle 
   0.095 ins/char,    0.206 cycle/char,   15.018 Gc/s (1.6 %)     2.00 byte/char 
convert_valid_utf16_to_latin1+westmere, input size: 864610, iterations: 30000, dataset: /home/leorio/unicode_lipsum/wikipedia_mars/french.utflatin16.txt
   0.282 ins/byte,    0.095 cycle/byte,   33.688 GB/s (2.4 %),     3.202 GHz,    2.962 ins/cycle 
   0.563 ins/char,    0.190 cycle/char,   16.844 Gc/s (2.4 %)     2.00 byte/char 
```