### PR TITLE
add Windows ARM64EC support

### DIFF
--- a/include/simdutf/internal/isadetection.h
+++ b/include/simdutf/internal/isadetection.h
@@ -122,7 +122,7 @@ static inline uint32_t detect_supported_architectures() {
   return host_isa;
 }
 
-#elif defined(__aarch64__) || defined(_M_ARM64)
+#elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 
 static inline uint32_t detect_supported_architectures() {
   return instruction_set::NEON;

--- a/include/simdutf/portability.h
+++ b/include/simdutf/portability.h
@@ -81,9 +81,9 @@
 #include <iso646.h>
 #endif
 
-#if defined(__x86_64__) || defined(_M_AMD64)
+#if (defined(__x86_64__) || defined(_M_AMD64)) && !defined(_M_ARM64EC)
 #define SIMDUTF_IS_X86_64 1
-#elif defined(__aarch64__) || defined(_M_ARM64)
+#elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #define SIMDUTF_IS_ARM64 1
 #elif defined(__PPC64__) || defined(_M_PPC64)
 //#define SIMDUTF_IS_PPC64 1


### PR DESCRIPTION
This PR solves compilation errors when building for the [Windows ARM64EC ABI](https://blogs.windows.com/windowsdeveloper/2021/06/28/announcing-arm64ec-building-native-and-interoperable-apps-for-windows-11-on-arm/).

You can repro in an [ARM64 Visual Studio Developer Command Prompt](https://devblogs.microsoft.com/cppblog/arm64ec-support-in-visual-studio/#developer-command-prompt):

```
>cl /nologo /c /EHsc /std:c++17 /arm64EC simdutf.cpp

simdutf.cpp : error C7303: AVX512 types (__m512) are not currently supported in ARM64EC code
simdutf.cpp : error C7303: AVX512 types (__m512) are not currently supported in ARM64EC code
simdutf.cpp : error C7303: AVX512 types (__m512) are not currently supported in ARM64EC code
simdutf.cpp : error C7303: AVX512 types (__m512) are not currently supported in ARM64EC code
simdutf.cpp : error C7303: AVX512 types (__m512) are not currently supported in ARM64EC code
simdutf.cpp : error C7303: AVX512 types (__m512) are not currently supported in ARM64EC code
simdutf.cpp : error C7303: AVX512 types (__m512) are not currently supported in ARM64EC code
simdutf.cpp : error C7303: AVX512 types (__m512) are not currently supported in ARM64EC code
simdutf.cpp : error C7303: AVX512 types (__m512) are not currently supported in ARM64EC code
simdutf.cpp : error C7303: AVX512 types (__m512) are not currently supported in ARM64EC code
...
```

When building for the ARM64EC ABI, the compiler [defines the `_M_X64` macro and _not_ the `_M_ARM64` macro](https://techcommunity.microsoft.com/t5/windows-os-platform-blog/getting-to-know-arm64ec-defines-and-intrinsic-functions/ba-p/2957235), to make incremental porting existing X64 Windows code to ARM easier.

This means that the library was detecting ARM64EC as AMD64 and trying to compile in the Intel SIMD vector implementations instead of NEON. This actually works in simple cases when building existing code that uses Intel intrinsics up to SSE4.2, because Windows provides [an emulated implementation of those SIMD instruction sets](http://www.emulators.com/docs/abc_arm64ec_explained.htm) in the `softintrin.lib` library, but it doesn't work at all for AVX+ intrinsics. It's also less efficient than using NEON directly.

The change makes the CPU architecture detection aware of the ARM64EC ABI so it can correctly detect the code as being built for ARM64 and use the right intrinsics.

See also: https://github.com/simdjson/simdjson/pull/2165