### PR TITLE
disables runtime dispatching when there is a single implementation.

### DIFF
--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -858,7 +858,7 @@ const implementation * get_default_implementation() {
 }
 #else
 internal::atomic_ptr<const implementation>& get_default_implementation() {
-  return internal::get_active_implementation();
+  return get_active_implementation();
 }
 #endif
 #define SIMDUTF_GET_CURRENT_IMPLEMENTION


### PR DESCRIPTION
This should slightly reduce the function call overhead on systems where runtime dispatching is not needed. Note that this overhead was already small so it may not translate into easily measurable gains.