### PR TITLE
fix rvv utf8 validation bug

### DIFF
--- a/tests/validate_utf8_brute_force_tests.cpp
+++ b/tests/validate_utf8_brute_force_tests.cpp
@@ -9,6 +9,52 @@
 #include <tests/reference/validate_utf8.h>
 #include <tests/helpers/test.h>
 
+template<typename T>
+static void test_corrupt(T &implementation, uint32_t seed, simdutf::tests::helpers::random_utf8 gen_utf8) {
+  std::mt19937 gen(seed);
+  for (size_t i = 0; i < 10; i++) {
+    auto UTF8 = gen_utf8.generate(1000);
+    if (!implementation.validate_utf8((const char *)UTF8.data(), UTF8.size())) {
+      std::cerr << "bug" << std::endl;
+      ASSERT_TRUE(false);
+    }
+    std::uniform_int_distribution<size_t> distIdx{0, UTF8.size()-1};
+    for (size_t j = 0; j < 1000; ++j) {
+      const size_t corrupt = distIdx(gen);
+      uint8_t restore = UTF8[corrupt];
+      UTF8[corrupt] = uint8_t(gen());
+      bool is_ok =
+          implementation.validate_utf8((const char *)UTF8.data(), UTF8.size());
+      bool is_ok_basic =
+          simdutf::tests::reference::validate_utf8((const char *)UTF8.data(), UTF8.size());
+      if (is_ok != is_ok_basic) {
+        std::cerr << "bug" << std::endl;
+        ASSERT_TRUE(false);
+      }
+      UTF8[corrupt] = restore;
+    }
+  }
+}
+
+TEST(corrupt_1byte) {
+  uint32_t seed{1234};
+  test_corrupt(implementation, seed, simdutf::tests::helpers::random_utf8(seed, 1, 0, 0, 0));
+}
+
+TEST(corrupt_2byte) {
+  uint32_t seed{1234};
+  test_corrupt(implementation, seed, simdutf::tests::helpers::random_utf8(seed, 0, 1, 0, 0));
+  test_corrupt(implementation, seed, simdutf::tests::helpers::random_utf8(seed, 1, 1, 0, 0));
+}
+
+TEST(corrupt_3byte) {
+  uint32_t seed{1234};
+  test_corrupt(implementation, seed, simdutf::tests::helpers::random_utf8(seed, 0, 0, 1, 0));
+  test_corrupt(implementation, seed, simdutf::tests::helpers::random_utf8(seed, 0, 1, 1, 0));
+  test_corrupt(implementation, seed, simdutf::tests::helpers::random_utf8(seed, 1, 0, 1, 0));
+  test_corrupt(implementation, seed, simdutf::tests::helpers::random_utf8(seed, 1, 1, 1, 0));
+}
+
 TEST(brute_force) {
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf8 gen_1_2_3_4(seed, 1, 1, 1, 1);
@@ -34,9 +80,7 @@ TEST(brute_force) {
       }
     }
   }
-  puts("OK");
 }
-
 
 int main(int argc, char* argv[]) {
   return simdutf::test::main(argc, argv);


### PR DESCRIPTION
Thanks to @OMaghiarIMGs [comment](https://github.com/simdutf/simdutf/pull/373#discussion_r1529993897), I looked over the rvv utf8 validation code again, and found a bug in it.
The ASCII fast path must make sure that the next three bytes are valid.
An easy way to do that is to check if they are also ASCII, this is what this patch does.
An alternative would be to subtract three from `vl`, but then you would need to avoid the possibility of such code turning into an infinite loop, when `vl<=3`. The first fix seemed more straight forward.

I also cleaned up the `tail` variable. It was used for three separate things, and two of those could've used a smaller value.
