### PR TITLE
bug: Fix out of bounds access for haswell simd op

### DIFF
--- a/src/simdutf/haswell/simd.h
+++ b/src/simdutf/haswell/simd.h
@@ -348,9 +348,7 @@ namespace simd {
 
       return  simd8x64<bool>(
         (this->chunks[0] <= mask_high) & (this->chunks[0] >= mask_low),
-        (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low),
-        (this->chunks[2] <= mask_high) & (this->chunks[2] >= mask_low),
-        (this->chunks[3] <= mask_high) & (this->chunks[3] >= mask_low)
+        (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low)
       ).to_bitmask();
     }
     simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {

--- a/src/simdutf/haswell/simd16-inl.h
+++ b/src/simdutf/haswell/simd16-inl.h
@@ -243,9 +243,7 @@ struct simd16<uint16_t>: base16_numeric<uint16_t>  {
 
       return  simd16x32<bool>(
         (this->chunks[0] <= mask_high) & (this->chunks[0] >= mask_low),
-        (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low),
-        (this->chunks[2] <= mask_high) & (this->chunks[2] >= mask_low),
-        (this->chunks[3] <= mask_high) & (this->chunks[3] >= mask_low)
+        (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low)
       ).to_bitmask();
     }
     simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {


### PR DESCRIPTION
NUM_CHUNKS can only be 2, but we are accessing
indexes outside of this range i.e. 2,3.