### PR TITLE
Update actions/checkout in GitHub Actions to v4

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2
         name: Test
         id: runcmd

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -6,7 +6,7 @@ jobs:
   ubuntu-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: start docker
         run: |
           docker run -w /src -dit --name alpine -v $PWD:/src alpine:latest

--- a/.github/workflows/armv7.yml
+++ b/.github/workflows/armv7.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2
         name: Test
         id: runcmd

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -16,7 +16,7 @@ jobs:
       image: debian:testing
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,7 +19,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Doxygen
         run: sudo apt-get install doxygen graphviz -y
       - name: Generate Doxygen Documentation

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -12,7 +12,7 @@ jobs:
           - {shared: ON}
           - {shared: OFF}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use cmake
         run: |
           mkdir build

--- a/.github/workflows/msys2-clang.yml
+++ b/.github/workflows/msys2-clang.yml
@@ -35,7 +35,7 @@ jobs:
       CMAKE_GENERATOR: Ninja
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
         with:
           update: true

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -35,7 +35,7 @@ jobs:
       CMAKE_GENERATOR: Ninja
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
         with:
           update: false

--- a/.github/workflows/s390x.yml
+++ b/.github/workflows/s390x.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2
         name: Test
         id: runcmd

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -17,7 +17,7 @@ jobs:
           - {shared: ON}
           - {shared: OFF}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use cmake
         run: |
           mkdir build &&

--- a/.github/workflows/ubuntu20sani.yml
+++ b/.github/workflows/ubuntu20sani.yml
@@ -12,7 +12,7 @@ jobs:
   ubuntu-build:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use cmake with address sanitizer
         run: |
           mkdir build &&

--- a/.github/workflows/ubuntu20single.yml
+++ b/.github/workflows/ubuntu20single.yml
@@ -12,7 +12,7 @@ jobs:
   ubuntu-build:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use cmake
         run: |
           python3 ./singleheader/amalgamate.py &&

--- a/.github/workflows/ubuntu22-cxx20.yml
+++ b/.github/workflows/ubuntu22-cxx20.yml
@@ -17,7 +17,7 @@ jobs:
           - {shared: ON}
           - {shared: OFF}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use cmake
         run: |
           mkdir build &&

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -17,7 +17,7 @@ jobs:
           - {shared: ON}
           - {shared: OFF}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use cmake
         run: |
           mkdir build &&

--- a/.github/workflows/ubuntu22_gcc12.yml
+++ b/.github/workflows/ubuntu22_gcc12.yml
@@ -17,7 +17,7 @@ jobs:
           - {shared: ON}
           - {shared: OFF}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use cmake
         run: |
           mkdir build &&

--- a/.github/workflows/ubuntu22sani.yml
+++ b/.github/workflows/ubuntu22sani.yml
@@ -12,7 +12,7 @@ jobs:
   ubuntu-build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use cmake with address sanitizer
         run: |
           mkdir build &&

--- a/.github/workflows/vs16-ci.yml
+++ b/.github/workflows/vs16-ci.yml
@@ -16,7 +16,7 @@ jobs:
           - {gen: Visual Studio 16 2019, arch: Win32, shared: OFF}
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure
       run: |
         cmake -G "${{matrix.gen}}" -DSIMDUTF_BENCHMARKS=ON -A ${{matrix.arch}} -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build

--- a/.github/workflows/vs17-arm-ci.yml
+++ b/.github/workflows/vs17-arm-ci.yml
@@ -13,7 +13,7 @@ jobs:
           - {gen: Visual Studio 17 2022, arch: ARM64}
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use cmake
         run: |
           cmake -G "${{matrix.gen}}" -A ${{ matrix.arch }} -DCMAKE_CROSSCOMPILING=1 -DSIMDUTF_ICONV=OFF -B build  &&

--- a/.github/workflows/vs17-ci-cxx20.yml
+++ b/.github/workflows/vs17-ci-cxx20.yml
@@ -16,7 +16,7 @@ jobs:
           - {gen: Visual Studio 17 2022, arch: Win32, shared: OFF}
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure
       run: |
         cmake  -DSIMDUTF_CXX_STANDARD=20 -DSIMDUTF_BENCHMARKS=ON -G "${{matrix.gen}}" -A ${{matrix.arch}} -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build

--- a/.github/workflows/vs17-ci.yml
+++ b/.github/workflows/vs17-ci.yml
@@ -16,7 +16,7 @@ jobs:
           - {gen: Visual Studio 17 2022, arch: Win32, shared: OFF}
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure
       run: |
         cmake -G "${{matrix.gen}}" -A ${{matrix.arch}} -DSIMDUTF_BENCHMARKS=ON -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build

--- a/.github/workflows/vs17-clang-ci.yml
+++ b/.github/workflows/vs17-clang-ci.yml
@@ -16,7 +16,7 @@ jobs:
           - {gen: Visual Studio 17 2022, arch: Win32, shared: OFF}
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure
       run: |
         cmake -G "${{matrix.gen}}" -A ${{matrix.arch}} -DSIMDUTF_BENCHMARKS=ON  -T ClangCL -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build


### PR DESCRIPTION
This updates [actions/checkout](https://github.com/actions/checkout) to v4, it's current version.

Changelog:

> ## v4.1.0
> - Add support for partial checkout filters
>
> ## v4.0.0
> - Support fetching without the --progress option
> - Update to node20