### PR TITLE
We can improve slightly UTF-8 validation under some x64 targets.

### DIFF
--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -33,10 +33,9 @@ simdutf_unused simdutf_really_inline simd8<bool> must_be_continuation(const simd
 }
 
 simdutf_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
-  simd8<uint8_t> is_third_byte  = prev2.saturating_sub(0b11100000u-1); // Only 111_____ will be > 0
-  simd8<uint8_t> is_fourth_byte = prev3.saturating_sub(0b11110000u-1); // Only 1111____ will be > 0
-  // Caller requires a bool (all 1's). All values resulting from the subtraction will be <= 64, so signed comparison is fine.
-  return simd8<int8_t>(is_third_byte | is_fourth_byte) > int8_t(0);
+  simd8<uint8_t> is_third_byte  = prev2.saturating_sub(0xe0u-0x80); // Only 111_____ will be > 0x80
+  simd8<uint8_t> is_fourth_byte = prev3.saturating_sub(0xf0u-0x80); // Only 1111____ will be > 0x80
+  return simd8<bool>(is_third_byte | is_fourth_byte);
 }
 
 #include "haswell/avx2_detect_encodings.cpp"

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -40,10 +40,10 @@ simdutf_unused simdutf_really_inline simd8<bool> must_be_continuation(const simd
 }
 
 simdutf_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
-  simd8<uint8_t> is_third_byte  = prev2.saturating_sub(0b11100000u-1); // Only 111_____ will be > 0
-  simd8<uint8_t> is_fourth_byte = prev3.saturating_sub(0b11110000u-1); // Only 1111____ will be > 0
+  simd8<uint8_t> is_third_byte  = prev2.saturating_sub(0xe0u-0x80); // Only 111_____ will be >= 0x80
+  simd8<uint8_t> is_fourth_byte = prev3.saturating_sub(0xf0u-0x80); // Only 1111____ will be >= 0x80
   // Caller requires a bool (all 1's). All values resulting from the subtraction will be <= 64, so signed comparison is fine.
-  return simd8<int8_t>(is_third_byte | is_fourth_byte) > int8_t(0);
+  return simd8<bool>(is_third_byte | is_fourth_byte);
 }
 
 } // unnamed namespace

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -20,10 +20,9 @@ simdutf_unused simdutf_really_inline simd8<bool> must_be_continuation(const simd
 }
 
 simdutf_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
-  simd8<uint8_t> is_third_byte  = prev2.saturating_sub(0b11100000u-1); // Only 111_____ will be > 0
-  simd8<uint8_t> is_fourth_byte = prev3.saturating_sub(0b11110000u-1); // Only 1111____ will be > 0
-  // Caller requires a bool (all 1's). All values resulting from the subtraction will be <= 64, so signed comparison is fine.
-  return simd8<int8_t>(is_third_byte | is_fourth_byte) > int8_t(0);
+  simd8<uint8_t> is_third_byte  = prev2.saturating_sub(0xe0u-0x80); // Only 111_____ will be >= 0x80
+  simd8<uint8_t> is_fourth_byte = prev3.saturating_sub(0xf0u-0x80); // Only 1111____ will be >= 0x80
+  return simd8<bool>(is_third_byte | is_fourth_byte);
 }
 
 #include "westmere/internal/loader.cpp"


### PR DESCRIPTION
Credit @Validark


Test results... GCC 12, Icelake, Arabic-Lipsum.utf8.txt 

I am getting a 2% to 4% gain. By itself, this may not be statistically meaningful, but we see the instruction count going down by about the same amount which tells us (with high confidence) that it is an actual optimization.

Before:
```
validate_utf8+haswell, input size: 81685, iterations: 20000, dataset: unicode_lipsum/lipsum/Arabic-Lipsum.utf8.txt
   1.113 ins/byte,    0.319 cycle/byte,   10.081 GB/s (0.5 %),     3.213 GHz,    3.493 ins/cycle 
   1.987 ins/char,    0.569 cycle/char,    5.648 Gc/s (0.5 %)     1.78 byte/char 
validate_utf8+westmere, input size: 81685, iterations: 20000, dataset: unicode_lipsum/lipsum/Arabic-Lipsum.utf8.txt
   2.426 ins/byte,    0.492 cycle/byte,    6.514 GB/s (2.8 %),     3.206 GHz,    4.931 ins/cycle 
   4.331 ins/char,    0.878 cycle/char,    3.650 Gc/s (2.8 %)     1.78 byte/char 
```
After:


```
validate_utf8+haswell, input size: 81685, iterations: 30000, dataset: unicode_lipsum/lipsum/Arabic-Lipsum.utf8.txt
   1.066 ins/byte,    0.306 cycle/byte,   10.485 GB/s (1.7 %),     3.213 GHz,    3.479 ins/cycle 
   1.903 ins/char,    0.547 cycle/char,    5.874 Gc/s (1.7 %)     1.78 byte/char 
validate_utf8+westmere, input size: 81685, iterations: 30000, dataset: unicode_lipsum/lipsum/Arabic-Lipsum.utf8.txt
   2.364 ins/byte,    0.484 cycle/byte,    6.628 GB/s (0.4 %),     3.206 GHz,    4.887 ins/cycle 
   4.219 ins/char,    0.863 cycle/char,    3.713 Gc/s (0.4 %)     1.78 byte/char 
```

