### PR TITLE
guard against nullptr arithmetic

### DIFF
--- a/src/haswell/avx2_validate_utf16.cpp
+++ b/src/haswell/avx2_validate_utf16.cpp
@@ -45,6 +45,9 @@
 */
 template <endianness big_endian>
 const char16_t* avx2_validate_utf16(const char16_t* input, size_t size) {
+    if (simdutf_unlikely(size == 0)) {
+        return input;
+    }
     const char16_t* end = input + size;
 
     const auto v_d8 = simd8<uint8_t>::splat(0xd8);
@@ -122,7 +125,10 @@ const char16_t* avx2_validate_utf16(const char16_t* input, size_t size) {
 
 template <endianness big_endian>
 const result avx2_validate_utf16_with_errors(const char16_t* input, size_t size) {
-    const char16_t* start = input;
+    if (simdutf_unlikely(size == 0)) {
+        return result(error_code::SUCCESS, 0);
+    }
+    const char16_t *start = input;
     const char16_t* end = input + size;
 
     const auto v_d8 = simd8<uint8_t>::splat(0xd8);

--- a/src/haswell/avx2_validate_utf32le.cpp
+++ b/src/haswell/avx2_validate_utf32le.cpp
@@ -3,6 +3,9 @@
    - nullptr if an error was detected.
 */
 const char32_t* avx2_validate_utf32le(const char32_t* input, size_t size) {
+    if (simdutf_unlikely(size == 0)) {
+        return input;
+    }
     const char32_t* end = input + size;
 
     const __m256i standardmax = _mm256_set1_epi32(0x10ffff);
@@ -32,6 +35,9 @@ const char32_t* avx2_validate_utf32le(const char32_t* input, size_t size) {
 
 
 const result avx2_validate_utf32le_with_errors(const char32_t* input, size_t size) {
+    if (simdutf_unlikely(size == 0)) {
+        return result(error_code::SUCCESS, 0);
+    }
     const char32_t* start = input;
     const char32_t* end = input + size;
 

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -185,6 +185,9 @@ implementation::detect_encodings(const char *input,
 }
 
 simdutf_warn_unused bool implementation::validate_utf8(const char *buf, size_t len) const noexcept {
+  if (simdutf_unlikely(len == 0)) {
+    return true;
+  }
     avx512_utf8_checker checker{};
     const char* ptr = buf;
     const char* end = ptr + len;
@@ -201,6 +204,9 @@ simdutf_warn_unused bool implementation::validate_utf8(const char *buf, size_t l
 }
 
 simdutf_warn_unused result implementation::validate_utf8_with_errors(const char *buf, size_t len) const noexcept {
+    if (simdutf_unlikely(len == 0)) {
+       return result(error_code::SUCCESS, len);
+    }
     avx512_utf8_checker checker{};
     const char* ptr = buf;
     const char* end = ptr + len;
@@ -663,6 +669,9 @@ simdutf_warn_unused size_t implementation::convert_utf8_to_utf32(const char* buf
 }
 
 simdutf_warn_unused result implementation::convert_utf8_to_utf32_with_errors(const char* buf, size_t len, char32_t* utf32) const noexcept {
+  if (simdutf_unlikely(len == 0)) {
+    return {error_code::SUCCESS, 0};
+  }
   uint32_t * utf32_output = reinterpret_cast<uint32_t *>(utf32);
   auto ret = icelake::validating_utf8_to_fixed_length_with_constant_checks<endianness::LITTLE, uint32_t>(buf, len, utf32_output);
 

--- a/src/westmere/sse_validate_utf16.cpp
+++ b/src/westmere/sse_validate_utf16.cpp
@@ -45,6 +45,9 @@
 */
 template <endianness big_endian>
 const char16_t* sse_validate_utf16(const char16_t* input, size_t size) {
+    if (simdutf_unlikely(size == 0)) {
+        return input;
+    }
     const char16_t* end = input + size;
 
     const auto v_d8 = simd8<uint8_t>::splat(0xd8);
@@ -121,6 +124,9 @@ const char16_t* sse_validate_utf16(const char16_t* input, size_t size) {
 
 template <endianness big_endian>
 const result sse_validate_utf16_with_errors(const char16_t* input, size_t size) {
+    if (simdutf_unlikely(size == 0)) {
+        return result(error_code::SUCCESS, 0);
+    }
     const char16_t* start = input;
     const char16_t* end = input + size;
 

--- a/src/westmere/sse_validate_utf32le.cpp
+++ b/src/westmere/sse_validate_utf32le.cpp
@@ -3,6 +3,9 @@
    - nullptr if an error was detected.
 */
 const char32_t* sse_validate_utf32le(const char32_t* input, size_t size) {
+    if (size == 0) {
+        return input;
+    }
     const char32_t* end = input + size;
 
     const __m128i standardmax = _mm_set1_epi32(0x10ffff);
@@ -32,6 +35,9 @@ const char32_t* sse_validate_utf32le(const char32_t* input, size_t size) {
 
 
 const result sse_validate_utf32le_with_errors(const char32_t* input, size_t size) {
+    if (size == 0) {
+        return result(error_code::SUCCESS, 0);
+    }
     const char32_t* start = input;
     const char32_t* end = input + size;
 

--- a/tests/null_safety_tests.cpp
+++ b/tests/null_safety_tests.cpp
@@ -9,9 +9,9 @@ TEST(test_empty) {
     const std::vector<char16_t> i16data;
     const std::vector<char32_t> i32data;
     //outputs
-    std::vector<char> o8data(4);
-    std::vector<char16_t> o16data(4);
-    std::vector<char32_t> o32data(4);
+    std::vector<char> o8data;
+    std::vector<char16_t> o16data;
+    std::vector<char32_t> o32data;
 
     const auto *i8 = i8data.data();
     const auto *i16 = i16data.data();
@@ -20,6 +20,7 @@ TEST(test_empty) {
     auto *o16 = o16data.data();
     auto *o32 = o32data.data();
 
+    std::ignore = implementation.autodetect_encoding(i8, 0);
     std::ignore = implementation.base64_length_from_binary(0);
     std::ignore = implementation.base64_to_binary(i16, 0, o8);
     std::ignore = implementation.base64_to_binary(i8, 0, o8);


### PR DESCRIPTION
This is a PR for discussion.

Current master does not go through the tests clean with UB sanitizer. I fixed the places reported by the sanitizer in this PR. That does not mean there is no UB left. 

I ran the benchmarks and it seems to be a bit slower but the noise is big - is there some way to do A/B-testing with the benchmark and see the difference compared to the noise?

I used
`benchmarks/benchmark -F unicode_lipsum/lipsum/*.utf8.txt -P validate_utf8+icelake -I 100000 `
and it gives say 0.3 % difference (very noisy) on the first file (Arabic).

openssl has a special "pedantic" mode so it is possible to fuzz or use other tools on the library. I am not convinced that is a good idea for simdutf. Perhaps just fixing the issues reported by the sanitizer is enough, given that performance does not drop significantly.