### PR TITLE
fix: add more variants to base64

### DIFF
--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -1389,9 +1389,13 @@ simdutf_warn_unused size_t trim_partial_utf16(const char16_t* input, size_t leng
 
 // base64_options are used to specify the base64 encoding options.
 using base64_options = uint64_t;
+using base64_options = uint64_t;
 enum : base64_options {
-  base64_default = 0, /* standard base64 format */
-  base64_url = 1 /* base64url format*/
+  base64_default = 0, /* standard base64 format (with padding) */
+  base64_url = 1, /* base64url format (no padding) */
+  base64_reverse_padding = 2, /* modifier for base64_default and base64_url */
+  base64_default_no_padding = base64_default | base64_reverse_padding, /* standard base64 format without padding */
+  base64_url_with_padding = base64_url | base64_reverse_padding, /* base64url with padding */
 };
 
 /**

--- a/src/haswell/avx2_base64.cpp
+++ b/src/haswell/avx2_base64.cpp
@@ -54,8 +54,8 @@ simdutf_really_inline __m256i lookup_pshufb_improved(const __m256i input) {
   return _mm256_add_epi8(result, input);
 }
 
-template <base64_options options>
-size_t encode_base64(char *dst, const char *src, size_t srclen) {
+template <bool isbase64url>
+size_t encode_base64(char *dst, const char *src, size_t srclen, base64_options options) {
   // credit: Wojciech Muła
   const uint8_t *input = (const uint8_t *)src;
 
@@ -122,18 +122,18 @@ size_t encode_base64(char *dst, const char *src, size_t srclen) {
     const __m256i input3 = _mm256_or_si256(t1_3, t3_3);
 
     _mm256_storeu_si256(reinterpret_cast<__m256i *>(out),
-                        lookup_pshufb_improved<options == base64_url>(input0));
+                        lookup_pshufb_improved<isbase64url>(input0));
     out += 32;
 
     _mm256_storeu_si256(reinterpret_cast<__m256i *>(out),
-                        lookup_pshufb_improved<options == base64_url>(input1));
+                        lookup_pshufb_improved<isbase64url>(input1));
     out += 32;
 
     _mm256_storeu_si256(reinterpret_cast<__m256i *>(out),
-                        lookup_pshufb_improved<options == base64_url>(input2));
+                        lookup_pshufb_improved<isbase64url>(input2));
     out += 32;
     _mm256_storeu_si256(reinterpret_cast<__m256i *>(out),
-                        lookup_pshufb_improved<options == base64_url>(input3));
+                        lookup_pshufb_improved<isbase64url>(input3));
     out += 32;
   }
   for (; i + 28 <= srclen; i += 24) {
@@ -157,7 +157,7 @@ size_t encode_base64(char *dst, const char *src, size_t srclen) {
     const __m256i indices = _mm256_or_si256(t1, t3);
 
     _mm256_storeu_si256(reinterpret_cast<__m256i *>(out),
-                        lookup_pshufb_improved<options == base64_url>(indices));
+                        lookup_pshufb_improved<isbase64url>(indices));
     out += 32;
   }
   return i / 3 * 4 + scalar::base64::tail_encode_base64((char *)out, src + i,

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -800,9 +800,9 @@ simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t leng
 
 size_t implementation::binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept {
   if(options & base64_url) {
-    return encode_base64<base64_url>(output, input, length);
+    return encode_base64<true>(output, input, length, options);
   } else {
-    return encode_base64<base64_default>(output, input, length);
+    return encode_base64<false>(output, input, length, options);
   }
 }
 } // namespace SIMDUTF_IMPLEMENTATION

--- a/src/scalar/base64.h
+++ b/src/scalar/base64.h
@@ -293,7 +293,14 @@ simdutf_warn_unused size_t maximal_binary_length_from_base64(const char_type * i
 }
 
 simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) noexcept {
-  if(options & base64_url) {
+  // By default, we use padding if we are not using the URL variant.
+  // This is check with ((options & base64_url) == 0) which returns true if we are not using the URL variant.
+  // However, we also allow 'inversion' of the convention with the base64_reverse_padding option.
+  // If the base64_reverse_padding option is set, we use padding if we are using the URL variant,
+  // and we omit it if we are not using the URL variant. This is checked with
+  // ((options & base64_reverse_padding) == base64_reverse_padding).
+  bool use_padding = ((options & base64_url) == 0) ^ ((options & base64_reverse_padding) == base64_reverse_padding);
+  if(use_padding) {
     return length/3 * 4 + ((length % 3) ? (length % 3) + 1 : 0);
   }
   return (length + 2)/3 * 4; // We use padding to make the length a multiple of 4.

--- a/src/scalar/base64.h
+++ b/src/scalar/base64.h
@@ -300,7 +300,7 @@ simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_optio
   // and we omit it if we are not using the URL variant. This is checked with
   // ((options & base64_reverse_padding) == base64_reverse_padding).
   bool use_padding = ((options & base64_url) == 0) ^ ((options & base64_reverse_padding) == base64_reverse_padding);
-  if(use_padding) {
+  if(!use_padding) {
     return length/3 * 4 + ((length % 3) ? (length % 3) + 1 : 0);
   }
   return (length + 2)/3 * 4; // We use padding to make the length a multiple of 4.

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -800,10 +800,10 @@ simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t leng
 }
 
 size_t implementation::binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept {
-  if(options == base64_url) {
-    return encode_base64<base64_url>(output, input, length);
+  if(options & base64_url) {
+    return encode_base64<true>(output, input, length, options);
   } else {
-    return encode_base64<base64_default>(output, input, length);
+    return encode_base64<false>(output, input, length, options);
   }
 }
 } // namespace SIMDUTF_IMPLEMENTATION

--- a/src/westmere/sse_base64.cpp
+++ b/src/westmere/sse_base64.cpp
@@ -56,8 +56,8 @@ template <bool base64_url> __m128i lookup_pshufb_improved(const __m128i input) {
   return _mm_add_epi8(result, input);
 }
 
-template <base64_options options>
-size_t encode_base64(char *dst, const char *src, size_t srclen) {
+template <bool isbase64url>
+size_t encode_base64(char *dst, const char *src, size_t srclen, base64_options options) {
   // credit: Wojciech Muła
   // SSE (lookup: pshufb improved unrolled)
   const uint8_t *input = (const uint8_t *)src;
@@ -108,19 +108,19 @@ size_t encode_base64(char *dst, const char *src, size_t srclen) {
     const __m128i input3 = _mm_or_si128(t1_3, t3_3);
 
     _mm_storeu_si128(reinterpret_cast<__m128i *>(out),
-                     lookup_pshufb_improved<options & base64_url>(input0));
+                     lookup_pshufb_improved<isbase64url>(input0));
     out += 16;
 
     _mm_storeu_si128(reinterpret_cast<__m128i *>(out),
-                     lookup_pshufb_improved<options & base64_url>(input1));
+                     lookup_pshufb_improved<isbase64url>(input1));
     out += 16;
 
     _mm_storeu_si128(reinterpret_cast<__m128i *>(out),
-                     lookup_pshufb_improved<options & base64_url>(input2));
+                     lookup_pshufb_improved<isbase64url>(input2));
     out += 16;
 
     _mm_storeu_si128(reinterpret_cast<__m128i *>(out),
-                     lookup_pshufb_improved<options & base64_url>(input3));
+                     lookup_pshufb_improved<isbase64url>(input3));
     out += 16;
   }
   for (; i + 16 <= srclen; i += 12) {
@@ -160,7 +160,7 @@ size_t encode_base64(char *dst, const char *src, size_t srclen) {
     const __m128i indices = _mm_or_si128(t1, t3);
 
     _mm_storeu_si128(reinterpret_cast<__m128i *>(out),
-                     lookup_pshufb_improved<options & base64_url>(indices));
+                     lookup_pshufb_improved<isbase64url>(indices));
     out += 16;
   }
 

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -219,7 +219,7 @@ TEST(encode_base64_cases_no_padding) {
   printf(" -- ");
   for (std::pair<std::string, std::string> p : cases) {
     std::vector<char> buffer(
-        implementation.base64_length_from_binary(p.first.size()));
+        implementation.base64_length_from_binary(p.first.size()), simdutf::base64_default_no_padding);
     ASSERT_EQUAL(buffer.size(), p.second.size());
     size_t s = implementation.binary_to_base64(p.first.data(), p.first.size(),
                                                buffer.data(), simdutf::base64_default_no_padding);
@@ -297,7 +297,7 @@ TEST(encode_base64url_with_padding_cases) {
   printf(" -- ");
   for (std::pair<std::string, std::string> p : cases) {
     std::vector<char> buffer(
-        implementation.base64_length_from_binary(p.first.size(), simdutf::base64_url));
+        implementation.base64_length_from_binary(p.first.size(), simdutf::base64_url_with_padding));
     ASSERT_EQUAL(buffer.size(), p.second.size());
     size_t s = implementation.binary_to_base64(p.first.data(), p.first.size(),
                                                buffer.data(), simdutf::base64_url_with_padding);

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -206,6 +206,28 @@ TEST(encode_base64_cases) {
   }
 }
 
+
+TEST(encode_base64_cases_no_padding) {
+  std::vector<std::pair<std::string, std::string>> cases = {
+      {"Hello, World!", "SGVsbG8sIFdvcmxkIQ"},
+      {"GeeksforGeeks", "R2Vla3Nmb3JHZWVrcw"},
+      {"123456", "MTIzNDU2"},
+      {"Base64 Encoding", "QmFzZTY0IEVuY29kaW5n"},
+      {"!R~J2jL&mI]O)3=c:G3Mo)oqmJdxoprTZDyxEvU0MI.'Ww5H{G>}y;;+B8E_Ah,Ed[ PdBqY'^N>O$4:7LK1<:|7)btV@|{YWR$$Er59-XjVrFl4L}~yzTEd4'E[@k", "IVJ+SjJqTCZtSV1PKTM9YzpHM01vKW9xbUpkeG9wclRaRHl4RXZVME1JLidXdzVIe0c+fXk7OytCOEVfQWgsRWRbIFBkQnFZJ15OPk8kNDo3TEsxPDp8NylidFZAfHtZV1IkJEVyNTktWGpWckZsNEx9fnl6VEVkNCdFW0Br"}};
+  std::vector<simdutf::error_code> codes = {simdutf::error_code::SUCCESS};
+  std::vector<size_t> counts = {1};
+  printf(" -- ");
+  for (std::pair<std::string, std::string> p : cases) {
+    std::vector<char> buffer(
+        implementation.base64_length_from_binary(p.first.size()));
+    ASSERT_EQUAL(buffer.size(), p.second.size());
+    size_t s = implementation.binary_to_base64(p.first.data(), p.first.size(),
+                                               buffer.data(), simdutf::base64_default_no_padding);
+    ASSERT_EQUAL(s, p.second.size());
+    ASSERT_EQUAL(std::string(buffer.data(), buffer.size()), p.second);
+  }
+}
+
 #if SIMDUTF_BASE64URL_TESTS
 
 TEST(encode_base64url_cases) {
@@ -259,6 +281,33 @@ TEST(encode_base64url_cases) {
     for (size_t i = 0; i < buffer.size(); i++) {
       ASSERT_EQUAL(buffer[i], p.first[i]);
     }
+  }
+}
+
+
+TEST(encode_base64url_with_padding_cases) {
+  std::vector<std::pair<std::string, std::string>> cases = {
+      {"Hello, World!", "SGVsbG8sIFdvcmxkIQ=="},
+      {"GeeksforGeeks", "R2Vla3Nmb3JHZWVrcw=="},
+      {"123456", "MTIzNDU2"},
+      {"Base64 Encoding", "QmFzZTY0IEVuY29kaW5n"},
+      {"!R~J2jL&mI]O)3=c:G3Mo)oqmJdxoprTZDyxEvU0MI.'Ww5H{G>}y;;+B8E_Ah,Ed[ PdBqY'^N>O$4:7LK1<:|7)btV@|{YWR$$Er59-XjVrFl4L}~yzTEd4'E[@k", "IVJ+SjJqTCZtSV1PKTM9YzpHM01vKW9xbUpkeG9wclRaRHl4RXZVME1JLidXdzVIe0c+fXk7OytCOEVfQWgsRWRbIFBkQnFZJ15OPk8kNDo3TEsxPDp8NylidFZAfHtZV1IkJEVyNTktWGpWckZsNEx9fnl6VEVkNCdFW0Br"}};
+  std::vector<simdutf::error_code> codes = {simdutf::error_code::SUCCESS};
+  std::vector<size_t> counts = {1};
+  printf(" -- ");
+  for (std::pair<std::string, std::string> p : cases) {
+    std::vector<char> buffer(
+        implementation.base64_length_from_binary(p.first.size(), simdutf::base64_url));
+    ASSERT_EQUAL(buffer.size(), p.second.size());
+    size_t s = implementation.binary_to_base64(p.first.data(), p.first.size(),
+                                               buffer.data(), simdutf::base64_url_with_padding);
+    ASSERT_EQUAL(s, p.second.size());
+    if(std::string(buffer.data(), buffer.size()) != p.second) {
+      printf("difference:\n");
+      printf(" %.*s\n", (int)s, buffer.data());
+      printf(" %.*s\n", (int)s, p.second.data());
+    }
+    ASSERT_EQUAL(std::string(buffer.data(), buffer.size()), p.second);
   }
 }
 

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -219,7 +219,7 @@ TEST(encode_base64_cases_no_padding) {
   printf(" -- ");
   for (std::pair<std::string, std::string> p : cases) {
     std::vector<char> buffer(
-        implementation.base64_length_from_binary(p.first.size()), simdutf::base64_default_no_padding);
+        implementation.base64_length_from_binary(p.first.size(), simdutf::base64_default_no_padding));
     ASSERT_EQUAL(buffer.size(), p.second.size());
     size_t s = implementation.binary_to_base64(p.first.data(), p.first.size(),
                                                buffer.data(), simdutf::base64_default_no_padding);
@@ -291,7 +291,7 @@ TEST(encode_base64url_with_padding_cases) {
       {"GeeksforGeeks", "R2Vla3Nmb3JHZWVrcw=="},
       {"123456", "MTIzNDU2"},
       {"Base64 Encoding", "QmFzZTY0IEVuY29kaW5n"},
-      {"!R~J2jL&mI]O)3=c:G3Mo)oqmJdxoprTZDyxEvU0MI.'Ww5H{G>}y;;+B8E_Ah,Ed[ PdBqY'^N>O$4:7LK1<:|7)btV@|{YWR$$Er59-XjVrFl4L}~yzTEd4'E[@k", "IVJ+SjJqTCZtSV1PKTM9YzpHM01vKW9xbUpkeG9wclRaRHl4RXZVME1JLidXdzVIe0c+fXk7OytCOEVfQWgsRWRbIFBkQnFZJ15OPk8kNDo3TEsxPDp8NylidFZAfHtZV1IkJEVyNTktWGpWckZsNEx9fnl6VEVkNCdFW0Br"}};
+      {"!R~J2jL&mI]O)3=c:G3Mo)oqmJdxoprTZDyxEvU0MI.'Ww5H{G>}y;;+B8E_Ah,Ed[ PdBqY'^N>O$4:7LK1<:|7)btV@|{YWR$$Er59-XjVrFl4L}~yzTEd4'E[@k", "IVJ-SjJqTCZtSV1PKTM9YzpHM01vKW9xbUpkeG9wclRaRHl4RXZVME1JLidXdzVIe0c-fXk7OytCOEVfQWgsRWRbIFBkQnFZJ15OPk8kNDo3TEsxPDp8NylidFZAfHtZV1IkJEVyNTktWGpWckZsNEx9fnl6VEVkNCdFW0Br"}};
   std::vector<simdutf::error_code> codes = {simdutf::error_code::SUCCESS};
   std::vector<size_t> counts = {1};
   printf(" -- ");


### PR DESCRIPTION
By default, we use padding except for the URL variant where we do not. However, some users of the library might need other variations: the conventional base64 without padding *or* the URL variant with padding. This PR provides this functionality.

I also give more of an explanation as to why we have the padding conventions we do. They come from RFC 4648.

cc @constellation