### PR TITLE
Issue 333

### DIFF
--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           mkdir build &&
           cd build &&
-          cmake -DCMAKE_CXX_FLAGS=-Werror -DCMAKE_INSTALL_PREFIX:PATH=destination -DBUILD_SHARED_LIBS=${{matrix.shared}} ..  -DSIMDUTF_BENCHMARKS=OFF &&
+          cmake -DCMAKE_CXX_FLAGS=-Werror -DSIMDUTF_BENCHMARKS=ON  -DCMAKE_INSTALL_PREFIX:PATH=destination -DBUILD_SHARED_LIBS=${{matrix.shared}} ..  -DSIMDUTF_BENCHMARKS=OFF &&
           cmake --build .   &&
           ctest -j --output-on-failure &&
           cmake --install . &&

--- a/.github/workflows/ubuntu22_gcc12.yml
+++ b/.github/workflows/ubuntu22_gcc12.yml
@@ -22,6 +22,6 @@ jobs:
         run: |
           mkdir build &&
           cd build &&
-          CXX=g++-12 cmake -DCMAKE_CXX_FLAGS=-Werror  -DBUILD_SHARED_LIBS=${{matrix.shared}} ..  -DSIMDUTF_BENCHMARKS=OFF &&
+          CXX=g++-12 cmake -DCMAKE_CXX_FLAGS=-Werror -DSIMDUTF_BENCHMARKS=ON  -DBUILD_SHARED_LIBS=${{matrix.shared}} ..  -DSIMDUTF_BENCHMARKS=OFF &&
           cmake --build .   &&
           ctest -j --output-on-failure

--- a/.github/workflows/vs16-ci.yml
+++ b/.github/workflows/vs16-ci.yml
@@ -19,11 +19,11 @@ jobs:
       uses: actions/checkout@v3
     - name: Configure
       run: |
-        cmake -G "${{matrix.gen}}" -A ${{matrix.arch}} -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build
+        cmake -G "${{matrix.gen}}" -DSIMDUTF_BENCHMARKS=ON -A ${{matrix.arch}} -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build
     - name: Build Debug
-      run: cmake --build build -DSIMDUTF_BENCHMARKS=ON --config Debug --verbose
+      run: cmake --build build --config Debug --verbose
     - name: Build Release
-      run: cmake --build build -DSIMDUTF_BENCHMARKS=ON --config Release --verbose
+      run: cmake --build build --config Release --verbose
     - name: Run Release tests
       run: |
         cd build

--- a/.github/workflows/vs16-ci.yml
+++ b/.github/workflows/vs16-ci.yml
@@ -21,9 +21,9 @@ jobs:
       run: |
         cmake -G "${{matrix.gen}}" -A ${{matrix.arch}} -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build
     - name: Build Debug
-      run: cmake --build build --config Debug --verbose
+      run: cmake --build build -DSIMDUTF_BENCHMARKS=ON --config Debug --verbose
     - name: Build Release
-      run: cmake --build build --config Release --verbose
+      run: cmake --build build -DSIMDUTF_BENCHMARKS=ON --config Release --verbose
     - name: Run Release tests
       run: |
         cd build

--- a/.github/workflows/vs17-ci-cxx20.yml
+++ b/.github/workflows/vs17-ci-cxx20.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Configure
       run: |
-        cmake  -DSIMDUTF_CXX_STANDARD=20 -G "${{matrix.gen}}" -A ${{matrix.arch}} -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build
+        cmake  -DSIMDUTF_CXX_STANDARD=20 -DSIMDUTF_BENCHMARKS=ON -G "${{matrix.gen}}" -A ${{matrix.arch}} -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build
     - name: Build Debug
       run: cmake --build build --config Debug --verbose
     - name: Build Release

--- a/.github/workflows/vs17-ci.yml
+++ b/.github/workflows/vs17-ci.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Configure
       run: |
-        cmake -G "${{matrix.gen}}" -A ${{matrix.arch}} -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build
+        cmake -G "${{matrix.gen}}" -A ${{matrix.arch}} -DSIMDUTF_BENCHMARKS=ON -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build
     - name: Build Debug
       run: cmake --build build --config Debug --verbose
     - name: Build Release

--- a/.github/workflows/vs17-clang-ci.yml
+++ b/.github/workflows/vs17-clang-ci.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Configure
       run: |
-        cmake -G "${{matrix.gen}}" -A ${{matrix.arch}}  -T ClangCL -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build
+        cmake -G "${{matrix.gen}}" -A ${{matrix.arch}} -DSIMDUTF_BENCHMARKS=ON  -T ClangCL -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build
     - name: Build Debug
       run: cmake --build build --config Debug --verbose
     - name: Build Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ include(cmake/simdutf-flags.cmake)
 set(SIMDUTF_LIB_VERSION "5.0.0" CACHE STRING "simdutf library version")
 set(SIMDUTF_LIB_SOVERSION "5" CACHE STRING "simdutf library soversion")
 option(SIMDUTF_TESTS "Whether the tests are included as part of the CMake Build." ON)
-option(SIMDUTF_BENCHMARKS "Whether the benchmarks are included as part of the CMake Build." ON)
+option(SIMDUTF_BENCHMARKS "Whether the benchmarks are included as part of the CMake Build." OFF)
 option(SIMDUTF_TOOLS "Whether the tools are included as part of the CMake build." ON)
 option(SIMDUTF_ICONV "Whether to use iconv as part of the CMake build if available." ON)
 

--- a/benchmarks/competition/inoue2008/inoue_utf8_to_utf16.h
+++ b/benchmarks/competition/inoue2008/inoue_utf8_to_utf16.h
@@ -44,9 +44,9 @@
 #define INOUE2008
 #include "inoue_utf8_to_utf16_tables.h"
 #include <utility>
-#ifdef __ARM_NEON
+#ifdef __aarch64__
 #include <arm_neon.h>
-#endif // __ARM_NEON
+#endif // __aarch64__
 
 #ifdef __x86_64__
 #include "simdutf.h"
@@ -77,7 +77,7 @@ SIMDUTF_TARGET_WESTMERE
 #endif // __x86_64__
 
 namespace inoue2008 {
-#ifdef __ARM_NEON
+#ifdef __aarch64__
 
 static inline uint8x16x2_t vector_load_32bytes(const uint8_t *ptr) noexcept {
   // Note that vld2q_u8 does interleave, which we do not want!
@@ -194,10 +194,10 @@ static inline void store_8_ascii_bytes_as_utf16(const uint8_t *input, char16_t *
   _mm_storeu_si128(reinterpret_cast<__m128i *>(output), _mm_cvtepu8_epi16(_mm_loadu_si128(reinterpret_cast<const __m128i *>(input))));
 }
 
-#else // __ARM_NEON
+#else // __aarch64__
 // It is not 64-bit ARM or x64 so...?
 #undef INOUE2008
-#endif // __ARM_NEON
+#endif // __aarch64__
 
 #ifdef INOUE2008
 static inline size_t scalar_convert_valid(const char *buf, size_t len,

--- a/include/simdutf/portability.h
+++ b/include/simdutf/portability.h
@@ -115,12 +115,7 @@
 #ifdef SIMDUTF_IS_32BITS
 #ifndef SIMDUTF_NO_PORTABILITY_WARNING
 // In the future, we may want to warn users of 32-bit systems that
-// the simdutf does not support accelerated kernels for such systems:
-//#pragma message("The simdutf library is designed \
-for 64-bit processors and it seems that you are not \
-compiling for a known 64-bit platform. All fast kernels \
-will be disabled and performance may be poor. Please \
-use a 64-bit target such as x64, 64-bit ARM or 64-bit PPC.")
+// the simdutf does not support accelerated kernels for such systems.
 #endif // SIMDUTF_NO_PORTABILITY_WARNING
 #endif // SIMDUTF_IS_32BITS
 

--- a/include/simdutf/portability.h
+++ b/include/simdutf/portability.h
@@ -114,7 +114,9 @@
 
 #ifdef SIMDUTF_IS_32BITS
 #ifndef SIMDUTF_NO_PORTABILITY_WARNING
-#pragma message("The simdutf library is designed \
+// In the future, we may want to warn users of 32-bit systems that
+// the simdutf does not support accelerated kernels for such systems:
+//#pragma message("The simdutf library is designed \
 for 64-bit processors and it seems that you are not \
 compiling for a known 64-bit platform. All fast kernels \
 will be disabled and performance may be poor. Please \


### PR DESCRIPTION
This PR does a few things:

- [x] By default, CMake will not build the benchmarks. It takes time and unless you can about benchmarking yourself, it is useless.
- [x] In the benchmark, we had one hand-coded implementation of a routine by Inoue et al. Incorrectly, this code would detect 32-bit ARM NEON as 64-bit ARM NEON.
- [x] I am silencing a build-time warning for 32-bit systems.

Fixes https://github.com/simdutf/simdutf/issues/333