### PR TITLE
The basic_fuzzer test times out too often when running the tests in debug mode under windows.

### DIFF
--- a/.github/workflows/vs16-ci.yml
+++ b/.github/workflows/vs16-ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Run Debug tests
       run: |
         cd build
-        ctest -C Debug  --output-on-failure
+        ctest -C Debug  --output-on-failure -E basic_fuzzer
     - name: Install
       run: |
         cmake --install build --config Release

--- a/.github/workflows/vs17-ci-cxx20.yml
+++ b/.github/workflows/vs17-ci-cxx20.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Run Debug tests
       run: |
         cd build
-        ctest -C Debug  --output-on-failure
+        ctest -C Debug  --output-on-failure  -E basic_fuzzer
     - name: Install
       run: |
         cmake --install build --config Release

--- a/.github/workflows/vs17-ci.yml
+++ b/.github/workflows/vs17-ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Run Debug tests
       run: |
         cd build
-        ctest -C Debug  --output-on-failure
+        ctest -C Debug  --output-on-failure  -E basic_fuzzer
     - name: Install
       run: |
         cmake --install build --config Release

--- a/.github/workflows/vs17-clang-ci.yml
+++ b/.github/workflows/vs17-clang-ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Run Debug tests
       run: |
         cd build
-        ctest -C Debug  --output-on-failure
+        ctest -C Debug  --output-on-failure  -E basic_fuzzer
     - name: Install
       run: |
         cmake --install build --config Release


### PR DESCRIPTION
This should also speed up CI generally.