### PR TITLE
provide convenience functions to trim partial characters at the end of a string.

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -19,7 +19,7 @@ jobs:
           cd build
           cmake -DCMAKE_CXX_FLAGS=-Werror -DCMAKE_INSTALL_PREFIX:PATH=destination -DBUILD_SHARED_LIBS=${{matrix.shared}} ..   -DSIMDUTF_BENCHMARKS=OFF
           cmake --build .
-          ctest -j --output-on-failure
+          ctest --output-on-failure
           cmake --install .
           cd ../tests/installation_tests/find
           mkdir build

--- a/.github/workflows/ubuntu22sani.yml
+++ b/.github/workflows/ubuntu22sani.yml
@@ -19,11 +19,11 @@ jobs:
           cd build &&
           cmake -DSIMDUTF_SANITIZE=ON ..  &&
           cmake --build .   &&
-          ctest -j --output-on-failure
+          ctest --output-on-failure
       - name: Use cmake with undefined behavior sanitizer
         run: |
           mkdir buildundef &&
           cd buildundef &&
           cmake -DSIMDUTF_SANITIZE_UNDEFINED=ON ..  &&
           cmake --build .   &&
-          ctest -j --output-on-failure
+          ctest --output-on-failure

--- a/README.md
+++ b/README.md
@@ -1243,7 +1243,7 @@ You can use the same approach with UTF-16:
       simdutf::convert_utf16_to_utf8(unicode, length, utf8.get());
   // We can then transcode the next batch
   const char16_t * next = unicode + length;
-  size_t next_length = sizeof(unicode)/sizeof(char16_t) - length;
+  size_t next_length = 6 - length;
   size_t next_budget_utf8 = simdutf::utf8_length_from_utf16(next, next_length);
   std::unique_ptr<char[]> next_utf8{new char[next_budget_utf8]};
   size_t next_utf8words =

--- a/README.md
+++ b/README.md
@@ -1243,7 +1243,7 @@ You can use the same approach with UTF-16:
       simdutf::convert_utf16_to_utf8(unicode, length, utf8.get());
   // We can then transcode the next batch
   const char16_t * next = unicode + length;
-  size_t next_length = sizeof(unicode) - length;
+  size_t next_length = sizeof(unicode)/sizeof(char16_t) - length;
   size_t next_budget_utf8 = simdutf::utf8_length_from_utf16(next, next_length);
   std::unique_ptr<char[]> next_utf8{new char[next_budget_utf8]};
   size_t next_utf8words =

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -1319,6 +1319,68 @@ simdutf_warn_unused size_t count_utf16be(const char16_t * input, size_t length) 
 simdutf_warn_unused size_t count_utf8(const char * input, size_t length) noexcept;
 
 /**
+ * Given a valid UTF-8 string having a possibly truncated last character,
+ * this function checks the end of string. If the last character is truncated (or partial),
+ * then it returns a shorter length (shorter by 1 to 3 bytes) so that the short UTF-8
+ * strings only contain complete characters. If there is no truncated character,
+ * the original length is returned.
+ *
+ * This function assumes that the input string is valid UTF-8, but possibly truncated.
+ *
+ * @param input         the UTF-8 string to process
+ * @param length        the length of the string in bytes
+ * @return the length of the string in bytes, possibly shorter by 1 to 3 bytes
+ */
+simdutf_warn_unused size_t trim_partial_utf8(const char *input, size_t length);
+
+/**
+ * Given a valid UTF-16BE string having a possibly truncated last character,
+ * this function checks the end of string. If the last character is truncated (or partial),
+ * then it returns a shorter length (shorter by 1 unit) so that the short UTF-16BE
+ * strings only contain complete characters. If there is no truncated character,
+ * the original length is returned.
+ *
+ * This function assumes that the input string is valid UTF-16BE, but possibly truncated.
+ *
+ * @param input         the UTF-16BE string to process
+ * @param length        the length of the string in bytes
+ * @return the length of the string in bytes, possibly shorter by 1 unit
+ */
+simdutf_warn_unused size_t trim_partial_utf16be(const char16_t* input, size_t length);
+
+/**
+ * Given a valid UTF-16LE string having a possibly truncated last character,
+ * this function checks the end of string. If the last character is truncated (or partial),
+ * then it returns a shorter length (shorter by 1 unit) so that the short UTF-16LE
+ * strings only contain complete characters. If there is no truncated character,
+ * the original length is returned.
+ *
+ * This function assumes that the input string is valid UTF-16LE, but possibly truncated.
+ *
+ * @param input         the UTF-16LE string to process
+ * @param length        the length of the string in bytes
+ * @return the length of the string in unit, possibly shorter by 1 unit
+ */
+simdutf_warn_unused size_t trim_partial_utf16le(const char16_t* input, size_t length);
+
+
+/**
+ * Given a valid UTF-16 string having a possibly truncated last character,
+ * this function checks the end of string. If the last character is truncated (or partial),
+ * then it returns a shorter length (shorter by 1 unit) so that the short UTF-16
+ * strings only contain complete characters. If there is no truncated character,
+ * the original length is returned.
+ *
+ * This function assumes that the input string is valid UTF-16, but possibly truncated.
+ * We use the native endianness.
+ *
+ * @param input         the UTF-16 string to process
+ * @param length        the length of the string in bytes
+ * @return the length of the string in unit, possibly shorter by 1 unit
+ */
+simdutf_warn_unused size_t trim_partial_utf16(const char16_t* input, size_t length);
+
+/**
  * An implementation of simdutf for a particular CPU architecture.
  *
  * Also used to maintain the currently active implementation. The active implementation is

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -320,7 +320,7 @@ simdutf_warn_unused size_t convert_utf8_to_utf16be(const char * input, size_t le
 
 
   /**
-   * Convert possibly broken UTF-8 string into latin1 string. with errors
+   * Convert possibly broken UTF-8 string into latin1 string with errors.
    *
    * During the conversion also validation of the input string is done.
    * This function is suitable to work with inputs from untrusted sources.
@@ -1636,7 +1636,7 @@ public:
   simdutf_warn_unused virtual size_t convert_utf8_to_latin1(const char * input, size_t length, char* latin1_output) const noexcept = 0;
 
   /**
-   * Convert possibly broken UTF-8 string into latin1 string. with errors
+   * Convert possibly broken UTF-8 string into latin1 string with errors
    *
    * During the conversion also validation of the input string is done.
    * This function is suitable to work with inputs from untrusted sources.

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -28,6 +28,9 @@ std::string toBinaryString(T b) {
 #include "simdutf/ppc64.h"
 #include "simdutf/fallback.h" // have it always last.
 
+#include "scalar/utf8.h"
+#include "scalar/utf16.h"
+
 namespace simdutf {
 bool implementation::supported_by_runtime_system() const {
   uint32_t required_instruction_sets = this->required_instruction_sets();
@@ -1182,6 +1185,25 @@ const implementation * builtin_implementation() {
   return builtin_impl;
 }
 
+simdutf_warn_unused size_t trim_partial_utf8(const char *input, size_t length) {
+  return scalar::utf8::trim_partial_utf8(input, length);
+}
+
+simdutf_warn_unused size_t trim_partial_utf16be(const char16_t* input, size_t length) {
+  return scalar::utf16::trim_partial_utf16<BIG>(input, length);
+}
+
+simdutf_warn_unused size_t trim_partial_utf16le(const char16_t* input, size_t length) {
+  return scalar::utf16::trim_partial_utf16<LITTLE>(input, length);
+}
+
+simdutf_warn_unused size_t trim_partial_utf16(const char16_t* input, size_t length) {
+  #if SIMDUTF_IS_BIG_ENDIAN
+  return trim_partial_utf16be(input, length);
+  #else
+  return trim_partial_utf16le(input, length);
+  #endif
+}
 
 } // namespace simdutf
 

--- a/src/scalar/utf16.h
+++ b/src/scalar/utf16.h
@@ -103,6 +103,18 @@ simdutf_really_inline void change_endianness_utf16(const char16_t* in, size_t si
   }
 }
 
+
+template <endianness big_endian>
+simdutf_warn_unused inline size_t trim_partial_utf16(const char16_t* input, size_t length) {
+  if (length <= 1) {
+    return length;
+  }
+  uint16_t last_word = uint16_t(input[length-1]);
+  last_word = !match_system(big_endian) ? swap_bytes(last_word) : last_word;
+  length -= ((last_word & 0xFC00) == 0xD800);
+  return length;
+}
+
 } // utf16 namespace
 } // unnamed namespace
 } // namespace scalar

--- a/src/scalar/utf8.h
+++ b/src/scalar/utf8.h
@@ -195,6 +195,26 @@ inline size_t latin1_length_from_utf8(const char *buf, size_t len) {
     return answer;
 }
 
+simdutf_warn_unused inline size_t trim_partial_utf8(const char *input, size_t length) {
+  if (length < 3) {
+    switch (length) {
+      case 2:
+        if (uint8_t(input[length-1]) >= 0xc0) { return length-1; } // 2-, 3- and 4-byte characters with only 1 byte left
+        if (uint8_t(input[length-2]) >= 0xe0) { return length-2; } // 3- and 4-byte characters with only 2 bytes left
+        return length;
+      case 1:
+        if (uint8_t(input[length-1]) >= 0xc0) { return length-1; } // 2-, 3- and 4-byte characters with only 1 byte left
+        return length;
+      case 0:
+        return length;
+    }
+  }
+  if (uint8_t(input[length-1]) >= 0xc0) { return length-1; } // 2-, 3- and 4-byte characters with only 1 byte left
+  if (uint8_t(input[length-2]) >= 0xe0) { return length-2; } // 3- and 4-byte characters with only 1 byte left
+  if (uint8_t(input[length-3]) >= 0xf0) { return length-3; } // 4-byte characters with only 3 bytes left
+  return length;
+}
+
 } // utf8 namespace
 } // unnamed namespace
 } // namespace scalar

--- a/tests/helpers/test.h
+++ b/tests/helpers/test.h
@@ -34,7 +34,7 @@ void test_impl_##name(const simdutf::implementation& impl); \
 void name(const simdutf::implementation& impl) {            \
   std::string title = #name;                                \
   std::replace(title.begin(), title.end(), '_', ' ');       \
-  printf("%s...", title.c_str()); fflush(stdout);           \
+  printf("Running '%s'... ", title.c_str()); fflush(stdout);\
   test_impl_##name(impl);                                   \
   puts(" OK");                                              \
 }                                                           \

--- a/tests/readme_tests.cpp
+++ b/tests/readme_tests.cpp
@@ -79,24 +79,25 @@ TEST(utf8_streaming) {
 
 TEST(utf16_streaming) {
   // We have three sequences of surrogate pairs (UTF-16).
-  const char16_t unicode[] = u"\x3cd8\x10df\x3cd8\x10df\x3cd8\x10df";
+  alignas(char16_t) const char unicode_char[] = "\x3c\xd8\x10\xdf\x3c\xd8\x10\xdf\x3c\xd8\x10\xdf";
+  const char16_t * unicode = reinterpret_cast<const char16_t *>(unicode_char);
   // suppose you want to decode only the start of this string.
   size_t length = 3;
   // Picking 3 units is problematic because we might end up in the middle of a
   // surrogate pair. But we can rewind to the previous code point.
-  length = simdutf::trim_partial_utf16(unicode, length);
+  length = simdutf::trim_partial_utf16le(unicode, length);
   // Now we can transcode safely
-  size_t budget_utf8 = simdutf::utf8_length_from_utf16(unicode, length);
+  size_t budget_utf8 = simdutf::utf8_length_from_utf16le(unicode, length);
   std::unique_ptr<char[]> utf8{new char[budget_utf8]};
   size_t utf8words =
-      simdutf::convert_utf16_to_utf8(unicode, length, utf8.get());
+      simdutf::convert_utf16le_to_utf8(unicode, length, utf8.get());
   // We can then transcode the next batch
   const char16_t * next = unicode + length;
   size_t next_length = sizeof(unicode) - length;
-  size_t next_budget_utf8 = simdutf::utf8_length_from_utf16(next, next_length);
+  size_t next_budget_utf8 = simdutf::utf8_length_from_utf16le(next, next_length);
   std::unique_ptr<char[]> next_utf8{new char[next_budget_utf8]};
   size_t next_utf8words =
-      simdutf::convert_utf16_to_utf8(next, next_length, next_utf8.get());
+      simdutf::convert_utf16le_to_utf8(next, next_length, next_utf8.get());
   ASSERT_EQUAL(next_utf8words, next_budget_utf8);
   ASSERT_EQUAL(utf8words, budget_utf8);
 }

--- a/tests/readme_tests.cpp
+++ b/tests/readme_tests.cpp
@@ -93,7 +93,7 @@ TEST(utf16_streaming) {
       simdutf::convert_utf16le_to_utf8(unicode, length, utf8.get());
   // We can then transcode the next batch
   const char16_t * next = unicode + length;
-  size_t next_length = sizeof(unicode) - length;
+  size_t next_length = sizeof(unicode)/sizeof(char16_t) - length;
   size_t next_budget_utf8 = simdutf::utf8_length_from_utf16le(next, next_length);
   std::unique_ptr<char[]> next_utf8{new char[next_budget_utf8]};
   size_t next_utf8words =

--- a/tests/readme_tests.cpp
+++ b/tests/readme_tests.cpp
@@ -53,7 +53,53 @@ int main_demo() {
   return EXIT_SUCCESS;
 }
 
+TEST(utf8_streaming) {
+  const char unicode[] = "\xc3\xa9\x63ole d'\xc3\xa9t\xc3\xa9";
+  // suppose you want to decode only the start of this string.
+  size_t length = 10;
+  // Picking 10 bytes is problematic because we might end up in the middle of a
+  // code point. But we can rewind to the previous code point.
+  length = simdutf::trim_partial_utf8(unicode, length);
+  // Now we can transcode safely
+  size_t budget_utf16 = simdutf::utf16_length_from_utf8(unicode, length);
+  std::unique_ptr<char16_t[]> utf16{new char16_t[budget_utf16]};
+  size_t utf16words =
+      simdutf::convert_utf8_to_utf16le(unicode, length, utf16.get());
+  // We can then transcode the next batch
+  const char * next = unicode + length;
+  size_t next_length = sizeof(unicode) - length;
+  size_t next_budget_utf16 = simdutf::utf16_length_from_utf8(next, next_length);
+  std::unique_ptr<char16_t[]> next_utf16{new char16_t[next_budget_utf16]};
+  size_t next_utf16words =
+      simdutf::convert_utf8_to_utf16le(next, next_length, next_utf16.get());
+  ASSERT_EQUAL(next_utf16words, next_budget_utf16);
+  ASSERT_EQUAL(utf16words, budget_utf16);
+}
 
+
+TEST(utf16_streaming) {
+  // We have three sequences of surrogate pairs (UTF-16).
+  const char16_t unicode[] = u"\x3cd8\x10df\x3cd8\x10df\x3cd8\x10df";
+  // suppose you want to decode only the start of this string.
+  size_t length = 3;
+  // Picking 3 units is problematic because we might end up in the middle of a
+  // surrogate pair. But we can rewind to the previous code point.
+  length = simdutf::trim_partial_utf16(unicode, length);
+  // Now we can transcode safely
+  size_t budget_utf8 = simdutf::utf8_length_from_utf16(unicode, length);
+  std::unique_ptr<char[]> utf8{new char[budget_utf8]};
+  size_t utf8words =
+      simdutf::convert_utf16_to_utf8(unicode, length, utf8.get());
+  // We can then transcode the next batch
+  const char16_t * next = unicode + length;
+  size_t next_length = sizeof(unicode) - length;
+  size_t next_budget_utf8 = simdutf::utf8_length_from_utf16(next, next_length);
+  std::unique_ptr<char[]> next_utf8{new char[next_budget_utf8]};
+  size_t next_utf8words =
+      simdutf::convert_utf16_to_utf8(next, next_length, next_utf8.get());
+  ASSERT_EQUAL(next_utf8words, next_budget_utf8);
+  ASSERT_EQUAL(utf8words, budget_utf8);
+}
 
 TEST(error_location_badascii) {
   // this ASCII string has a bad byte at index 5

--- a/tests/readme_tests.cpp
+++ b/tests/readme_tests.cpp
@@ -93,7 +93,7 @@ TEST(utf16_streaming) {
       simdutf::convert_utf16le_to_utf8(unicode, length, utf8.get());
   // We can then transcode the next batch
   const char16_t * next = unicode + length;
-  size_t next_length = std::char_traits<char16_t>::length(unicode) - length;
+  size_t next_length = 6 - length;
   size_t next_budget_utf8 = simdutf::utf8_length_from_utf16le(next, next_length);
   std::unique_ptr<char[]> next_utf8{new char[next_budget_utf8]};
   size_t next_utf8words =

--- a/tests/readme_tests.cpp
+++ b/tests/readme_tests.cpp
@@ -93,7 +93,7 @@ TEST(utf16_streaming) {
       simdutf::convert_utf16le_to_utf8(unicode, length, utf8.get());
   // We can then transcode the next batch
   const char16_t * next = unicode + length;
-  size_t next_length = sizeof(unicode)/sizeof(char16_t) - length;
+  size_t next_length = std::char_traits<char16_t>::length(unicode) - length;
   size_t next_budget_utf8 = simdutf::utf8_length_from_utf16le(next, next_length);
   std::unique_ptr<char[]> next_utf8{new char[next_budget_utf8]};
   size_t next_utf8words =


### PR DESCRIPTION
If you take a UTF-8 (or UTF-16) input and consider an arbitrary prefix, the end of the prefix might contain a partial character.  You can simply roll back to the previous complete character, and decode without error. In the next iteration, you include the truncated content with the rest of the string.


You can thus decode a UTF-8 string piece by piece:

```cpp
  const char unicode[] = "\xc3\xa9\x63ole d'\xc3\xa9t\xc3\xa9";
  // suppose you want to decode only the start of this string.
  size_t length = 10;
  // Picking 10 bytes is problematic because we might end up in the middle of a
  // code point. But we can rewind to the previous code point.
  length = simdutf::trim_partial_utf8(unicode, length);
  // Now we can transcode safely
  size_t budget_utf16 = simdutf::utf16_length_from_utf8(unicode, length);
  std::unique_ptr<char16_t[]> utf16{new char16_t[budget_utf16]};
  size_t utf16words =
      simdutf::convert_utf8_to_utf16le(unicode, length, utf16.get());
  // We can then transcode the next batch
  const char * next = unicode + length;
  size_t next_length = sizeof(unicode) - length;
  size_t next_budget_utf16 = simdutf::utf16_length_from_utf8(next, next_length);
  std::unique_ptr<char16_t[]> next_utf16{new char16_t[next_budget_utf16]};
  size_t next_utf16words =
      simdutf::convert_utf8_to_utf16le(next, next_length, next_utf16.get());
```

fixes: https://github.com/simdutf/simdutf/issues/348