### PR TITLE
add Windows ARM64EC CI workflow

### DIFF
--- a/.github/workflows/vs17-arm-ci.yml
+++ b/.github/workflows/vs17-arm-ci.yml
@@ -11,10 +11,11 @@ jobs:
       matrix:
         include:
           - {gen: Visual Studio 17 2022, arch: ARM64}
+          - {gen: Visual Studio 17 2022, arch: ARM64EC}
     steps:
       - name: checkout
         uses: actions/checkout@v4
       - name: Use cmake
         run: |
-          cmake -G "${{matrix.gen}}" -A ${{ matrix.arch }} -DSIMDUTF_ALWAYS_INCLUDE_FALLBACK=ON -DCMAKE_CROSSCOMPILING=1 -DSIMDUTF_ICONV=OFF -B build  &&
+          cmake -G "${{matrix.gen}}" -A ${{ matrix.arch }} -DCMAKE_SYSTEM_VERSION="10.0.22621.0" -DSIMDUTF_ALWAYS_INCLUDE_FALLBACK=ON -DCMAKE_CROSSCOMPILING=1 -DSIMDUTF_ICONV=OFF -B build  &&
           cmake --build build --verbose


### PR DESCRIPTION
This PR adds an ARM64EC architecture CI build workflow to windows-vs17. See [here](https://github.com/jblazquez/simdutf/actions/runs/8610077872/job/23595020847) for an example of a passing CI run. I had to switch the vs17-arm-ci builds to [target the Windows 11 SDK](https://stackoverflow.com/a/77651884) because ARM64EC is Windows 11 only.

It's not currently possible (as far as I know) to actually run Windows ARM tests in CI, so - as before - the Windows ARM CI workflows are build-only.

Note that support for ARM64EC was [added in CMake 3.20.0 and improved in 3.23.0](https://gitlab.kitware.com/cmake/cmake/-/issues/21724). The minimum version of CMake declared in the CMakeLists.txt file is [3.15.0](https://github.com/simdutf/simdutf/blob/d12bb58/CMakeLists.txt#L1). I'm not sure if we need to do something about that minimum version.