### PR TITLE
The convert_valid_*_to_latin1 were never documented in our README and they should not be considered part of our public API. 

### DIFF
--- a/include/simdutf/common_defs.h
+++ b/include/simdutf/common_defs.h
@@ -24,6 +24,8 @@
 #define SIMDUTF_ISALIGNED_N(ptr, n) (((uintptr_t)(ptr) & ((n)-1)) == 0)
 
 #if defined(SIMDUTF_REGULAR_VISUAL_STUDIO)
+  #define SIMDUTF_DEPRECATED __declspec(deprecated)
+
 
   #define simdutf_really_inline __forceinline
   #define simdutf_never_inline __declspec(noinline)
@@ -64,6 +66,8 @@
 #else
   #define simdutf_really_inline inline
 #endif
+
+  #define SIMDUTF_DEPRECATED __attribute__((deprecated))
   #define simdutf_never_inline inline __attribute__((noinline))
 
   #define simdutf_unused __attribute__((unused))

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -400,19 +400,22 @@ simdutf_warn_unused size_t convert_utf8_to_utf32(const char * input, size_t leng
  */
 simdutf_warn_unused result convert_utf8_to_utf32_with_errors(const char * input, size_t length, char32_t* utf32_output) noexcept;
 
-    /**
-   * Convert valid UTF-8 string into latin1 string.
-   *
-   * This function assumes that the input string is valid UTF-8 and that it can be represented as Latin1.
-   *
-   * This function is not BOM-aware.
-   *
-   * @param input         the UTF-8 string to convert
-   * @param length        the length of the string in bytes
-   * @param latin1_output  the pointer to buffer that can hold conversion result
-   * @return the number of written char; 0 if the input was not valid UTF-8 string
-   */
-  simdutf_warn_unused size_t convert_valid_utf8_to_latin1(const char * input, size_t length, char* latin1_output) noexcept;
+/**
+ * Convert valid UTF-8 string into latin1 string.
+ *
+ * This function assumes that the input string is valid UTF-8 and that it can be represented as Latin1.
+ * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+ *
+ * This function is for expert users only and not part of our public API. Use convert_utf8_to_latin1 instead.
+ *
+ * This function is not BOM-aware.
+ *
+ * @param input         the UTF-8 string to convert
+ * @param length        the length of the string in bytes
+ * @param latin1_output  the pointer to buffer that can hold conversion result
+ * @return the number of written char; 0 if the input was not valid UTF-8 string
+ */
+SIMDUTF_DEPRECATED simdutf_warn_unused size_t convert_valid_utf8_to_latin1(const char * input, size_t length, char* latin1_output) noexcept;
 
 
 /**
@@ -721,6 +724,9 @@ simdutf_warn_unused size_t convert_valid_utf16_to_utf8(const char16_t * input, s
  * Using native endianness, convert UTF-16 string into Latin1 string.
  *
  * This function assumes that the input string is valid UTF-16 and that it can be represented as Latin1.
+ * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+ *
+ * This function is for expert users only and not part of our public API. Use convert_utf16_to_latin1 instead.
  *
  * This function is not BOM-aware.
  *
@@ -729,12 +735,15 @@ simdutf_warn_unused size_t convert_valid_utf16_to_utf8(const char16_t * input, s
  * @param latin1_buffer   the pointer to buffer that can hold conversion result
  * @return number of written code units; 0 if conversion is not possible
  */
-simdutf_warn_unused size_t convert_valid_utf16_to_latin1(const char16_t * input, size_t length, char* latin1_buffer) noexcept;
+SIMDUTF_DEPRECATED simdutf_warn_unused size_t convert_valid_utf16_to_latin1(const char16_t * input, size_t length, char* latin1_buffer) noexcept;
 
 /**
  * Convert valid UTF-16LE string into Latin1 string.
  *
  * This function assumes that the input string is valid UTF-16LE and that it can be represented as Latin1.
+ * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+ *
+ * This function is for expert users only and not part of our public API. Use convert_utf16le_to_latin1 instead.
  *
  * This function is not BOM-aware.
  *
@@ -743,12 +752,15 @@ simdutf_warn_unused size_t convert_valid_utf16_to_latin1(const char16_t * input,
  * @param latin1_buffer   the pointer to buffer that can hold conversion result
  * @return number of written code units; 0 if conversion is not possible
  */
-simdutf_warn_unused size_t convert_valid_utf16le_to_latin1(const char16_t * input, size_t length, char* latin1_buffer) noexcept;
+SIMDUTF_DEPRECATED simdutf_warn_unused size_t convert_valid_utf16le_to_latin1(const char16_t * input, size_t length, char* latin1_buffer) noexcept;
 
 /**
  * Convert valid UTF-16BE string into Latin1 string.
  *
  * This function assumes that the input string is valid UTF-16BE and that it can be represented as Latin1.
+ * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+ *
+ * This function is for expert users only and not part of our public API. Use convert_utf16be_to_latin1 instead.
  *
  * This function is not BOM-aware.
  *
@@ -757,7 +769,7 @@ simdutf_warn_unused size_t convert_valid_utf16le_to_latin1(const char16_t * inpu
  * @param latin1_buffer   the pointer to buffer that can hold conversion result
  * @return number of written code units; 0 if conversion is not possible
  */
-simdutf_warn_unused size_t convert_valid_utf16be_to_latin1(const char16_t * input, size_t length, char* latin1_buffer) noexcept;
+SIMDUTF_DEPRECATED simdutf_warn_unused size_t convert_valid_utf16be_to_latin1(const char16_t * input, size_t length, char* latin1_buffer) noexcept;
 
 
 /**
@@ -1083,6 +1095,9 @@ simdutf_warn_unused result convert_utf32_to_latin1_with_errors(const char32_t * 
  * Convert valid UTF-32 string into Latin1 string.
  *
  * This function assumes that the input string is valid UTF-32 and that it can be represented as Latin1.
+ * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+ *
+ * This function is for expert users only and not part of our public API. Use convert_utf32_to_latin1 instead.
  *
  * This function is not BOM-aware.
  *
@@ -1091,7 +1106,7 @@ simdutf_warn_unused result convert_utf32_to_latin1_with_errors(const char32_t * 
  * @param latin1_buffer   the pointer to buffer that can hold the conversion result
  * @return number of written code units; 0 if conversion is not possible
  */
-simdutf_warn_unused size_t convert_valid_utf32_to_latin1(const char32_t * input, size_t length, char* latin1_buffer) noexcept;
+SIMDUTF_DEPRECATED simdutf_warn_unused size_t convert_valid_utf32_to_latin1(const char32_t * input, size_t length, char* latin1_buffer) noexcept;
 
 /**
  * Convert possibly broken UTF-32 string into UTF-16BE string.
@@ -1851,6 +1866,9 @@ public:
    * Convert valid UTF-8 string into latin1 string.
    *
    * This function assumes that the input string is valid UTF-8 and that it can be represented as Latin1.
+   * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+   *
+   * This function is for expert users only and not part of our public API. Use convert_utf8_to_latin1 instead.
    *
    * This function is not BOM-aware.
    *
@@ -2068,7 +2086,10 @@ public:
    * Convert valid UTF-16LE string into Latin1 string.
    *
    * This function assumes that the input string is valid UTF-L16LE and that it can be represented as Latin1.
-
+   * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+   *
+   * This function is for expert users only and not part of our public API. Use convert_utf16le_to_latin1 instead.
+   *
    * This function is not BOM-aware.
    *
    * @param input         the UTF-16LE string to convert
@@ -2082,6 +2103,9 @@ public:
    * Convert valid UTF-16BE string into Latin1 string.
    *
    * This function assumes that the input string is valid UTF16-BE and that it can be represented as Latin1.
+   * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+   *
+   * This function is for expert users only and not part of our public API. Use convert_utf16be_to_latin1 instead.
    *
    * This function is not BOM-aware.
    *
@@ -2331,7 +2355,10 @@ public:
   /**
    * Convert valid UTF-32 string into Latin1 string.
    *
-   * This function assumes that the input string is valid UTF-32.
+   * This function assumes that the input string is valid UTF-32 and can be represented as Latin1.
+   * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
+   *
+   * This function is for expert users only and not part of our public API. Use convert_utf32_to_latin1 instead.
    *
    * This function is not BOM-aware.
    *

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -407,6 +407,7 @@ simdutf_warn_unused result convert_utf8_to_utf32_with_errors(const char * input,
  * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
  *
  * This function is for expert users only and not part of our public API. Use convert_utf8_to_latin1 instead.
+ * The function may be removed from the library in the future.
  *
  * This function is not BOM-aware.
  *
@@ -415,7 +416,7 @@ simdutf_warn_unused result convert_utf8_to_utf32_with_errors(const char * input,
  * @param latin1_output  the pointer to buffer that can hold conversion result
  * @return the number of written char; 0 if the input was not valid UTF-8 string
  */
-SIMDUTF_DEPRECATED simdutf_warn_unused size_t convert_valid_utf8_to_latin1(const char * input, size_t length, char* latin1_output) noexcept;
+simdutf_warn_unused size_t convert_valid_utf8_to_latin1(const char * input, size_t length, char* latin1_output) noexcept;
 
 
 /**
@@ -727,6 +728,7 @@ simdutf_warn_unused size_t convert_valid_utf16_to_utf8(const char16_t * input, s
  * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
  *
  * This function is for expert users only and not part of our public API. Use convert_utf16_to_latin1 instead.
+ * The function may be removed from the library in the future.
  *
  * This function is not BOM-aware.
  *
@@ -735,7 +737,7 @@ simdutf_warn_unused size_t convert_valid_utf16_to_utf8(const char16_t * input, s
  * @param latin1_buffer   the pointer to buffer that can hold conversion result
  * @return number of written code units; 0 if conversion is not possible
  */
-SIMDUTF_DEPRECATED simdutf_warn_unused size_t convert_valid_utf16_to_latin1(const char16_t * input, size_t length, char* latin1_buffer) noexcept;
+simdutf_warn_unused size_t convert_valid_utf16_to_latin1(const char16_t * input, size_t length, char* latin1_buffer) noexcept;
 
 /**
  * Convert valid UTF-16LE string into Latin1 string.
@@ -744,6 +746,7 @@ SIMDUTF_DEPRECATED simdutf_warn_unused size_t convert_valid_utf16_to_latin1(cons
  * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
  *
  * This function is for expert users only and not part of our public API. Use convert_utf16le_to_latin1 instead.
+ * The function may be removed from the library in the future.
  *
  * This function is not BOM-aware.
  *
@@ -752,7 +755,7 @@ SIMDUTF_DEPRECATED simdutf_warn_unused size_t convert_valid_utf16_to_latin1(cons
  * @param latin1_buffer   the pointer to buffer that can hold conversion result
  * @return number of written code units; 0 if conversion is not possible
  */
-SIMDUTF_DEPRECATED simdutf_warn_unused size_t convert_valid_utf16le_to_latin1(const char16_t * input, size_t length, char* latin1_buffer) noexcept;
+simdutf_warn_unused size_t convert_valid_utf16le_to_latin1(const char16_t * input, size_t length, char* latin1_buffer) noexcept;
 
 /**
  * Convert valid UTF-16BE string into Latin1 string.
@@ -761,6 +764,7 @@ SIMDUTF_DEPRECATED simdutf_warn_unused size_t convert_valid_utf16le_to_latin1(co
  * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
  *
  * This function is for expert users only and not part of our public API. Use convert_utf16be_to_latin1 instead.
+ * The function may be removed from the library in the future.
  *
  * This function is not BOM-aware.
  *
@@ -769,7 +773,7 @@ SIMDUTF_DEPRECATED simdutf_warn_unused size_t convert_valid_utf16le_to_latin1(co
  * @param latin1_buffer   the pointer to buffer that can hold conversion result
  * @return number of written code units; 0 if conversion is not possible
  */
-SIMDUTF_DEPRECATED simdutf_warn_unused size_t convert_valid_utf16be_to_latin1(const char16_t * input, size_t length, char* latin1_buffer) noexcept;
+simdutf_warn_unused size_t convert_valid_utf16be_to_latin1(const char16_t * input, size_t length, char* latin1_buffer) noexcept;
 
 
 /**
@@ -1098,6 +1102,7 @@ simdutf_warn_unused result convert_utf32_to_latin1_with_errors(const char32_t * 
  * If you violate this assumption, the result is implementation defined and may include system-dependent behavior such as crashes.
  *
  * This function is for expert users only and not part of our public API. Use convert_utf32_to_latin1 instead.
+ * The function may be removed from the library in the future.
  *
  * This function is not BOM-aware.
  *
@@ -1106,7 +1111,7 @@ simdutf_warn_unused result convert_utf32_to_latin1_with_errors(const char32_t * 
  * @param latin1_buffer   the pointer to buffer that can hold the conversion result
  * @return number of written code units; 0 if conversion is not possible
  */
-SIMDUTF_DEPRECATED simdutf_warn_unused size_t convert_valid_utf32_to_latin1(const char32_t * input, size_t length, char* latin1_buffer) noexcept;
+simdutf_warn_unused size_t convert_valid_utf32_to_latin1(const char32_t * input, size_t length, char* latin1_buffer) noexcept;
 
 /**
  * Convert possibly broken UTF-32 string into UTF-16BE string.


### PR DESCRIPTION
These assume that the user knows that the function will succeed. It does not do any validation. If the input is invalid (cannot be converted to latin1), the result is undetermined and may include crashes.

This PR will deprecate them formally.