### PR TITLE
fix: base64url should omit padding by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1697,13 +1697,15 @@ simdutf_warn_unused size_t maximal_binary_length_from_base64(const char16_t * in
  */
 simdutf_warn_unused result base64_to_binary(const char * input, size_t length, char* output, base64_options options = base64_default) noexcept;
 
-/**
- * Provide the base64 length in bytes given the length of a binary input.
- *
- * @param length        the length of the input in bytes
- * @return number of base64 bytes
- */
-simdutf_warn_unused size_t base64_length_from_binary(size_t length) noexcept;
+  /**
+   * Provide the base64 length in bytes given the length of a binary input.
+   *
+   * @param length        the length of the input in bytes
+   * @parem options       the base64 options to use, can be base64_default or base64_url, is base64_default by default.
+   * @return number of base64 bytes
+   */
+  simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options = base64_default) noexcept;
+
 
 /**
  * Convert a binary input to a base64 ouput. The output is always padded with equal signs so that it is

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 add_subdirectory(src)
 
 add_executable(benchmark benchmark.cpp)
-target_link_libraries(benchmark PUBLIC simdutf simdutf::benchmarks::benchmark)
+target_link_libraries(benchmark PUBLIC simdutf::benchmarks::benchmark)
 
 set_property(TARGET benchmark PROPERTY CXX_STANDARD 17)
 set_property(TARGET benchmark PROPERTY CXX_STANDARD_REQUIRED ON)

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -1444,7 +1444,7 @@ simdutf_warn_unused result base64_to_binary(const char * input, size_t length, c
  * @param length        the length of the input in bytes
  * @return number of base64 bytes
  */
-simdutf_warn_unused size_t base64_length_from_binary(size_t length) noexcept;
+simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options = base64_default) noexcept;
 
 /**
  * Convert a binary input to a base64 ouput. The output is always padded with equal signs so that it is
@@ -2660,9 +2660,10 @@ public:
    * Provide the base64 length in bytes given the length of a binary input.
    *
    * @param length        the length of the input in bytes
+   * @parem options       the base64 options to use, can be base64_default or base64_url, is base64_default by default.
    * @return number of base64 bytes
    */
-  simdutf_warn_unused virtual size_t base64_length_from_binary(size_t length) const noexcept = 0;
+  simdutf_warn_unused virtual size_t base64_length_from_binary(size_t length, base64_options options = base64_default) const noexcept = 0;
 
   /**
    * Convert a binary input to a base64 ouput. The output is always padded with equal signs so that it is

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -851,8 +851,8 @@ simdutf_warn_unused result implementation::base64_to_binary(const char16_t * inp
   return (options & base64_url) ? compress_decode_base64<true>(output, input, length, options) : compress_decode_base64<false>(output, input, length, options);
 }
 
-simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t length) const noexcept {
-  return scalar::base64::base64_length_from_binary(length);
+simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t length, base64_options options) const noexcept {
+  return scalar::base64::base64_length_from_binary(length, options);
 }
 
 size_t implementation::binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept {

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -380,8 +380,8 @@ simdutf_warn_unused result implementation::base64_to_binary(const char16_t * inp
   return scalar::base64::base64_tail_decode(output, input, length, options);
 }
 
-simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t length) const noexcept {
-  return scalar::base64::base64_length_from_binary(length);
+simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t length, base64_options options) const noexcept {
+  return scalar::base64::base64_length_from_binary(length, options);
 }
 
 size_t implementation::binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept {

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -794,8 +794,8 @@ simdutf_warn_unused result implementation::base64_to_binary(const char16_t * inp
   return (options & base64_url) ? compress_decode_base64<true>(output, input, length, options) : compress_decode_base64<false>(output, input, length, options);
 }
 
-simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t length) const noexcept {
-  return scalar::base64::base64_length_from_binary(length);
+simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t length, base64_options options) const noexcept {
+  return scalar::base64::base64_length_from_binary(length, options);
 }
 
 size_t implementation::binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept {

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -1381,8 +1381,8 @@ simdutf_warn_unused result implementation::base64_to_binary(const char16_t * inp
 }
 
 
-simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t length) const noexcept {
-  return scalar::base64::base64_length_from_binary(length);
+simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t length, base64_options options) const noexcept {
+  return scalar::base64::base64_length_from_binary(length, options);
 }
 
 size_t implementation::binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept {

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -471,8 +471,8 @@ public:
     return set_best()->base64_to_binary(input, length, output, options);
   }
 
-  simdutf_warn_unused size_t base64_length_from_binary(size_t length) const noexcept override {
-    return set_best()->base64_length_from_binary(length);
+  simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) const noexcept override {
+    return set_best()->base64_length_from_binary(length, options);
   }
 
   size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept override {
@@ -836,7 +836,7 @@ public:
   }
 
 
-  simdutf_warn_unused size_t base64_length_from_binary(size_t) const noexcept override {
+  simdutf_warn_unused size_t base64_length_from_binary(size_t, base64_options) const noexcept override {
     return 0;
   }
 
@@ -1316,7 +1316,7 @@ simdutf_warn_unused result base64_to_binary_safe_impl(const chartype * input, si
   }
   // The output buffer is maybe too small. We will decode a truncated version of the input.
   size_t outlen3 = outlen / 3 * 3; // round down to multiple of 3
-  size_t safe_input = base64_length_from_binary(outlen3);
+  size_t safe_input = base64_length_from_binary(outlen3, options);
   result r = base64_to_binary(input, safe_input, output, options);
   if(r.error == error_code::INVALID_BASE64_CHARACTER) { return r; }
   size_t offset = (r.error == error_code::BASE64_INPUT_REMAINDER) ? 1 :
@@ -1359,8 +1359,8 @@ simdutf_warn_unused result base64_to_binary_safe(const char16_t * input, size_t 
   return base64_to_binary_safe_impl<char16_t>(input, length, output, outlen, options);
 }
 
-simdutf_warn_unused size_t base64_length_from_binary(size_t length) noexcept {
-  return get_default_implementation()->base64_length_from_binary(length);
+simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) noexcept {
+  return get_default_implementation()->base64_length_from_binary(length, options);
 }
 
 size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) noexcept {

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -319,8 +319,8 @@ simdutf_warn_unused result implementation::base64_to_binary(const char16_t * inp
   return scalar::base64::base64_to_binary(input, length, output, options);
 }
 
-simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t length) const noexcept {
-  return scalar::base64::base64_length_from_binary(length);
+simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t length, base64_options options) const noexcept {
+  return scalar::base64::base64_length_from_binary(length, options);
 }
 
 size_t implementation::binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept {

--- a/src/rvv/implementation.cpp
+++ b/src/rvv/implementation.cpp
@@ -113,8 +113,8 @@ simdutf_warn_unused result implementation::base64_to_binary(const char16_t * inp
   return scalar::base64::base64_tail_decode(output, input, length, options);
 }
 
-simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t length) const noexcept {
-  return scalar::base64::base64_length_from_binary(length);
+simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t length, base64_options options) const noexcept {
+  return scalar::base64::base64_length_from_binary(length, options);
 }
 
 size_t implementation::binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept {

--- a/src/scalar/base64.h
+++ b/src/scalar/base64.h
@@ -241,8 +241,10 @@ size_t tail_encode_base64(char *dst, const char *src, size_t srclen, base64_opti
     t1 = uint8_t(src[i]);
     *out++ = e0[t1];
     *out++ = e1[(t1 & 0x03) << 4];
-    *out++ = '=';
-    *out++ = '=';
+    if((options & base64_url) == 0) {
+      *out++ = '=';
+      *out++ = '=';
+    }
     break;
   default: /* case 2 */
     t1 = uint8_t(src[i]);
@@ -250,7 +252,9 @@ size_t tail_encode_base64(char *dst, const char *src, size_t srclen, base64_opti
     *out++ = e0[t1];
     *out++ = e1[((t1 & 0x03) << 4) | ((t2 >> 4) & 0x0F)];
     *out++ = e2[(t2 & 0x0F) << 2];
-    *out++ = '=';
+    if((options & base64_url) == 0) {
+      *out++ = '=';
+    }
   }
   return (size_t)(out - dst);
 }
@@ -275,7 +279,10 @@ simdutf_warn_unused size_t maximal_binary_length_from_base64(const char_type * i
   return  actual_length / 4 * 3 + (actual_length %4)  - 1;
 }
 
-simdutf_warn_unused size_t base64_length_from_binary(size_t length) noexcept {
+simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) noexcept {
+  if(options & base64_url) {
+    return length/3 * 4 + ((length % 3) ? (length % 3) + 1 : 0);
+  }
   return (length + 2)/3 * 4; // We use padding to make the length a multiple of 4.
 }
 

--- a/src/simdutf/arm64/implementation.h
+++ b/src/simdutf/arm64/implementation.h
@@ -93,7 +93,7 @@ public:
   simdutf_warn_unused result base64_to_binary(const char * input, size_t length, char* output, base64_options options) const noexcept;
   simdutf_warn_unused size_t maximal_binary_length_from_base64(const char16_t * input, size_t length) const noexcept;
   simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options) const noexcept;
-  simdutf_warn_unused size_t base64_length_from_binary(size_t length) const noexcept;
+  simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) const noexcept;
   size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept;
 };
 

--- a/src/simdutf/fallback/implementation.h
+++ b/src/simdutf/fallback/implementation.h
@@ -96,7 +96,7 @@ public:
   simdutf_warn_unused result base64_to_binary(const char * input, size_t length, char* output, base64_options options) const noexcept;
   simdutf_warn_unused size_t maximal_binary_length_from_base64(const char16_t * input, size_t length) const noexcept;
   simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options) const noexcept;
-  simdutf_warn_unused size_t base64_length_from_binary(size_t length) const noexcept;
+  simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) const noexcept;
   size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept;
 };
 } // namespace fallback

--- a/src/simdutf/haswell/implementation.h
+++ b/src/simdutf/haswell/implementation.h
@@ -95,7 +95,7 @@ public:
   simdutf_warn_unused virtual result base64_to_binary(const char * input, size_t length, char* output, base64_options options) const noexcept;
   simdutf_warn_unused virtual size_t maximal_binary_length_from_base64(const char16_t * input, size_t length) const noexcept;
   simdutf_warn_unused virtual result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options) const noexcept;
-  simdutf_warn_unused virtual size_t base64_length_from_binary(size_t length) const noexcept;
+  simdutf_warn_unused virtual size_t base64_length_from_binary(size_t length, base64_options options) const noexcept;
   size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept;
 };
 

--- a/src/simdutf/icelake/implementation.h
+++ b/src/simdutf/icelake/implementation.h
@@ -95,7 +95,7 @@ public:
   simdutf_warn_unused result base64_to_binary(const char * input, size_t length, char* output, base64_options options) const noexcept;
   simdutf_warn_unused size_t maximal_binary_length_from_base64(const char16_t * input, size_t length) const noexcept;
   simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options) const noexcept;
-  simdutf_warn_unused size_t base64_length_from_binary(size_t length) const noexcept;
+  simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) const noexcept;
   size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept;
 };
 

--- a/src/simdutf/ppc64/implementation.h
+++ b/src/simdutf/ppc64/implementation.h
@@ -73,7 +73,7 @@ public:
   simdutf_warn_unused result base64_to_binary(const char * input, size_t length, char* output, base64_options options) const noexcept;
   simdutf_warn_unused size_t maximal_binary_length_from_base64(const char16_t * input, size_t length) const noexcept;
   simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options) const noexcept;
-  simdutf_warn_unused size_t base64_length_from_binary(size_t length) const noexcept;
+  simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) const noexcept;
   size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept;
 };
 

--- a/src/simdutf/rvv/implementation.h
+++ b/src/simdutf/rvv/implementation.h
@@ -97,7 +97,7 @@ public:
   simdutf_warn_unused result base64_to_binary(const char * input, size_t length, char* output, base64_options options) const noexcept;
   simdutf_warn_unused size_t maximal_binary_length_from_base64(const char16_t * input, size_t length) const noexcept;
   simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options) const noexcept;
-  simdutf_warn_unused size_t base64_length_from_binary(size_t length) const noexcept;
+  simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) const noexcept;
   size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept;
 private:
   const bool _supports_zvbb;

--- a/src/simdutf/westmere/implementation.h
+++ b/src/simdutf/westmere/implementation.h
@@ -93,7 +93,7 @@ public:
   simdutf_warn_unused result base64_to_binary(const char * input, size_t length, char* output, base64_options options) const noexcept;
   simdutf_warn_unused size_t maximal_binary_length_from_base64(const char16_t * input, size_t length) const noexcept;
   simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options) const noexcept;
-  simdutf_warn_unused size_t base64_length_from_binary(size_t length) const noexcept;
+  simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) const noexcept;
   size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept;
 };
 

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -795,8 +795,8 @@ simdutf_warn_unused result implementation::base64_to_binary(const char16_t * inp
   return (options & base64_url) ? compress_decode_base64<true>(output, input, length, options) : compress_decode_base64<false>(output, input, length, options);
 }
 
-simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t length) const noexcept {
-  return scalar::base64::base64_length_from_binary(length);
+simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t length, base64_options options) const noexcept {
+  return scalar::base64::base64_length_from_binary(length, options);
 }
 
 size_t implementation::binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept {

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -160,8 +160,8 @@ TEST(encode_base64_cases) {
 
 TEST(encode_base64url_cases) {
   std::vector<std::pair<std::string, std::string>> cases = {
-      {"Hello, World!", "SGVsbG8sIFdvcmxkIQ=="},
-      {"GeeksforGeeks", "R2Vla3Nmb3JHZWVrcw=="},
+      {"Hello, World!", "SGVsbG8sIFdvcmxkIQ"},
+      {"GeeksforGeeks", "R2Vla3Nmb3JHZWVrcw"},
       {"123456", "MTIzNDU2"},
       {"Base64 Encoding", "QmFzZTY0IEVuY29kaW5n"},
       {"!R~J2jL&mI]O)3=c:G3Mo)oqmJdxoprTZDyxEvU0MI.'Ww5H{G>}y;;+B8E_Ah,Ed[ PdBqY'^N>O$4:7LK1<:|7)btV@|{YWR$$Er59-XjVrFl4L}~yzTEd4'E[@k", "IVJ-SjJqTCZtSV1PKTM9YzpHM01vKW9xbUpkeG9wclRaRHl4RXZVME1JLidXdzVIe0c-fXk7OytCOEVfQWgsRWRbIFBkQnFZJ15OPk8kNDo3TEsxPDp8NylidFZAfHtZV1IkJEVyNTktWGpWckZsNEx9fnl6VEVkNCdFW0Br"}};
@@ -170,7 +170,7 @@ TEST(encode_base64url_cases) {
   printf(" -- ");
   for (std::pair<std::string, std::string> p : cases) {
     std::vector<char> buffer(
-        implementation.base64_length_from_binary(p.first.size()));
+        implementation.base64_length_from_binary(p.first.size(), simdutf::base64_url));
     ASSERT_EQUAL(buffer.size(), p.second.size());
     size_t s = implementation.binary_to_base64(p.first.data(), p.first.size(),
                                                buffer.data(), simdutf::base64_url);
@@ -258,8 +258,8 @@ TEST(encode_base64_cases_16) {
 
 TEST(encode_base64url_cases_16) {
   std::vector<std::pair<std::string, std::u16string>> cases = {
-      {"Hello, World!", u"SGVsbG8sIFdvcmxkIQ=="},
-      {"GeeksforGeeks", u"R2Vla3Nmb3JHZWVrcw=="},
+      {"Hello, World!", u"SGVsbG8sIFdvcmxkIQ"},
+      {"GeeksforGeeks", u"R2Vla3Nmb3JHZWVrcw"},
       {"123456", u"MTIzNDU2"},
       {"Base64 Encoding", u"QmFzZTY0IEVuY29kaW5n"},
       {"!R~J2jL&mI]O)3=c:G3Mo)oqmJdxoprTZDyxEvU0MI.'Ww5H{G>}y;;+B8E_Ah,Ed[ PdBqY'^N>O$4:7LK1<:|7)btV@|{YWR$$Er59-XjVrFl4L}~yzTEd4'E[@k", u"IVJ-SjJqTCZtSV1PKTM9YzpHM01vKW9xbUpkeG9wclRaRHl4RXZVME1JLidXdzVIe0c-fXk7OytCOEVfQWgsRWRbIFBkQnFZJ15OPk8kNDo3TEsxPDp8NylidFZAfHtZV1IkJEVyNTktWGpWckZsNEx9fnl6VEVkNCdFW0Br"}};
@@ -388,7 +388,7 @@ TEST(roundtrip_base64url) {
   for (size_t len = 0; len < 2048; len++) {
     std::vector<char> source(len, 0);
     std::vector<char> buffer;
-    buffer.resize(implementation.base64_length_from_binary(len));
+    buffer.resize(implementation.base64_length_from_binary(len, simdutf::base64_url));
     std::vector<char> back(len);
     std::mt19937 gen((std::mt19937::result_type)(seed));
     std::uniform_int_distribution<int> byte_generator{0, 255};
@@ -398,7 +398,7 @@ TEST(roundtrip_base64url) {
       }
       size_t size = implementation.binary_to_base64(
           source.data(), source.size(), buffer.data(), simdutf::base64_url);
-      ASSERT_TRUE(size == implementation.base64_length_from_binary(len));
+      ASSERT_TRUE(size == implementation.base64_length_from_binary(len, simdutf::base64_url));
       simdutf::result r =
           implementation.base64_to_binary(buffer.data(), size, back.data(), simdutf::base64_url);
       ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
@@ -428,7 +428,7 @@ TEST(roundtrip_base64url_16) {
     std::vector<char> buffer;
     std::vector<char16_t> buffer16;
 
-    buffer.resize(implementation.base64_length_from_binary(len));
+    buffer.resize(implementation.base64_length_from_binary(len, simdutf::base64_url));
     std::vector<char> back(len);
     std::mt19937 gen((std::mt19937::result_type)(seed));
     std::uniform_int_distribution<int> byte_generator{0, 255};
@@ -443,7 +443,7 @@ TEST(roundtrip_base64url_16) {
       for (size_t i = 0; i < buffer.size(); i++) {
         buffer16[i] = buffer[i];
       }
-      ASSERT_TRUE(size == implementation.base64_length_from_binary(len));
+      ASSERT_TRUE(size == implementation.base64_length_from_binary(len, simdutf::base64_url));
       simdutf::result r =
           implementation.base64_to_binary(buffer16.data(), size, back.data(), simdutf::base64_url);
       ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);


### PR DESCRIPTION
Though base64url allows padding characters, they are most commonly omitted by default. This PR adopts the common default.