### PR TITLE
Silencing some more warnings.

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -1,7 +1,7 @@
 namespace simdutf {
 
-  simdutf_really_inline result::result() : error{error_code::SUCCESS}, count{0} {};
+  simdutf_really_inline result::result() : error{error_code::SUCCESS}, count{0} {}
 
-  simdutf_really_inline result::result(error_code _err, size_t _pos) : error{_err}, count{_pos} {};
+  simdutf_really_inline result::result(error_code _err, size_t _pos) : error{_err}, count{_pos} {}
 
 }

--- a/src/generic/utf8_to_latin1/valid_utf8_to_latin1.h
+++ b/src/generic/utf8_to_latin1/valid_utf8_to_latin1.h
@@ -68,7 +68,7 @@ using namespace simd;
       return latin1_output - start;
     }
 
-  }; 
+  }
 }   // utf8_to_latin1 namespace
 }   // unnamed namespace
 }   // namespace SIMDUTF_IMPLEMENTATION

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -123,7 +123,6 @@ implementation::detect_encodings(const char *input,
           }
           return simdutf::encoding_type::unspecified;
         }
-        break;
       }
       // If no surrogate, validate under other encodings as well
 

--- a/src/westmere/internal/write_v_u16_11bits_to_utf8.cpp
+++ b/src/westmere/internal/write_v_u16_11bits_to_utf8.cpp
@@ -51,7 +51,7 @@ inline void write_v_u16_11bits_to_utf8(
 
   // 6. adjust pointers
   utf8_output += row[0];
-};
+}
 
 inline void write_v_u16_11bits_to_utf8(
   const __m128i v_u16,
@@ -65,4 +65,4 @@ inline void write_v_u16_11bits_to_utf8(
 
   write_v_u16_11bits_to_utf8(
     v_u16, utf8_output, one_byte_bytemask, one_byte_bitmask);
-};
+}

--- a/src/westmere/sse_convert_latin1_to_utf8.cpp
+++ b/src/westmere/sse_convert_latin1_to_utf8.cpp
@@ -79,4 +79,4 @@ std::pair<const char* const, char* const> sse_convert_latin1_to_utf8(
   }
 
   return std::make_pair(latin_input, utf8_output);
-};
+}


### PR DESCRIPTION
A few more warnings were reported:

https://github.com/nodejs/node/pull/50930#issuecomment-1835032160

Note that all but one of these warnings have to do with C++98 compatibility but `simdutf` requires C++11 or better. 

cc @anonrig 