### PR TITLE
Fixing issue 337: rewrite of sse_convert_utf32_to_latin1 (simplify)

### DIFF
--- a/src/westmere/sse_convert_utf32_to_latin1.cpp
+++ b/src/westmere/sse_convert_utf32_to_latin1.cpp
@@ -4,7 +4,7 @@ sse_convert_utf32_to_latin1(const char32_t *buf, size_t len,
   const size_t rounded_len = len & ~0xF; // Round down to nearest multiple of 16
 
   __m128i high_bytes_mask = _mm_set1_epi32(0xFFFFFF00);
-  __m128i shufmask_1 =
+  __m128i shufmask =
       _mm_set_epi8(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 12, 8, 4, 0);
 
   for (size_t i = 0; i < rounded_len; i += 16) {
@@ -20,18 +20,10 @@ sse_convert_utf32_to_latin1(const char32_t *buf, size_t len,
     if (!_mm_testz_si128(check_combined, high_bytes_mask)) {
       return std::make_pair(nullptr, latin1_output);
     }
-
-    __m128i shuffled1 = _mm_shuffle_epi8(in1, shufmask_1);
-    _mm_storeu_si64(latin1_output, shuffled1);
-    __m128i shuffled2 = _mm_shuffle_epi8(in2, shufmask_1);
-    _mm_storeu_si64(latin1_output + 4, shuffled2);
-    __m128i shuffled3 = _mm_shuffle_epi8(in3, shufmask_1);
-    _mm_storeu_si64(latin1_output + 8, shuffled3);
-    __m128i shuffled4 = _mm_shuffle_epi8(in4, shufmask_1);
-
-    *reinterpret_cast<uint32_t *>(latin1_output + 12) =
-        _mm_cvtsi128_si32(shuffled4);
-
+    __m128i pack1 = _mm_unpacklo_epi32(_mm_shuffle_epi8(in1, shufmask), _mm_shuffle_epi8(in2, shufmask));
+    __m128i pack2 = _mm_unpacklo_epi32(_mm_shuffle_epi8(in3, shufmask), _mm_shuffle_epi8(in4, shufmask));
+    __m128i pack = _mm_unpacklo_epi64(pack1, pack2);
+    _mm_storeu_si128((__m128i *)latin1_output, pack);
     latin1_output += 16;
     buf += 16;
   }
@@ -73,17 +65,10 @@ sse_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
       buf += 16;
       continue;
     }
-
-    __m128i shuffled1 = _mm_shuffle_epi8(in1, shufmask);
-    _mm_storeu_si64(latin1_output, shuffled1);
-    __m128i shuffled2 = _mm_shuffle_epi8(in2, shufmask);
-    _mm_storeu_si64(latin1_output + 4, shuffled2);
-    __m128i shuffled3 = _mm_shuffle_epi8(in3, shufmask);
-    _mm_storeu_si64(latin1_output + 8, shuffled3);
-    __m128i shuffled4 = _mm_shuffle_epi8(in4, shufmask);
-    *reinterpret_cast<uint32_t *>(latin1_output + 12) =
-        _mm_cvtsi128_si32(shuffled4);
-
+    __m128i pack1 = _mm_unpacklo_epi32(_mm_shuffle_epi8(in1, shufmask), _mm_shuffle_epi8(in2, shufmask));
+    __m128i pack2 = _mm_unpacklo_epi32(_mm_shuffle_epi8(in3, shufmask), _mm_shuffle_epi8(in4, shufmask));
+    __m128i pack = _mm_unpacklo_epi64(pack1, pack2);
+    _mm_storeu_si128((__m128i *)latin1_output, pack);
     latin1_output += 16;
     buf += 16;
   }


### PR DESCRIPTION
Performance note: the unpack instructions are very fast (1 latency, high throughput). So many machines can do the two unpack in one cycle, and then the second unpack immediately after. Then we store the result. Having fewer stores is beneficial. And it happens to solve build problems with GCC8.

Fixes https://github.com/simdutf/simdutf/issues/337

cc @anonrig 