### PR TITLE
prevent invoking memcpy on nullptr in utf16_to_lat1::convert

### DIFF
--- a/src/scalar/utf16_to_latin1/utf16_to_latin1.h
+++ b/src/scalar/utf16_to_latin1/utf16_to_latin1.h
@@ -10,6 +10,9 @@ namespace utf16_to_latin1 {
 
 template <endianness big_endian>
 inline size_t convert(const char16_t* buf, size_t len, char* latin_output) {
+  if (len == 0) {
+    return 0;
+  }
   const uint16_t *data = reinterpret_cast<const uint16_t *>(buf);
   size_t pos = 0;
   std::vector<char> temp_output(len);


### PR DESCRIPTION
This fixes sending a nullptr to memcpy, which is undefined behaviour. It also prevents doing pointer arithmetics on a nullptr in the return statement.

The existing test "random_fuzzer" covers this.
