### PR TITLE
fix utf8type.py

### DIFF
--- a/benchmarks/dataset/scripts/utf8type.py
+++ b/benchmarks/dataset/scripts/utf8type.py
@@ -12,11 +12,11 @@ with open(filename, "rb") as file_content:
     maxv = max(array)
     minv = min(array)
     if(minv < 0): print("bug")
-    if(maxv>=240):
+    if(maxv>=0b11110000):
         print("four bytes")
-    elif(maxv>=0b11110000):
-        print("three bytes")
     elif(maxv>=0b11100000):
+        print("three bytes")
+    elif(maxv>=0b11000000):
         print("two bytes")
     else:
         print("ascii")
@@ -24,17 +24,17 @@ with open(filename, "rb") as file_content:
     for x in array:
         if(x>=0b11110000):
           counter[3] += 1
-        elif(maxv>=0b11100000):
+        elif(x>=0b11100000):
           counter[2] += 1
-        elif(maxv>=0b11000000):
+        elif(x>=0b11000000):
           counter[1] += 1
-        elif(maxv < 0b10000000):
+        elif(x < 0b10000000):
           counter[0] += 1
         else:
           #we have a continuation byte
           pass
     print("ASCII: {}  2-Bytes: {}  3-Bytes: {} 4-Bytes: {}".format(*counter))
-    l = len(array)
+    l = sum(counter)
     counter = [c * 100.0 / l for c in counter]
     print("ASCII: {}%  2-Bytes: {}%  3-Bytes: {}% 4-Bytes: {}%".format(*counter))
 


### PR DESCRIPTION
The `utf8type.py` script currently doesn't behave as expected, and reports the wrong character counts:

```bash
$ ./scripts/utf8type.py wikipedia_mars/chinese.txt
two bytes
ASCII: 0  2-Bytes: 0  3-Bytes: 95328 4-Bytes: 0
ASCII: 0.0%  2-Bytes: 0.0%  3-Bytes: 100.0% 4-Bytes: 0.0%
```

after the patch:

```bash
$ ./scripts/utf8type.py wikipedia_mars/chinese.txt
three bytes
ASCII: 32751  2-Bytes: 507  3-Bytes: 20521 4-Bytes: 0
ASCII: 34.35611782477341%  2-Bytes: 0.5318479355488419%  3-Bytes: 21.526728768042968% 4-Bytes: 0.0%
```

The output might be a bit confusing as the percentages don't add up to 100%, since it uses the percentage of total bytes used by the character types.

To get the percentage of characters that have a specific length, `l = len(array)` could be changed to `l = sum(counts)`, this would result in:

```
$ ./scripts/utf8type.py wikipedia_mars/chinese.txt
three bytes
ASCII: 32751  2-Bytes: 507  3-Bytes: 20521 4-Bytes: 0
ASCII: 60.899235761170715%  2-Bytes: 0.9427471689693003%  3-Bytes: 38.15801706985998% 4-Bytes: 0.0%
```
