### PR TITLE
Drop reference to std::cout and friends

### DIFF
--- a/src/scalar/utf8_to_latin1/utf8_to_latin1.h
+++ b/src/scalar/utf8_to_latin1/utf8_to_latin1.h
@@ -1,6 +1,5 @@
 #ifndef SIMDUTF_UTF8_TO_LATIN1_H
 #define SIMDUTF_UTF8_TO_LATIN1_H
-#include <iostream>
 
 namespace simdutf {
 namespace scalar {


### PR DESCRIPTION
Remove unnecessary include in a header file.