### PR TITLE
fix alignment issue for bele tests

### DIFF
--- a/tests/bele_tests.cpp
+++ b/tests/bele_tests.cpp
@@ -5,19 +5,16 @@
 #include <tests/helpers/test.h>
 
 // We use explicit arrays so that no funny business is possible.
-
-//
-// s = "@\u00A7\u2208\U0001D4AA"
 const unsigned char utf8_string[] = {0x40,0xc2,0xa7,0xe2,0x88,0x88,0xf0,0x9d,0x92,0xaa};
 const char *utf8 = reinterpret_cast<const char*>(utf8_string);
 const size_t utf8_size = sizeof(utf8_string)/sizeof(uint8_t);
 
-const unsigned char utf16le_string[] = {0x40,0x00,0xa7,0x00,0x08,0x22,0x35,0xd8,0xaa,0xdc};
+alignas(char16_t) const unsigned char utf16le_string[] = {0x40,0x00,0xa7,0x00,0x08,0x22,0x35,0xd8,0xaa,0xdc};
 const char16_t *utf16le = reinterpret_cast<const char16_t*>(utf16le_string);
 const size_t utf16_size = sizeof(utf16le_string)/sizeof(uint16_t);
 
 
-const unsigned char utf16be_string[] = {0x00,0x40,0x00,0xa7,0x22,0x08,0xd8,0x35,0xdc,0xaa};
+alignas(char16_t) const unsigned char utf16be_string[] = {0x00,0x40,0x00,0xa7,0x22,0x08,0xd8,0x35,0xdc,0xaa};
 const char16_t *utf16be = reinterpret_cast<const char16_t*>(utf16be_string);
 #if SIMDUTF_IS_BIG_ENDIAN
 const char16_t *utf16 = utf16be;
@@ -27,11 +24,11 @@ const char16_t *utf16 = utf16le;
 
 // Native order
 #if SIMDUTF_IS_BIG_ENDIAN
-const unsigned char utf32_string[] = {0x00,0x00,0x00,0x40,0x00,0x00,0x00,0xa7,0x00,0x00,0x22,0x08,0x00,0x01,0xd4,0xaa};
-const char32_t *utf32 = reinterpret_cast<const char32_t*>(utf32_string); // Technically undefined behavior.
+alignas(char32_t) const unsigned char utf32_string[] = {0x00,0x00,0x00,0x40,0x00,0x00,0x00,0xa7,0x00,0x00,0x22,0x08,0x00,0x01,0xd4,0xaa};
+const char32_t *utf32 = reinterpret_cast<const char32_t*>(utf32_string);
 #else
 const unsigned char utf32_string[] = {0x40,0x00,0x00,0x00,0xa7,0x00,0x00,0x00,0x08,0x22,0x00,0x00,0xaa,0xd4,0x01,0x00};
-const char32_t *utf32 = reinterpret_cast<const char32_t*>(utf32_string); // Technically undefined behavior.
+alignas(char32_t) const char32_t *utf32 = reinterpret_cast<const char32_t*>(utf32_string);
 #endif
 const size_t utf32_size = sizeof(utf32_string)/sizeof(char32_t);
 const size_t number_of_code_points = utf32_size;


### PR DESCRIPTION
The test is poorly written and on some system, it may lead to unaligned access when running the tests (armv7). Thanks to @clausecker for proposing a fix.

Fixes https://github.com/simdutf/simdutf/issues/341