### PR TITLE
adding copyright sign tests

### DIFF
--- a/tests/convert_utf8_to_utf16be_tests.cpp
+++ b/tests/convert_utf8_to_utf16be_tests.cpp
@@ -114,6 +114,18 @@ TEST(convert_3_or_4_UTF8_bytes) {
   }
 }
 
+TEST(special_cases) {
+  const uint8_t utf8[] = {0xC2, 0xA9}; // copyright sign
+  const uint8_t expected[] = {0x00, 0xA9}; // expected UTF-16BE
+  size_t utf16len = implementation.utf16_length_from_utf8((const char*)utf8, 2);
+  ASSERT_TRUE(utf16len == 1);
+  std::unique_ptr<char16_t[]> utf16(new char16_t[utf16len]);
+  size_t utf16size = implementation.convert_utf8_to_utf16be((const char*)utf8, 2, utf16.get());
+  ASSERT_TRUE(utf16size == utf16len);
+  memcmp((const char*)utf16.get(), expected, 2);
+}
+
+
 int main(int argc, char* argv[]) {
   return simdutf::test::main(argc, argv);
 }

--- a/tests/convert_utf8_to_utf16be_tests.cpp
+++ b/tests/convert_utf8_to_utf16be_tests.cpp
@@ -122,7 +122,7 @@ TEST(special_cases) {
   std::unique_ptr<char16_t[]> utf16(new char16_t[utf16len]);
   size_t utf16size = implementation.convert_utf8_to_utf16be((const char*)utf8, 2, utf16.get());
   ASSERT_TRUE(utf16size == utf16len);
-  memcmp((const char*)utf16.get(), expected, 2);
+  ASSERT_TRUE(memcmp((const char*)utf16.get(), expected, 2) == 0);
 }
 
 

--- a/tests/convert_utf8_to_utf16le_tests.cpp
+++ b/tests/convert_utf8_to_utf16le_tests.cpp
@@ -245,6 +245,17 @@ TEST(issue111) {
 }
 #endif
 
+TEST(special_cases) {
+  const uint8_t utf8[] = {0xC2, 0xA9}; // copyright sign
+  const uint8_t expected[] = {0xA9, 0x00}; // expected UTF-16LE
+  size_t utf16len = implementation.utf16_length_from_utf8((const char*)utf8, 2);
+  ASSERT_TRUE(utf16len == 1);
+  std::unique_ptr<char16_t[]> utf16(new char16_t[utf16len]);
+  size_t utf16size = implementation.convert_utf8_to_utf16le((const char*)utf8, 2, utf16.get());
+  ASSERT_TRUE(utf16size == utf16len);
+  memcmp((const char*)utf16.get(), expected, 2);
+}
+
 int main(int argc, char* argv[]) {
   return simdutf::test::main(argc, argv);
 }

--- a/tests/convert_utf8_to_utf16le_tests.cpp
+++ b/tests/convert_utf8_to_utf16le_tests.cpp
@@ -253,7 +253,7 @@ TEST(special_cases) {
   std::unique_ptr<char16_t[]> utf16(new char16_t[utf16len]);
   size_t utf16size = implementation.convert_utf8_to_utf16le((const char*)utf8, 2, utf16.get());
   ASSERT_TRUE(utf16size == utf16len);
-  memcmp((const char*)utf16.get(), expected, 2);
+  ASSERT_TRUE(memcmp((const char*)utf16.get(), expected, 2) == 0);
 }
 
 int main(int argc, char* argv[]) {

--- a/tests/convert_valid_utf8_to_utf16be_tests.cpp
+++ b/tests/convert_valid_utf8_to_utf16be_tests.cpp
@@ -109,7 +109,7 @@ TEST(special_cases) {
   std::unique_ptr<char16_t[]> utf16(new char16_t[utf16len]);
   size_t utf16size = implementation.convert_valid_utf8_to_utf16be((const char*)utf8, 2, utf16.get());
   ASSERT_TRUE(utf16size == utf16len);
-  memcmp((const char*)utf16.get(), expected, 2);
+  ASSERT_TRUE(memcmp((const char*)utf16.get(), expected, 2) == 0);
 }
 
 int main(int argc, char* argv[]) {

--- a/tests/convert_valid_utf8_to_utf16be_tests.cpp
+++ b/tests/convert_valid_utf8_to_utf16be_tests.cpp
@@ -101,6 +101,17 @@ TEST(convert_3_or_4_UTF8_bytes) {
   }
 }
 
+TEST(special_cases) {
+  const uint8_t utf8[] = {0xC2, 0xA9}; // copyright sign
+  const uint8_t expected[] = {0x00, 0xA9}; // expected UTF-16BE
+  size_t utf16len = implementation.utf16_length_from_utf8((const char*)utf8, 2);
+  ASSERT_TRUE(utf16len == 1);
+  std::unique_ptr<char16_t[]> utf16(new char16_t[utf16len]);
+  size_t utf16size = implementation.convert_valid_utf8_to_utf16be((const char*)utf8, 2, utf16.get());
+  ASSERT_TRUE(utf16size == utf16len);
+  memcmp((const char*)utf16.get(), expected, 2);
+}
+
 int main(int argc, char* argv[]) {
   return simdutf::test::main(argc, argv);
 }

--- a/tests/convert_valid_utf8_to_utf16le_tests.cpp
+++ b/tests/convert_valid_utf8_to_utf16le_tests.cpp
@@ -163,7 +163,7 @@ TEST(special_cases) {
   std::unique_ptr<char16_t[]> utf16(new char16_t[utf16len]);
   size_t utf16size = implementation.convert_valid_utf8_to_utf16le((const char*)utf8, 2, utf16.get());
   ASSERT_TRUE(utf16size == utf16len);
-  memcmp((const char*)utf16.get(), expected, 2);
+  ASSERT_TRUE(memcmp((const char*)utf16.get(), expected, 2) == 0);
 }
 
 int main(int argc, char* argv[]) {

--- a/tests/convert_valid_utf8_to_utf16le_tests.cpp
+++ b/tests/convert_valid_utf8_to_utf16le_tests.cpp
@@ -154,6 +154,18 @@ TEST(issue111) {
 }
 #endif
 
+
+TEST(special_cases) {
+  const uint8_t utf8[] = {0xC2, 0xA9}; // copyright sign
+  const uint8_t expected[] = {0xA9, 0x00}; // expected UTF-16LE
+  size_t utf16len = implementation.utf16_length_from_utf8((const char*)utf8, 2);
+  ASSERT_TRUE(utf16len == 1);
+  std::unique_ptr<char16_t[]> utf16(new char16_t[utf16len]);
+  size_t utf16size = implementation.convert_valid_utf8_to_utf16le((const char*)utf8, 2, utf16.get());
+  ASSERT_TRUE(utf16size == utf16len);
+  memcmp((const char*)utf16.get(), expected, 2);
+}
+
 int main(int argc, char* argv[]) {
   return simdutf::test::main(argc, argv);
 }

--- a/tests/validate_utf8_basic_tests.cpp
+++ b/tests/validate_utf8_basic_tests.cpp
@@ -13,6 +13,12 @@ TEST(node48995) {
   ASSERT_FALSE(implementation.validate_utf8(bad, length));
 }
 
+TEST(copyright) {
+  const char good[2] = {'\xC2', '\xA9'};
+  size_t length = 2;
+  ASSERT_TRUE(implementation.validate_utf8(good, length));
+}
+
 TEST(good_bad_sequences) {
   // additional tests are from autobahn websocket testsuite
   // https://github.com/crossbario/autobahn-testsuite/tree/master/autobahntestsuite/autobahntestsuite/case

--- a/tests/validate_utf8_with_errors_tests.cpp
+++ b/tests/validate_utf8_with_errors_tests.cpp
@@ -19,6 +19,14 @@ TEST(node48995) {
   ASSERT_TRUE(res.error);
 }
 
+TEST(copyright) {
+  const char good[2] = {'\xC2', '\xA9'};
+  size_t length = 2;
+  simdutf::result res = implementation.validate_utf8_with_errors(good, length);
+  ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
+}
+
+
 TEST(no_error) {
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf8 generator{seed, 1, 1, 1, 1};


### PR DESCRIPTION
The copyright sign (bytes 0xC2, 0xA9) in UTF-8 should transcode in UTF-16 to 0x00, 0xA9 or 0xA9, 0x00 depending on the endianness. In particular, the copyright sign (bytes 0xC2, 0xA9) should be detected as valid UTF-8.