### PR TITLE
optimize utf8_length_from_latin1 for short strings

### DIFF
--- a/benchmarks/src/benchmark_base.h
+++ b/benchmarks/src/benchmark_base.h
@@ -83,6 +83,7 @@ namespace simdutf::benchmarks {
           event_count allocate_count = collector.end();
           all << allocate_count / multiplier;
         }
+        all.has_events = collector.has_events();
         return all;
     }
 }

--- a/cmake/simdutf-flags.cmake
+++ b/cmake/simdutf-flags.cmake
@@ -1,7 +1,7 @@
 
 option(SIMDUTF_SANITIZE "Sanitize addresses" OFF)
 option(SIMDUTF_SANITIZE_UNDEFINED "Sanitize undefined behavior" OFF)
-option(SIMDUTF_ALWAYS_INCLUDE_FALLBACK "Sanitize addresses" OFF)
+option(SIMDUTF_ALWAYS_INCLUDE_FALLBACK "Always include fallback" OFF)
 
 if (NOT CMAKE_BUILD_TYPE)
   message(STATUS "No build type selected, default to Release")

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -28,6 +28,8 @@
 #include "scalar/latin1.h"
 #include "scalar/utf8_to_latin1/valid_utf8_to_latin1.h"
 #include "scalar/utf8_to_latin1/utf8_to_latin1.h"
+#include <cstdint>
+#include <cstring>
 
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
@@ -302,7 +304,32 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf32(size_t lengt
 }
 
 simdutf_warn_unused size_t implementation::utf8_length_from_latin1(const char * input, size_t length) const noexcept {
-  return scalar::latin1::utf8_length_from_latin1(input,length);
+  size_t answer = length;
+  size_t i = 0;
+  auto pop = [](uint64_t v) {
+    return ((v>>7) & UINT64_C(0x0101010101010101)) * UINT64_C(0x0101010101010101) >> 56;
+  };
+  for(; i + 32 <= length; i += 32) {
+    uint64_t v;
+    memcpy(&v, input + i, sizeof(v));
+    answer += pop(v);
+    memcpy(&v, input + i + 8, sizeof(v));
+    answer += pop(v);
+    memcpy(&v, input + i + 16, sizeof(v));
+    answer += pop(v);
+    memcpy(&v, input + i + 24, sizeof(v));
+    answer += pop(v);
+  }
+  for(; i + 8 <= length; i += 8) {
+    uint64_t v;
+    memcpy(&v, input + i, sizeof(v));
+    answer += pop(v);
+  }
+  while (i < length) {
+      answer += ((uint8_t)input[i] >> 7);
+      i++;
+  }
+  return answer;
 }
 
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16le(const char16_t * input, size_t length) const noexcept {

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -325,9 +325,8 @@ simdutf_warn_unused size_t implementation::utf8_length_from_latin1(const char * 
     memcpy(&v, input + i, sizeof(v));
     answer += pop(v);
   }
-  while (i < length) {
+  for(; i + 1 <= length; i += 1) {
       answer += ((uint8_t)input[i] >> 7);
-      i++;
   }
   return answer;
 }

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -311,7 +311,7 @@ simdutf_warn_unused size_t implementation::utf8_length_from_latin1(const char * 
   };
   for(; i + 32 <= length; i += 32) {
     uint64_t v;
-    memcpy(&v, input + i, sizeof(v));
+    memcpy(&v, input + i, 8);
     answer += pop(v);
     memcpy(&v, input + i + 8, sizeof(v));
     answer += pop(v);

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -326,7 +326,7 @@ simdutf_warn_unused size_t implementation::utf8_length_from_latin1(const char * 
     answer += pop(v);
   }
   for(; i + 1 <= length; i += 1) {
-      answer += ((uint8_t)input[i] >> 7);
+      answer += static_cast<uint8_t>(input[i]) >> 7;
   }
   return answer;
 }

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -307,7 +307,7 @@ simdutf_warn_unused size_t implementation::utf8_length_from_latin1(const char * 
   size_t answer = length;
   size_t i = 0;
   auto pop = [](uint64_t v) {
-    return ((v>>7) & UINT64_C(0x0101010101010101)) * UINT64_C(0x0101010101010101) >> 56;
+    return (size_t)(((v>>7) & UINT64_C(0x0101010101010101)) * UINT64_C(0x0101010101010101) >> 56);
   };
   for(; i + 32 <= length; i += 32) {
     uint64_t v;

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -716,40 +716,48 @@ simdutf_warn_unused size_t implementation::utf8_length_from_latin1(const char *i
   const uint8_t *data = reinterpret_cast<const uint8_t *>(input);
   size_t answer = len / sizeof(__m256i) * sizeof(__m256i);
   size_t i = 0;
-  __m256i four_64bits = _mm256_setzero_si256();
-  while (i + sizeof(__m256i) <= len) {
-    __m256i runner = _mm256_setzero_si256();
-    // We can do up to 255 loops without overflow.
-    size_t iterations = (len - i) / sizeof(__m256i);
-    if (iterations > 255) {
-      iterations = 255;
+  if(answer >= 2048) { // long strings optimization
+    __m256i four_64bits = _mm256_setzero_si256();
+    while (i + sizeof(__m256i) <= len) {
+      __m256i runner = _mm256_setzero_si256();
+      // We can do up to 255 loops without overflow.
+      size_t iterations = (len - i) / sizeof(__m256i);
+      if (iterations > 255) {
+        iterations = 255;
+      }
+      size_t max_i = i + iterations * sizeof(__m256i) - sizeof(__m256i);
+      for (; i + 4*sizeof(__m256i) <= max_i; i += 4*sizeof(__m256i)) {
+        __m256i input1 = _mm256_loadu_si256((const __m256i *)(data + i));
+        __m256i input2 = _mm256_loadu_si256((const __m256i *)(data + i + sizeof(__m256i)));
+        __m256i input3 = _mm256_loadu_si256((const __m256i *)(data + i + 2*sizeof(__m256i)));
+        __m256i input4 = _mm256_loadu_si256((const __m256i *)(data + i + 3*sizeof(__m256i)));
+        __m256i input12 = _mm256_add_epi8(_mm256_cmpgt_epi8(_mm256_setzero_si256(), input1),
+                _mm256_cmpgt_epi8(_mm256_setzero_si256(), input2));
+        __m256i input23 = _mm256_add_epi8(_mm256_cmpgt_epi8(_mm256_setzero_si256(), input3),
+                _mm256_cmpgt_epi8(_mm256_setzero_si256(), input4));
+        __m256i input1234 = _mm256_add_epi8(input12, input23);
+        runner = _mm256_sub_epi8(
+            runner, input1234);
+      }
+      for (; i <= max_i; i += sizeof(__m256i)) {
+        __m256i input_256_chunk = _mm256_loadu_si256((const __m256i *)(data + i));
+        runner = _mm256_sub_epi8(
+            runner, _mm256_cmpgt_epi8(_mm256_setzero_si256(), input_256_chunk));
+      }
+      four_64bits = _mm256_add_epi64(
+          four_64bits, _mm256_sad_epu8(runner, _mm256_setzero_si256()));
     }
-    size_t max_i = i + iterations * sizeof(__m256i) - sizeof(__m256i);
-    for (; i + 4*sizeof(__m256i) <= max_i; i += 4*sizeof(__m256i)) {
-      __m256i input1 = _mm256_loadu_si256((const __m256i *)(data + i));
-      __m256i input2 = _mm256_loadu_si256((const __m256i *)(data + i + sizeof(__m256i)));
-      __m256i input3 = _mm256_loadu_si256((const __m256i *)(data + i + 2*sizeof(__m256i)));
-      __m256i input4 = _mm256_loadu_si256((const __m256i *)(data + i + 3*sizeof(__m256i)));
-      __m256i input12 = _mm256_add_epi8(_mm256_cmpgt_epi8(_mm256_setzero_si256(), input1),
-              _mm256_cmpgt_epi8(_mm256_setzero_si256(), input2));
-      __m256i input23 = _mm256_add_epi8(_mm256_cmpgt_epi8(_mm256_setzero_si256(), input3),
-              _mm256_cmpgt_epi8(_mm256_setzero_si256(), input4));
-      __m256i input1234 = _mm256_add_epi8(input12, input23);
-      runner = _mm256_sub_epi8(
-          runner, input1234);
+    answer += _mm256_extract_epi64(four_64bits, 0) +
+              _mm256_extract_epi64(four_64bits, 1) +
+              _mm256_extract_epi64(four_64bits, 2) +
+              _mm256_extract_epi64(four_64bits, 3);
+  } else if (answer > 0) {
+    for(; i + sizeof(__m256i) <= len; i += sizeof(__m256i)) {
+      __m256i latin = _mm256_loadu_si256((const __m256i*)(data + i));
+      uint32_t non_ascii = _mm256_movemask_epi8(latin);
+      answer += count_ones(non_ascii);
     }
-    for (; i <= max_i; i += sizeof(__m256i)) {
-      __m256i input_256_chunk = _mm256_loadu_si256((const __m256i *)(data + i));
-      runner = _mm256_sub_epi8(
-          runner, _mm256_cmpgt_epi8(_mm256_setzero_si256(), input_256_chunk));
-    }
-    four_64bits = _mm256_add_epi64(
-        four_64bits, _mm256_sad_epu8(runner, _mm256_setzero_si256()));
   }
-  answer += _mm256_extract_epi64(four_64bits, 0) +
-            _mm256_extract_epi64(four_64bits, 1) +
-            _mm256_extract_epi64(four_64bits, 2) +
-            _mm256_extract_epi64(four_64bits, 3);
   return answer + scalar::latin1::utf8_length_from_latin1(reinterpret_cast<const char *>(data + i), len - i);
 }
 

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -1287,60 +1287,68 @@ simdutf_warn_unused size_t implementation::utf8_length_from_latin1(const char * 
   const uint8_t *str = reinterpret_cast<const uint8_t *>(input);
   size_t answer = length / sizeof(__m512i) * sizeof(__m512i);
   size_t i = 0;
-  unsigned char v_0xFF = 0xff;
-  __m512i eight_64bits = _mm512_setzero_si512();
-  while (i + sizeof(__m512i) <= length) {
-    __m512i runner = _mm512_setzero_si512();
-    size_t iterations = (length - i) / sizeof(__m512i);
-    if (iterations > 255) {
-      iterations = 255;
+  if(answer >= 2048) { // long strings optimization
+    unsigned char v_0xFF = 0xff;
+    __m512i eight_64bits = _mm512_setzero_si512();
+    while (i + sizeof(__m512i) <= length) {
+      __m512i runner = _mm512_setzero_si512();
+      size_t iterations = (length - i) / sizeof(__m512i);
+      if (iterations > 255) {
+        iterations = 255;
+      }
+      size_t max_i = i + iterations * sizeof(__m512i) - sizeof(__m512i);
+      for (; i + 4*sizeof(__m512i) <= max_i; i += 4*sizeof(__m512i)) {
+              // Load four __m512i vectors
+              __m512i input1 = _mm512_loadu_si512((const __m512i *)(str + i));
+              __m512i input2 = _mm512_loadu_si512((const __m512i *)(str + i + sizeof(__m512i)));
+              __m512i input3 = _mm512_loadu_si512((const __m512i *)(str + i + 2*sizeof(__m512i)));
+              __m512i input4 = _mm512_loadu_si512((const __m512i *)(str + i + 3*sizeof(__m512i)));
+
+              // Generate four masks
+              __mmask64 mask1 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input1);
+              __mmask64 mask2 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input2);
+              __mmask64 mask3 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input3);
+              __mmask64 mask4 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input4);
+              // Apply the masks and subtract from the runner
+              __m512i not_ascii1 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask1, v_0xFF);
+              __m512i not_ascii2 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask2, v_0xFF);
+              __m512i not_ascii3 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask3, v_0xFF);
+              __m512i not_ascii4 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask4, v_0xFF);
+
+              runner = _mm512_sub_epi8(runner, not_ascii1);
+              runner = _mm512_sub_epi8(runner, not_ascii2);
+              runner = _mm512_sub_epi8(runner, not_ascii3);
+              runner = _mm512_sub_epi8(runner, not_ascii4);
+      }
+
+      for (; i <= max_i; i += sizeof(__m512i)) {
+        __m512i more_input = _mm512_loadu_si512((const __m512i *)(str + i));
+
+        __mmask64 mask = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), more_input);
+        __m512i not_ascii = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask, v_0xFF);
+        runner = _mm512_sub_epi8(runner, not_ascii);
+      }
+
+      eight_64bits = _mm512_add_epi64(eight_64bits, _mm512_sad_epu8(runner, _mm512_setzero_si512()));
     }
-    size_t max_i = i + iterations * sizeof(__m512i) - sizeof(__m512i);
-    for (; i + 4*sizeof(__m512i) <= max_i; i += 4*sizeof(__m512i)) {
-            // Load four __m512i vectors
-            __m512i input1 = _mm512_loadu_si512((const __m512i *)(str + i));
-            __m512i input2 = _mm512_loadu_si512((const __m512i *)(str + i + sizeof(__m512i)));
-            __m512i input3 = _mm512_loadu_si512((const __m512i *)(str + i + 2*sizeof(__m512i)));
-            __m512i input4 = _mm512_loadu_si512((const __m512i *)(str + i + 3*sizeof(__m512i)));
 
-            // Generate four masks
-            __mmask64 mask1 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input1);
-            __mmask64 mask2 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input2);
-            __mmask64 mask3 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input3);
-            __mmask64 mask4 = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), input4);
-            // Apply the masks and subtract from the runner
-            __m512i not_ascii1 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask1, v_0xFF);
-            __m512i not_ascii2 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask2, v_0xFF);
-            __m512i not_ascii3 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask3, v_0xFF);
-            __m512i not_ascii4 = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask4, v_0xFF);
-
-            runner = _mm512_sub_epi8(runner, not_ascii1);
-            runner = _mm512_sub_epi8(runner, not_ascii2);
-            runner = _mm512_sub_epi8(runner, not_ascii3);
-            runner = _mm512_sub_epi8(runner, not_ascii4);
+    __m256i first_half = _mm512_extracti64x4_epi64(eight_64bits, 0);
+    __m256i second_half = _mm512_extracti64x4_epi64(eight_64bits, 1);
+    answer += (size_t)_mm256_extract_epi64(first_half, 0) +
+              (size_t)_mm256_extract_epi64(first_half, 1) +
+              (size_t)_mm256_extract_epi64(first_half, 2) +
+              (size_t)_mm256_extract_epi64(first_half, 3) +
+              (size_t)_mm256_extract_epi64(second_half, 0) +
+              (size_t)_mm256_extract_epi64(second_half, 1) +
+              (size_t)_mm256_extract_epi64(second_half, 2) +
+              (size_t)_mm256_extract_epi64(second_half, 3);
+  } else if (answer > 0) {
+    for(; i + sizeof(__m512i) <= length; i += sizeof(__m512i)) {
+      __m512i latin = _mm512_loadu_si512((const __m512i*)(str + i));
+      uint64_t non_ascii = _mm512_movepi8_mask(latin);
+      answer += count_ones(non_ascii);
     }
-
-    for (; i <= max_i; i += sizeof(__m512i)) {
-      __m512i more_input = _mm512_loadu_si512((const __m512i *)(str + i));
-
-      __mmask64 mask = _mm512_cmpgt_epi8_mask(_mm512_setzero_si512(), more_input);
-      __m512i not_ascii = _mm512_mask_set1_epi8(_mm512_setzero_si512(), mask, v_0xFF);
-      runner = _mm512_sub_epi8(runner, not_ascii);
-    }
-
-    eight_64bits = _mm512_add_epi64(eight_64bits, _mm512_sad_epu8(runner, _mm512_setzero_si512()));
   }
-
-  __m256i first_half = _mm512_extracti64x4_epi64(eight_64bits, 0);
-  __m256i second_half = _mm512_extracti64x4_epi64(eight_64bits, 1);
-  answer += (size_t)_mm256_extract_epi64(first_half, 0) +
-            (size_t)_mm256_extract_epi64(first_half, 1) +
-            (size_t)_mm256_extract_epi64(first_half, 2) +
-            (size_t)_mm256_extract_epi64(first_half, 3) +
-            (size_t)_mm256_extract_epi64(second_half, 0) +
-            (size_t)_mm256_extract_epi64(second_half, 1) +
-            (size_t)_mm256_extract_epi64(second_half, 2) +
-            (size_t)_mm256_extract_epi64(second_half, 3);
   return answer + scalar::latin1::utf8_length_from_latin1(reinterpret_cast<const char *>(str + i), length - i);
 }
 

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -699,46 +699,62 @@ simdutf_warn_unused size_t implementation::utf8_length_from_latin1(const char * 
   const uint8_t *str = reinterpret_cast<const uint8_t *>(input);
   size_t answer = len / sizeof(__m128i) * sizeof(__m128i);
   size_t i = 0;
-  __m128i two_64bits = _mm_setzero_si128();
-  while (i + sizeof(__m128i) <= len) {
-    __m128i runner = _mm_setzero_si128();
-    size_t iterations = (len - i) / sizeof(__m128i);
-    if (iterations > 255) {
-      iterations = 255;
+  if(answer >= 2048) { // long strings optimization
+    __m128i two_64bits = _mm_setzero_si128();
+    while (i + sizeof(__m128i) <= len) {
+      __m128i runner = _mm_setzero_si128();
+      size_t iterations = (len - i) / sizeof(__m128i);
+      if (iterations > 255) {
+        iterations = 255;
+      }
+      size_t max_i = i + iterations * sizeof(__m128i) - sizeof(__m128i);
+      for (; i + 4*sizeof(__m128i) <= max_i; i += 4*sizeof(__m128i)) {
+        __m128i input1 = _mm_loadu_si128((const __m128i *)(str + i));
+        __m128i input2 = _mm_loadu_si128((const __m128i *)(str + i + sizeof(__m128i)));
+        __m128i input3 = _mm_loadu_si128((const __m128i *)(str + i + 2*sizeof(__m128i)));
+        __m128i input4 = _mm_loadu_si128((const __m128i *)(str + i + 3*sizeof(__m128i)));
+        __m128i input12 = _mm_add_epi8(
+                                        _mm_cmpgt_epi8(
+                                                      _mm_setzero_si128(),
+                                                      input1),
+                                        _mm_cmpgt_epi8(
+                                                      _mm_setzero_si128(),
+                                                      input2));
+        __m128i input34 = _mm_add_epi8(
+                                        _mm_cmpgt_epi8(
+                                                      _mm_setzero_si128(),
+                                                      input3),
+                                        _mm_cmpgt_epi8(
+                                                      _mm_setzero_si128(),
+                                                      input4));
+        __m128i input1234 = _mm_add_epi8(input12, input34);
+        runner = _mm_sub_epi8(runner, input1234);
+      }
+      for (; i <= max_i; i += sizeof(__m128i)) {
+        __m128i more_input = _mm_loadu_si128((const __m128i *)(str + i));
+        runner = _mm_sub_epi8(
+            runner, _mm_cmpgt_epi8(_mm_setzero_si128(), more_input));
+      }
+      two_64bits = _mm_add_epi64(
+          two_64bits, _mm_sad_epu8(runner, _mm_setzero_si128()));
     }
-    size_t max_i = i + iterations * sizeof(__m128i) - sizeof(__m128i);
-    for (; i + 4*sizeof(__m128i) <= max_i; i += 4*sizeof(__m128i)) {
-      __m128i input1 = _mm_loadu_si128((const __m128i *)(str + i));
-      __m128i input2 = _mm_loadu_si128((const __m128i *)(str + i + sizeof(__m128i)));
-      __m128i input3 = _mm_loadu_si128((const __m128i *)(str + i + 2*sizeof(__m128i)));
-      __m128i input4 = _mm_loadu_si128((const __m128i *)(str + i + 3*sizeof(__m128i)));
-      __m128i input12 = _mm_add_epi8(
-                                      _mm_cmpgt_epi8(
-                                                    _mm_setzero_si128(),
-                                                    input1),
-                                      _mm_cmpgt_epi8(
-                                                    _mm_setzero_si128(),
-                                                    input2));
-      __m128i input34 = _mm_add_epi8(
-                                      _mm_cmpgt_epi8(
-                                                    _mm_setzero_si128(),
-                                                    input3),
-                                      _mm_cmpgt_epi8(
-                                                    _mm_setzero_si128(),
-                                                    input4));
-      __m128i input1234 = _mm_add_epi8(input12, input34);
-      runner = _mm_sub_epi8(runner, input1234);
+    answer += _mm_extract_epi64(two_64bits, 0) +
+              _mm_extract_epi64(two_64bits, 1);
+  } else if (answer > 0) { // short string optimization
+    for(; i + 2*sizeof(__m128i) <= len; i += 2*sizeof(__m128i)) {
+      __m128i latin = _mm_loadu_si128((const __m128i*)(input + i));
+      uint16_t non_ascii = (uint16_t)_mm_movemask_epi8(latin);
+      answer += count_ones(non_ascii);
+      latin = _mm_loadu_si128((const __m128i*)(input + i)+1);
+      non_ascii = (uint16_t)_mm_movemask_epi8(latin);
+      answer += count_ones(non_ascii);
     }
-    for (; i <= max_i; i += sizeof(__m128i)) {
-      __m128i more_input = _mm_loadu_si128((const __m128i *)(str + i));
-      runner = _mm_sub_epi8(
-          runner, _mm_cmpgt_epi8(_mm_setzero_si128(), more_input));
+    for(; i + sizeof(__m128i) <= len; i += sizeof(__m128i)) {
+      __m128i latin = _mm_loadu_si128((const __m128i*)(input + i));
+      uint16_t non_ascii = (uint16_t)_mm_movemask_epi8(latin);
+      answer += count_ones(non_ascii);
     }
-    two_64bits = _mm_add_epi64(
-        two_64bits, _mm_sad_epu8(runner, _mm_setzero_si128()));
   }
-  answer += _mm_extract_epi64(two_64bits, 0) +
-            _mm_extract_epi64(two_64bits, 1);
   return answer + scalar::latin1::utf8_length_from_latin1(reinterpret_cast<const char *>(str + i), len - i);
 }
 


### PR DESCRIPTION
Using this UTF8 short file:
https://github.com/lemire/unicode_lipsum/tree/main/short


Run the benchmark...

```
benchmark -P utf8_length_from_latin1 -F fourbytes.utf8.txt -I 1000000
```

GCC 12, Intel Ice Lake:

```
utf8_length_from_latin1+fallback, input size: 64, iterations: 100000, dataset: shorter.txt
   1.281 ins/byte,    0.266 cycle/byte,   11.825 GB/s (16.2 %),     3.141 GHz,    4.824 ins/cycle 
   5.125 ins/char,    1.062 cycle/char,    2.956 Gc/s (16.2 %)     4.00 byte/char      5.4 ns
WARNING: Measurements are noisy, try increasing iteration count (-I).
utf8_length_from_latin1+haswell, input size: 64, iterations: 100000, dataset: shorter.txt
   0.672 ins/byte,    0.219 cycle/byte,   14.493 GB/s (14.2 %),     3.170 GHz,    3.071 ins/cycle 
   2.688 ins/char,    0.875 cycle/char,    3.623 Gc/s (14.2 %)     4.00 byte/char      4.4 ns
WARNING: Measurements are noisy, try increasing iteration count (-I).
utf8_length_from_latin1+icelake, input size: 64, iterations: 100000, dataset: shorter.txt
   0.750 ins/byte,    0.172 cycle/byte,   17.913 GB/s (0.7 %),     3.079 GHz,    4.364 ins/cycle 
   3.000 ins/char,    0.688 cycle/char,    4.478 Gc/s (0.7 %)     4.00 byte/char      3.6 ns
utf8_length_from_latin1+node, input size: 64, iterations: 100000, dataset: shorter.txt
   1.266 ins/byte,    0.297 cycle/byte,   10.714 GB/s (0.6 %),     3.181 GHz,    4.263 ins/cycle 
   5.062 ins/char,    1.188 cycle/char,    2.678 Gc/s (0.6 %)     4.00 byte/char      6.0 ns
utf8_length_from_latin1+westmere, input size: 64, iterations: 100000, dataset: shorter.txt
   0.938 ins/byte,    0.172 cycle/byte,   18.357 GB/s (21.3 %),     3.155 GHz,    5.455 ins/cycle 
   3.750 ins/char,    0.688 cycle/char,    4.589 Gc/s (21.3 %)     4.00 byte/char      3.5 ns
WARNING: Measurements are noisy, try increasing iteration count (-I).
```


LLVM 16, Apple Silicon M2:

```
utf8_length_from_latin1+arm64, input size: 64, iterations: 1000000, dataset: shorter.txt
   0.844 ins/byte,    0.156 cycle/byte,   25.372 GB/s (7.9 %),     3.964 GHz,    5.400 ins/cycle
   3.375 ins/char,    0.625 cycle/char,    6.343 Gc/s (7.9 %)     4.00 byte/char      2.5 ns
utf8_length_from_latin1+fallback, input size: 64, iterations: 1000000, dataset: shorter.txt
   1.266 ins/byte,    0.203 cycle/byte,   22.475 GB/s (10.0 %),     4.565 GHz,    6.231 ins/cycle
   5.062 ins/char,    0.812 cycle/char,    5.619 Gc/s (10.0 %)     4.00 byte/char      2.8 ns
utf8_length_from_latin1+node, input size: 64, iterations: 1000000, dataset: shorter.txt
   1.641 ins/byte,    0.203 cycle/byte,   18.291 GB/s (6.7 %),     3.715 GHz,    8.077 ins/cycle
   6.562 ins/char,    0.812 cycle/char,    4.573 Gc/s (6.7 %)     4.00 byte/char      3.5 ns
```

See https://github.com/nodejs/node/pull/54345