### PR TITLE
ci: update codeql action to v3

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -27,7 +27,7 @@ jobs:
        path: ./out/artifacts
    - name: Upload Sarif
      if: always() && steps.build.outcome == 'success'
-     uses: github/codeql-action/upload-sarif@v2
+     uses: github/codeql-action/upload-sarif@v3
      with:
       # Path to SARIF file relative to the root of the repository
       sarif_file: cifuzz-sarif/results.sarif


### PR DESCRIPTION
There are warnings in CI.

Trying to get rid of them by following https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/