### PR TITLE
make convert_valid_utf32_to_latin1 scalar correct and consistent

### DIFF
--- a/src/scalar/utf32_to_latin1/valid_utf32_to_latin1.h
+++ b/src/scalar/utf32_to_latin1/valid_utf32_to_latin1.h
@@ -13,25 +13,31 @@ inline size_t convert_valid(const char32_t *buf, size_t len, char *latin1_output
   size_t pos = 0;
 
   while (pos < len) {
-  utf32_char = (uint32_t)data[pos];
+      utf32_char = (uint32_t) data[pos];
 
-  if (pos + 2 <= len) { // if it is safe to read 8 more bytes, check that they are Latin1
-      uint64_t v;
-      ::memcpy(&v, data + pos, sizeof(uint64_t));
-      if ((v & 0xFFFFFF00FFFFFF00) == 0) {
-      *latin1_output++ = char(buf[pos]);
-      *latin1_output++ = char(buf[pos+1]);
-      pos += 2;
-      continue;
-    }
-  }
-  *latin1_output++ = (char)(utf32_char & 0xFF);
-  pos++;
-
+      if (pos + 2 <= len) { // if it is safe to read 8 more bytes, check that they are Latin1
+          uint64_t v;
+          ::memcpy(&v, data + pos, sizeof(uint64_t));
+          if ((v & 0xFFFFFF00FFFFFF00) == 0) {
+              *latin1_output++ = char(buf[pos]);
+              *latin1_output++ = char(buf[pos + 1]);
+              pos += 2;
+              continue;
+          } else {
+              // output can not be represented in latin1
+              return 0;
+          }
+      }
+      if ((utf32_char & 0xFFFFFF00) == 0) {
+          *latin1_output++ = char(utf32_char);
+      } else {
+          // output can not be represented in latin1
+          return 0;
+      }
+      pos++;
   }
   return latin1_output - start;
 }
-
 
 } // utf32_to_latin1 namespace
 } // unnamed namespace

--- a/tests/convert_valid_utf32_to_latin1_tests.cpp
+++ b/tests/convert_valid_utf32_to_latin1_tests.cpp
@@ -12,6 +12,31 @@ namespace {
   using simdutf::tests::helpers::transcode_utf8_to_utf16_test_base;
 }
 
+TEST(issue_convert_valid_utf32_to_latin1_2104d5a31440e3ed)
+{
+    alignas(4) const unsigned char data[] = {0x20, 0x20, 0x05, 0x00};
+    constexpr std::size_t data_len_bytes = sizeof(data);
+    constexpr std::size_t data_len = data_len_bytes / sizeof(char32_t);
+    const auto validation1 = implementation.validate_utf32_with_errors((const char32_t *) data,
+                                                                       data_len);
+    ASSERT_EQUAL(validation1.count, 1);
+    ASSERT_EQUAL(validation1.error, simdutf::error_code::SUCCESS);
+
+    const bool validation2 = implementation.validate_utf32((const char32_t *) data, data_len);
+    ASSERT_EQUAL(validation1.error == simdutf::error_code::SUCCESS, validation2);
+
+    const auto outlen = implementation.latin1_length_from_utf32(data_len);
+    ASSERT_EQUAL(outlen, 1);
+    std::vector<char> output(outlen);
+    const auto r = implementation.convert_valid_utf32_to_latin1((const char32_t *) data,
+                                                                data_len,
+                                                                output.data());
+    /*
+     * fallback gets 1, the others 0
+     */
+    ASSERT_EQUAL(r, 0);
+}
+
 TEST(convert_latin1_only) {
   size_t counter = 0;
   auto generator = [&counter]() -> uint32_t {


### PR DESCRIPTION
the other implementations check for out of range values before converting them to latin1.

the scalar implementation skipped over such invalid values unless the input length was odd, in which case the last value is converted anyway.