### PR TITLE
fix error in convert_valid_utf16le_to_latin1 fallback

### DIFF
--- a/src/scalar/utf16_to_latin1/valid_utf16_to_latin1.h
+++ b/src/scalar/utf16_to_latin1/valid_utf16_to_latin1.h
@@ -15,8 +15,13 @@ inline size_t convert_valid(const char16_t* buf, size_t len, char* latin_output)
 
   while (pos < len) {
     word = !match_system(big_endian) ? utf16::swap_bytes(data[pos]) : data[pos];
-    *latin_output++ = char(word);
-    pos++;
+    if (word <= 0xFF) {
+        *latin_output++ = char(word);
+        pos++;
+    } else {
+        // can't be represented as latin1 - return error
+        return 0;
+    }
   }
 
   return latin_output - start;

--- a/tests/convert_valid_utf16be_to_utf8_tests.cpp
+++ b/tests/convert_valid_utf16be_to_utf8_tests.cpp
@@ -16,6 +16,12 @@ namespace {
   constexpr int trials = 1000;
 }
 
+TEST(valid_but_out_of_range_input)
+{
+    const char16_t input = 0x2020;
+    char out;
+    ASSERT_EQUAL(0, implementation.convert_valid_utf16le_to_latin1(&input, 1, &out));
+}
 
 TEST(convert_pure_ASCII) {
   size_t counter = 0;


### PR DESCRIPTION
the implementations were inconsistent, the fallback accepted the out of range input (bad) while the others did not (good).