### PR TITLE
fix: problems building Windows ARM on some platforms

### DIFF
--- a/benchmarks/base64/benchmark_base64.cpp
+++ b/benchmarks/base64/benchmark_base64.cpp
@@ -198,7 +198,7 @@ bool contains_spaces(std::vector<std::vector<char>> &data) {
 
 void bench(std::vector<std::vector<char>> &data, uint8_t mode) {
   size_t volume = std::accumulate(
-      data.begin(), data.end(), 0,
+      data.begin(), data.end(), size_t(0),
       [](size_t a, const std::vector<char> &b) { return a + b.size(); });
   size_t max_size = std::max_element(data.begin(), data.end(),
                                      [](const std::vector<char> &a,

--- a/src/arm64/arm_base64.cpp
+++ b/src/arm64/arm_base64.cpp
@@ -45,8 +45,17 @@ size_t encode_base64(char *dst, const char *src, size_t srclen,
       'N', 'd', 't', '9', 'O', 'e', 'u', '-', 'P', 'f', 'v', '_',
   };
   const uint8x16_t v3f = vdupq_n_u8(0x3f);
+#ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
+  // When trying to load a uint8_t array, Visual Studio might
+  // error with: error C2664: '__n128x4 neon_ld4m_q8(const char *)':
+  // cannot convert argument 1 from 'const uint8_t [64]' to 'const char *
+  const uint8x16x4_t table =
+      vld4q_u8((reinterpret_cast<const char *>(
+        options & base64_url) ? source_table_url : source_table));
+#else
   const uint8x16x4_t table =
       vld4q_u8((options & base64_url) ? source_table_url : source_table);
+#endif
   size_t i = 0;
   for (; i + 16 * 3 <= srclen; i += 16 * 3) {
     const uint8x16x3_t in = vld3q_u8((const uint8_t *)src + i);


### PR DESCRIPTION
This looks like a Visual Studio bug. The function `vld4q_u8` should take a `uint8_t*` pointer, not a `char*` pointer. I did not investigate further and I just fix the issue by casting when under Visual Studio.

Fixes https://github.com/simdutf/simdutf/issues/407