### PR TITLE
Fixing overflow in UTF32 to UTF8 under Neon.

### DIFF
--- a/src/arm64/arm_convert_utf32_to_utf8.cpp
+++ b/src/arm64/arm_convert_utf32_to_utf8.cpp
@@ -5,8 +5,9 @@ std::pair<const char32_t*, char*> arm_convert_utf32_to_utf8(const char32_t* buf,
   const uint16x8_t v_c080 = vmovq_n_u16((uint16_t)0xc080);
 
   uint16x8_t forbidden_bytemask = vmovq_n_u16(0x0);
+  const size_t safety_margin = 12; // to avoid overruns, see issue https://github.com/simdutf/simdutf/issues/92
 
-  while (buf + 8 < end) {
+  while (buf + 16 + safety_margin < end) {
     uint32x4_t in = vld1q_u32(reinterpret_cast<const uint32_t *>(buf));
     uint32x4_t nextin = vld1q_u32(reinterpret_cast<const uint32_t *>(buf+4));
 
@@ -238,8 +239,9 @@ std::pair<result, char*> arm_convert_utf32_to_utf8_with_errors(const char32_t* b
   const char32_t* end = buf + len;
 
   const uint16x8_t v_c080 = vmovq_n_u16((uint16_t)0xc080);
+  const size_t safety_margin = 12; // to avoid overruns, see issue https://github.com/simdutf/simdutf/issues/92
 
-  while (buf + 8 < end) {
+  while (buf + 16 + safety_margin < end) {
     uint32x4_t in = vld1q_u32(reinterpret_cast<const uint32_t *>(buf));
     uint32x4_t nextin = vld1q_u32(reinterpret_cast<const uint32_t *>(buf+4));
 

--- a/tests/convert_utf32_to_utf8_tests.cpp
+++ b/tests/convert_utf32_to_utf8_tests.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <iostream>
+#include <memory>
 
 #include <tests/reference/validate_utf32.h>
 #include <tests/reference/decode_utf32.h>

--- a/tests/convert_utf32_to_utf8_tests.cpp
+++ b/tests/convert_utf32_to_utf8_tests.cpp
@@ -140,6 +140,18 @@ TEST(convert_fails_if_input_too_large) {
   }
 }
 
+TEST(special_cases) {
+  const uint32_t utf32[] = {0x0000, 0x0054, 0x0001, 0x0000, 0x0000, 0x0007, 0x005d, 0x027f, 0x001a};
+  const char expected[] = "\x00\x54\x01\x00\x00\x07\x5d\xc9\xbf\x1a";
+  size_t utf8len = implementation.utf8_length_from_utf32((const char32_t*)utf32, 9);
+  std::unique_ptr<char[]> utf8(new char[utf8len]);
+  size_t utf8size = implementation.convert_utf32_to_utf8((const char32_t*)utf32, 9, utf8.get());
+  for(size_t i = 0; i < utf8len; i++) {
+    ASSERT_TRUE(utf8[i] == expected[i]);
+  }
+  ASSERT_TRUE(utf8size == utf8len);
+}
+
 int main(int argc, char* argv[]) {
   return simdutf::test::main(argc, argv);
 }

--- a/tests/convert_utf32_to_utf8_with_errors_tests.cpp
+++ b/tests/convert_utf32_to_utf8_with_errors_tests.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <iostream>
+#include <memory>
 
 #include <tests/reference/validate_utf32.h>
 #include <tests/reference/decode_utf32.h>

--- a/tests/convert_utf32_to_utf8_with_errors_tests.cpp
+++ b/tests/convert_utf32_to_utf8_with_errors_tests.cpp
@@ -154,6 +154,19 @@ TEST(convert_fails_if_input_too_large) {
   }
 }
 
+TEST(special_cases) {
+  const uint32_t utf32[] = {0x0000, 0x0054, 0x0001, 0x0000, 0x0000, 0x0007, 0x005d, 0x027f, 0x001a};
+  const char expected[] = "\x00\x54\x01\x00\x00\x07\x5d\xc9\xbf\x1a";
+  size_t utf8len = implementation.utf8_length_from_utf32((const char32_t*)utf32, 9);
+  std::unique_ptr<char[]> utf8(new char[utf8len]);
+  simdutf::result res = implementation.convert_utf32_to_utf8_with_errors((const char32_t*)utf32, 9, utf8.get());
+  ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
+  size_t utf8size = res.count;
+  for(size_t i = 0; i < utf8len; i++) {
+    ASSERT_TRUE(utf8[i] == expected[i]);
+  }
+  ASSERT_TRUE(utf8size == utf8len);
+}
 int main(int argc, char* argv[]) {
   return simdutf::test::main(argc, argv);
 }


### PR DESCRIPTION
Credit: Nathaniel Brough