### PR TITLE
Issue 414: making implementations trivially destructible

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   - [Base64](#base64)
   - [The sutf command-line tool](#the-sutf-command-line-tool)
   - [Manual implementation selection](#manual-implementation-selection)
+  - [Thread safety](#thread-safety)
   - [References](#references)
   - [License](#license)
 
@@ -1868,7 +1869,12 @@ int main() {
 }
 ```
 
-Within the simdutf library,
+Thread safety
+-----------
+
+We built simdutf with thread safety in mind. The simdutf library is single-threaded throughout.
+The CPU detection, which runs the first time parsing is attempted and switches to the fastest parser for your CPU, is transparent and thread-safe. Our runtime dispatching is based on global objects that are instantiated at the beginning of the main thread and may be discarded at the end of the main thread. If you have multiple threads running and some threads use the library while the main thread is cleaning up ressources, you may encounter issues. If you expect such problems, you may consider using [std::quick_exit](https://en.cppreference.com/w/cpp/utility/program/quick_exit)..
+
 
 References
 -----------

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -2696,8 +2696,8 @@ public:
 protected:
   /** @private Construct an implementation with the given name and description. For subclasses. */
   simdutf_really_inline implementation(
-    std::string name,
-    std::string description,
+    const char* name,
+    const char* description,
     uint32_t required_instruction_sets
   ) :
     _name(name),

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -1548,7 +1548,7 @@ public:
    *
    * @return the name of the implementation, e.g. "haswell", "westmere", "arm64"
    */
-  virtual const std::string &name() const { return _name; }
+  virtual std::string name() const { return std::string(_name); }
 
   /**
    * The description of this implementation.
@@ -1558,7 +1558,7 @@ public:
    *
    * @return the name of the implementation, e.g. "haswell", "westmere", "arm64"
    */
-  virtual const std::string &description() const { return _description; }
+  virtual std::string description() const { return std::string(_description); }
 
   /**
    * The instruction sets this implementation is compiled against
@@ -2705,18 +2705,18 @@ protected:
     _required_instruction_sets(required_instruction_sets)
   {
   }
-  virtual ~implementation()=default;
-
+protected:
+  ~implementation() = default;
 private:
   /**
    * The name of this implementation.
    */
-  const std::string _name;
+  std::string_view _name;
 
   /**
    * The description of this implementation.
    */
-  const std::string _description;
+  std::string_view _description;
 
   /**
    * Instruction sets required for this implementation.

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -2711,12 +2711,12 @@ private:
   /**
    * The name of this implementation.
    */
-  std::string_view _name;
+  const char* _name;
 
   /**
    * The description of this implementation.
    */
-  std::string_view _description;
+  const char* _description;
 
   /**
    * Instruction sets required for this implementation.

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -151,8 +151,8 @@ static const implementation* get_single_implementation() {
  */
 class detect_best_supported_implementation_on_first_use final : public implementation {
 public:
-  const std::string &name() const noexcept final { return set_best()->name(); }
-  const std::string &description() const noexcept final { return set_best()->description(); }
+  std::string name() const noexcept final { return set_best()->name(); }
+  std::string description() const noexcept final { return set_best()->description(); }
   uint32_t required_instruction_sets() const noexcept final { return set_best()->required_instruction_sets(); }
 
   simdutf_warn_unused int detect_encodings(const char * input, size_t length) const noexcept override {
@@ -484,6 +484,9 @@ public:
 private:
   const implementation *set_best() const noexcept;
 };
+
+static_assert(std::is_trivially_destructible<detect_best_supported_implementation_on_first_use>::value, "detect_best_supported_implementation_on_first_use should be trivially destructible");
+
 
 static const std::initializer_list<const implementation *>& get_available_implementation_pointers() {
   static const std::initializer_list<const implementation *> available_implementation_pointers {
@@ -848,6 +851,7 @@ public:
 };
 
 const unsupported_implementation unsupported_singleton{};
+static_assert(std::is_trivially_destructible<unsupported_implementation>::value, "unsupported_singleton should be trivially destructible");
 
 size_t available_implementation_list::size() const noexcept {
   return internal::get_available_implementation_pointers().size();


### PR DESCRIPTION
Issue 414 reported by @Jarred-Sumner illustrates a potential issue when using multiple threads. If the main thread is shutting down and deleting static objects while other threads are still running and potentially using simdutf, the result might be a crash. This PR will make our static objects ('implementations' used for runtime dispatching) trivially destructible. Many compilers appear to never call the destructor when the class is trivially destructible. (This makes sense since the destructor is guaranteed to have no effect.)

It is not entirely clear that it solves the issue. If the main thread is shutting down, and you have running threads, you might be outside of the standard memory model. 

Thus we also add some documentation that encourage users to call methods such as `std::quick_exit` when shutting down the main thread.

Fixes https://github.com/simdutf/simdutf/issues/414