### PR TITLE
fix alignment error in unit tests (gcc complains)

### DIFF
--- a/tests/convert_utf16be_to_utf8_tests.cpp
+++ b/tests/convert_utf16be_to_utf8_tests.cpp
@@ -312,7 +312,7 @@ TEST(all_possible_8_codepoint_combinations) {
 
 
 TEST(issue_443) {
-  const unsigned char crash[] = {0x20, 0x20};
+  alignas(2) const unsigned char crash[] = {0x20, 0x20};
   const unsigned int crash_len = 2;
   std::vector<char> output(4 * crash_len);
   const auto r = implementation.convert_utf16be_to_utf8((const char16_t *) crash,

--- a/tests/convert_utf16be_to_utf8_with_errors_tests.cpp
+++ b/tests/convert_utf16be_to_utf8_with_errors_tests.cpp
@@ -218,7 +218,7 @@ TEST(convert_fails_if_there_is_surrogate_pair_is_followed_by_high_surrogate) {
 }
 #endif
 TEST(issue_445) {
-  const unsigned char crash[] = {0x20, 0x20, 0xdd, 0x20};
+  alignas(2) const unsigned char crash[] = {0x20, 0x20, 0xdd, 0x20};
   const unsigned int crash_len = 4;
   std::vector<char> output(4 * crash_len);
   const auto r = implementation.convert_utf16be_to_utf8_with_errors((const char16_t *) crash,


### PR DESCRIPTION
While validating #469 I saw that ub sanitizer with gcc complains about unaligned load. 
This fixes the problem. clang does not complain.

Is there no CI job that runs gcc with sanitizers that has caught this?

I could not use the latest master because of the newly tweaked inline in 04b9b9ed1a698a161c71a6f901041735f19cd93b:

> pauldreik@privat-kodning:~/code/delaktig/simdutf/tests/blah-gcc$ ninja && ctest -j100
> [74/165] Building CXX object src/CMakeFiles/simdutf.dir/simdutf.cpp.o
> FAILED: src/CMakeFiles/simdutf.dir/simdutf.cpp.o 
> /usr/lib/ccache/g++-12  -I/home/pauldreik/code/delaktig/simdutf/src -I/home/pauldreik/code/delaktig/simdutf/include -g -std=c++11 -Wall -Wextra -Weffc++ -Wfatal-errors -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wconversion -Wno-sign-conversion -Wunused-function -mno-avx256-split-unaligned-load -mno-avx256-split-unaligned-store -fsanitize=undefined -fno-sanitize-recover=all -MD -MT src/CMakeFiles/simdutf.dir/simdutf.cpp.o -MF src/CMakeFiles/simdutf.dir/simdutf.cpp.o.d -o src/CMakeFiles/simdutf.dir/simdutf.cpp.o -c /home/pauldreik/code/delaktig/simdutf/src/simdutf.cpp
> In file included from /home/pauldreik/code/delaktig/simdutf/src/simdutf/haswell/simd.h:393,
>                  from /home/pauldreik/code/delaktig/simdutf/src/simdutf/haswell.h:59,
>                  from /home/pauldreik/code/delaktig/simdutf/src/implementation.cpp:27,
>                  from /home/pauldreik/code/delaktig/simdutf/src/simdutf.cpp:4:
> /home/pauldreik/code/delaktig/simdutf/src/simdutf/haswell/simd16-inl.h: In function ‘simdutf::haswell::{anonymous}::simd::simd16<bool> simdutf::haswell::{anonymous}::simd::operator==(simd16<short unsigned int>, simd16<short unsigned int>)’:
> /home/pauldreik/code/delaktig/simdutf/src/simdutf/haswell/simd16-inl.h:19:37: note: the ABI for passing parameters with 32-byte alignment has changed in GCC 4.6
>    19 |   friend simdutf_really_inline Mask operator==(const simd16<T> lhs, const simd16<T> rhs) { return _mm256_cmpeq_epi16(lhs, rhs); }
>       |                                     ^~~~~~~~
> /home/pauldreik/code/delaktig/simdutf/src/simdutf/haswell/simd16-inl.h:19:126: warning: AVX vector return without AVX enabled changes the ABI [-Wpsabi]
>    19 |   friend simdutf_really_inline Mask operator==(const simd16<T> lhs, const simd16<T> rhs) { return _mm256_cmpeq_epi16(lhs, rhs); }
>       |                                                                                                                              ^
> In file included from /usr/lib/gcc/x86_64-linux-gnu/12/include/immintrin.h:47,
>                  from /usr/lib/gcc/x86_64-linux-gnu/12/include/x86intrin.h:32,
>                  from /home/pauldreik/code/delaktig/simdutf/src/simdutf/icelake/intrinsics.h:20,
>                  from /home/pauldreik/code/delaktig/simdutf/src/simdutf/icelake.h:59,
>                  from /home/pauldreik/code/delaktig/simdutf/src/implementation.cpp:26:
> /usr/lib/gcc/x86_64-linux-gnu/12/include/avx2intrin.h: In function ‘simdutf::haswell::{anonymous}::simd::simd8<bool> simdutf::haswell::{anonymous}::simd::operator==(simd8<unsigned char>, simd8<unsigned char>)’:
> /usr/lib/gcc/x86_64-linux-gnu/12/include/avx2intrin.h:231:1: error: inlining failed in call to ‘always_inline’ ‘__m256i _mm256_cmpeq_epi8(__m256i, __m256i)’: target specific option mismatch
>   231 | _mm256_cmpeq_epi8 (__m256i __A, __m256i __B)
>       | ^~~~~~~~~~~~~~~~~
> compilation terminated due to -Wfatal-errors.
> [88/165] Building CXX object tests/CMakeFiles/base64_tests.dir/base64_tests.cpp.o
> ninja: build stopped: subcommand failed.
> 