### PR TITLE
Convert latin1 to utf8 safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,7 +863,7 @@ simdutf_warn_unused size_t convert_latin1_to_utf8(const char * input, size_t len
  * @param input         the Latin1 string to convert
  * @param length        the length of the string in bytes
  * @param utf8_output  	the pointer to buffer that can hold conversion result
- * @param utf8_len  the maximum output length
+ * @param utf8_len      the maximum output length
  * @return the number of written char; 0 if conversion is not possible
  */
 simdutf_warn_unused size_t convert_latin1_to_utf8_safe(const char * input, size_t length, char* utf8_output, size_t utf8_len) noexcept;

--- a/README.md
+++ b/README.md
@@ -850,7 +850,7 @@ scenario where you expect the input to be valid most of the time.
  *
  * @param input         the Latin1 string to convert
  * @param length        the length of the string in bytes
- * @param latin1_output  the pointer to buffer that can hold conversion result
+ * @param utf8_output  the pointer to buffer that can hold conversion result
  * @return the number of written char; 0 if conversion is not possible
  */
 simdutf_warn_unused size_t convert_latin1_to_utf8(const char * input, size_t length, char* utf8_output) noexcept;
@@ -866,7 +866,7 @@ simdutf_warn_unused size_t convert_latin1_to_utf8(const char * input, size_t len
  * @param utf8_len  the maximum output length
  * @return the number of written char; 0 if conversion is not possible
  */
-simdutf_warn_unused size_t convert_latin1_to_utf8(const char * input, size_t length, char* utf8_output, utf8_len) noexcept;
+simdutf_warn_unused size_t convert_latin1_to_utf8_safe(const char * input, size_t length, char* utf8_output, size_t utf8_len) noexcept;
 
 /**
  * Using native endianness, convert a Latin1 string into a UTF-16 string.

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -206,79 +206,79 @@ simdutf_warn_unused bool validate_utf32(const char32_t *buf, size_t len) noexcep
  */
 simdutf_warn_unused result validate_utf32_with_errors(const char32_t *buf, size_t len) noexcept;
 
-  /**
-   * Convert Latin1 string into UTF8 string.
-   *
-   * This function is suitable to work with inputs from untrusted sources.
-   *
-   * @param input         the Latin1 string to convert
-   * @param length        the length of the string in bytes
-   * @param utf8_output   the pointer to buffer that can hold conversion result
-   * @return the number of written char; 0 if conversion is not possible
-   */
-  simdutf_warn_unused size_t convert_latin1_to_utf8(const char * input, size_t length, char* utf8_output) noexcept;
+/**
+ * Convert Latin1 string into UTF8 string.
+ *
+ * This function is suitable to work with inputs from untrusted sources.
+ *
+ * @param input         the Latin1 string to convert
+ * @param length        the length of the string in bytes
+ * @param utf8_output   the pointer to buffer that can hold conversion result
+ * @return the number of written char; 0 if conversion is not possible
+ */
+simdutf_warn_unused size_t convert_latin1_to_utf8(const char * input, size_t length, char* utf8_output) noexcept;
 
-  /**
-   * Convert Latin1 string into UTF8 string with output limit.
-   *
-   * This function is suitable to work with inputs from untrusted sources.
-   *
-   * @param input         the Latin1 string to convert
-   * @param length        the length of the string in bytes
-   * @param utf8_output  	the pointer to buffer that can hold conversion result
-   * @param utf8_len  the maximum output length
-   * @return the number of written char; 0 if conversion is not possible
-   */
-  simdutf_warn_unused size_t convert_latin1_to_utf8_safe(const char * input, size_t length, char* utf8_output, size_t utf8_len) noexcept;
+/**
+ * Convert Latin1 string into UTF8 string with output limit.
+ *
+ * This function is suitable to work with inputs from untrusted sources.
+ *
+ * @param input         the Latin1 string to convert
+ * @param length        the length of the string in bytes
+ * @param utf8_output  	the pointer to buffer that can hold conversion result
+ * @param utf8_len      the maximum output length
+ * @return the number of written char; 0 if conversion is not possible
+ */
+simdutf_warn_unused size_t convert_latin1_to_utf8_safe(const char * input, size_t length, char* utf8_output, size_t utf8_len) noexcept;
 
-    /**
-   * Convert possibly Latin1 string into UTF-16LE string.
-   *
-   * This function is suitable to work with inputs from untrusted sources.
-   *
-   * @param input         the Latin1  string to convert
-   * @param length        the length of the string in bytes
-   * @param utf16_buffer  the pointer to buffer that can hold conversion result
-   * @return the number of written char16_t; 0 if conversion is not possible
-   */
-  simdutf_warn_unused size_t convert_latin1_to_utf16le(const char * input, size_t length, char16_t* utf16_output) noexcept;
+/**
+ * Convert possibly Latin1 string into UTF-16LE string.
+ *
+ * This function is suitable to work with inputs from untrusted sources.
+ *
+ * @param input         the Latin1  string to convert
+ * @param length        the length of the string in bytes
+ * @param utf16_buffer  the pointer to buffer that can hold conversion result
+ * @return the number of written char16_t; 0 if conversion is not possible
+ */
+simdutf_warn_unused size_t convert_latin1_to_utf16le(const char * input, size_t length, char16_t* utf16_output) noexcept;
 
-  /**
-   * Convert Latin1 string into UTF-16BE string.
-   *
-   * This function is suitable to work with inputs from untrusted sources.
-   *
-   * @param input         the Latin1 string to convert
-   * @param length        the length of the string in bytes
-   * @param utf16_buffer  the pointer to buffer that can hold conversion result
-   * @return the number of written char16_t; 0 if conversion is not possible
-   */
-  simdutf_warn_unused size_t convert_latin1_to_utf16be(const char * input, size_t length, char16_t* utf16_output) noexcept;
+/**
+ * Convert Latin1 string into UTF-16BE string.
+ *
+ * This function is suitable to work with inputs from untrusted sources.
+ *
+ * @param input         the Latin1 string to convert
+ * @param length        the length of the string in bytes
+ * @param utf16_buffer  the pointer to buffer that can hold conversion result
+ * @return the number of written char16_t; 0 if conversion is not possible
+ */
+simdutf_warn_unused size_t convert_latin1_to_utf16be(const char * input, size_t length, char16_t* utf16_output) noexcept;
 
-  /**
-   * Convert Latin1 string into UTF-32 string.
-   *
-   * This function is suitable to work with inputs from untrusted sources.
-   *
-   * @param input         the Latin1 string to convert
-   * @param length        the length of the string in bytes
-   * @param utf32_buffer  the pointer to buffer that can hold conversion result
-   * @return the number of written char32_t; 0 if conversion is not possible
-   */
-  simdutf_warn_unused size_t convert_latin1_to_utf32(const char * input, size_t length, char32_t* utf32_buffer) noexcept;
+/**
+ * Convert Latin1 string into UTF-32 string.
+ *
+ * This function is suitable to work with inputs from untrusted sources.
+ *
+ * @param input         the Latin1 string to convert
+ * @param length        the length of the string in bytes
+ * @param utf32_buffer  the pointer to buffer that can hold conversion result
+ * @return the number of written char32_t; 0 if conversion is not possible
+ */
+simdutf_warn_unused size_t convert_latin1_to_utf32(const char * input, size_t length, char32_t* utf32_buffer) noexcept;
 
- /**
-   * Convert possibly broken UTF-8 string into latin1 string.
-   *
-   * During the conversion also validation of the input string is done.
-   * This function is suitable to work with inputs from untrusted sources.
-   *
-   * @param input         the UTF-8 string to convert
-   * @param length        the length of the string in bytes
-   * @param latin1_output  the pointer to buffer that can hold conversion result
-   * @return the number of written char; 0 if the input was not valid UTF-8 string or if it cannot be represented as Latin1
-   */
-  simdutf_warn_unused size_t convert_utf8_to_latin1(const char * input, size_t length, char* latin1_output) noexcept;
+/**
+ * Convert possibly broken UTF-8 string into latin1 string.
+ *
+ * During the conversion also validation of the input string is done.
+ * This function is suitable to work with inputs from untrusted sources.
+ *
+ * @param input         the UTF-8 string to convert
+ * @param length        the length of the string in bytes
+ * @param latin1_output  the pointer to buffer that can hold conversion result
+ * @return the number of written char; 0 if the input was not valid UTF-8 string or if it cannot be represented as Latin1
+ */
+simdutf_warn_unused size_t convert_utf8_to_latin1(const char * input, size_t length, char* latin1_output) noexcept;
 
 /**
  * Using native endianness, convert possibly broken UTF-8 string into a UTF-16 string.
@@ -292,7 +292,6 @@ simdutf_warn_unused result validate_utf32_with_errors(const char32_t *buf, size_
  * @return the number of written char16_t; 0 if the input was not valid UTF-8 string
  */
 simdutf_warn_unused size_t convert_utf8_to_utf16(const char * input, size_t length, char16_t* utf16_output) noexcept;
-
 
 /**
  * Using native endianness, convert a Latin1 string into a UTF-16 string.

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -229,7 +229,7 @@ simdutf_warn_unused result validate_utf32_with_errors(const char32_t *buf, size_
    * @param utf8_len  the maximum output length
    * @return the number of written char; 0 if conversion is not possible
    */
-  simdutf_warn_unused size_t convert_latin1_to_utf8_s(const char * input, size_t length, char* utf8_output, size_t utf8_len) noexcept;
+  simdutf_warn_unused size_t convert_latin1_to_utf8_safe(const char * input, size_t length, char* utf8_output, size_t utf8_len) noexcept;
 
     /**
    * Convert possibly Latin1 string into UTF-16LE string.
@@ -1809,23 +1809,10 @@ public:
    *
    * @param input         the Latin1 string to convert
    * @param length        the length of the string in bytes
-   * @param latin1_output  the pointer to buffer that can hold conversion result
+   * @param utf8_output  the pointer to buffer that can hold conversion result
    * @return the number of written char; 0 if conversion is not possible
    */
   simdutf_warn_unused virtual size_t convert_latin1_to_utf8(const char * input, size_t length, char* utf8_output) const noexcept = 0;
-
-  /**
-   * Convert Latin1 string into UTF8 string with output limit.
-   *
-   * This function is suitable to work with inputs from untrusted sources.
-   *
-   * @param input         the Latin1 string to convert
-   * @param length        the length of the string in bytes
-   * @param utf8_output  	the pointer to buffer that can hold conversion result
-   * @param utf8_len  the maximum output length
-   * @return the number of written char; 0 if conversion is not possible
-   */
-  simdutf_warn_unused virtual size_t convert_latin1_to_utf8_s(const char * input, size_t length, char* utf8_output, size_t utf8_len) const noexcept;
 
   /**
    * Convert possibly Latin1 string into UTF-16LE string.

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -94,10 +94,6 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(const char * b
   return scalar::latin1_to_utf8::convert(buf, len, utf8_output);
 }
 
-simdutf_warn_unused size_t implementation::convert_latin1_to_utf8_s(const char * buf, size_t len, char* utf8_output, size_t utf8_len) const noexcept {
-  return scalar::latin1_to_utf8::convert_s(buf, len, utf8_output, utf8_len);
-}
-
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16le(const char* buf, size_t len, char16_t* utf16_output) const noexcept {
   return scalar::latin1_to_utf16::convert<endianness::LITTLE>(buf, len, utf16_output);
 }

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -204,29 +204,6 @@ public:
     return set_best()->convert_latin1_to_utf8(buf, len, utf8_output);
   }
 
-  simdutf_warn_unused size_t convert_latin1_to_utf8_s(const char * buf, size_t len, char* utf8_output, size_t utf8_len) const noexcept final override {
-    const auto start{utf8_output};
-
-    while (true) {
-      // convert_latin1_to_utf8 will never write more than input length * 2
-      auto read_len = std::min(len, utf8_len >> 1);
-      if (read_len <= 16) {
-        break;
-      }
-
-      const auto write_len = set_best()->convert_latin1_to_utf8(buf, read_len, utf8_output);
-
-      utf8_output += write_len;
-      utf8_len -= write_len;
-      buf += read_len;
-      len -= read_len;
-    }
-
-    utf8_output += scalar::latin1_to_utf8::convert_s(buf, len, utf8_output, utf8_len);
-
-    return utf8_output - start;
-  }
-
   simdutf_warn_unused size_t convert_latin1_to_utf16le(const char * buf, size_t len, char16_t* utf16_output) const noexcept final override {
     return set_best()->convert_latin1_to_utf16le(buf, len, utf16_output);
   }
@@ -1395,6 +1372,31 @@ simdutf_warn_unused result base64_to_binary_safe_impl(const chartype * input, si
   r.count += input_index;
   return r;
 }
+
+
+
+  simdutf_warn_unused size_t convert_latin1_to_utf8_safe(const char * buf, size_t len, char* utf8_output, size_t utf8_len) noexcept {
+    const auto start{utf8_output};
+
+    while (true) {
+      // convert_latin1_to_utf8 will never write more than input length * 2
+      auto read_len = std::min(len, utf8_len >> 1);
+      if (read_len <= 16) {
+        break;
+      }
+
+      const auto write_len = simdutf::convert_latin1_to_utf8(buf, read_len, utf8_output);
+
+      utf8_output += write_len;
+      utf8_len -= write_len;
+      buf += read_len;
+      len -= read_len;
+    }
+
+    utf8_output += scalar::latin1_to_utf8::convert_safe(buf, len, utf8_output, utf8_len);
+
+    return utf8_output - start;
+  }
 
 
 simdutf_warn_unused result base64_to_binary_safe(const char * input, size_t length, char* output, size_t& outlen, base64_options options) noexcept {

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1375,28 +1375,28 @@ simdutf_warn_unused result base64_to_binary_safe_impl(const chartype * input, si
 
 
 
-  simdutf_warn_unused size_t convert_latin1_to_utf8_safe(const char * buf, size_t len, char* utf8_output, size_t utf8_len) noexcept {
-    const auto start{utf8_output};
+simdutf_warn_unused size_t convert_latin1_to_utf8_safe(const char * buf, size_t len, char* utf8_output, size_t utf8_len) noexcept {
+  const auto start{utf8_output};
 
-    while (true) {
-      // convert_latin1_to_utf8 will never write more than input length * 2
-      auto read_len = std::min(len, utf8_len >> 1);
-      if (read_len <= 16) {
-        break;
-      }
-
-      const auto write_len = simdutf::convert_latin1_to_utf8(buf, read_len, utf8_output);
-
-      utf8_output += write_len;
-      utf8_len -= write_len;
-      buf += read_len;
-      len -= read_len;
+  while (true) {
+    // convert_latin1_to_utf8 will never write more than input length * 2
+    auto read_len = std::min(len, utf8_len >> 1);
+    if (read_len <= 16) {
+      break;
     }
 
-    utf8_output += scalar::latin1_to_utf8::convert_safe(buf, len, utf8_output, utf8_len);
+    const auto write_len = simdutf::convert_latin1_to_utf8(buf, read_len, utf8_output);
 
-    return utf8_output - start;
+    utf8_output += write_len;
+    utf8_len -= write_len;
+    buf += read_len;
+    len -= read_len;
   }
+
+  utf8_output += scalar::latin1_to_utf8::convert_safe(buf, len, utf8_output, utf8_len);
+
+  return utf8_output - start;
+}
 
 
 simdutf_warn_unused result base64_to_binary_safe(const char * input, size_t length, char* output, size_t& outlen, base64_options options) noexcept {

--- a/src/scalar/latin1_to_utf8/latin1_to_utf8.h
+++ b/src/scalar/latin1_to_utf8/latin1_to_utf8.h
@@ -43,7 +43,7 @@ inline size_t convert(const char* buf, size_t len, char* utf8_output) {
   return utf8_pos;
 }
 
-inline size_t convert_s(const char* buf, size_t len, char* utf8_output, size_t utf8_len) {
+inline size_t convert_safe(const char* buf, size_t len, char* utf8_output, size_t utf8_len) {
   const unsigned char *data = reinterpret_cast<const unsigned char *>(buf);
   size_t pos = 0;
   size_t skip_pos = 0;

--- a/src/simdutf/rvv/implementation.h
+++ b/src/simdutf/rvv/implementation.h
@@ -30,7 +30,6 @@ public:
   simdutf_warn_unused bool validate_utf32(const char32_t *buf, size_t len) const noexcept final;
   simdutf_warn_unused result validate_utf32_with_errors(const char32_t *buf, size_t len) const noexcept final;
   simdutf_warn_unused size_t convert_latin1_to_utf8(const char *buf, size_t len, char *utf8_output) const noexcept final;
-  simdutf_warn_unused size_t convert_latin1_to_utf8_s(const char *buf, size_t len, char *utf8_output, size_t utf8_len) const noexcept final;
   simdutf_warn_unused size_t convert_latin1_to_utf16le(const char *buf, size_t len, char16_t *utf16_buffer) const noexcept final;
   simdutf_warn_unused size_t convert_latin1_to_utf16be(const char *buf, size_t len, char16_t *utf16_buffer) const noexcept final;
   simdutf_warn_unused size_t convert_latin1_to_utf32(const char *buf, size_t len, char32_t *utf32_output) const noexcept final;

--- a/tests/convert_latin1_to_utf8_tests.cpp
+++ b/tests/convert_latin1_to_utf8_tests.cpp
@@ -29,4 +29,28 @@ TEST_LOOP(trials, convert_all_latin1) {
       ASSERT_TRUE(test.check_size(size_procedure));
 }
 
+
+TEST(convert_all_latin1_safe) {
+    std::vector<char> latin1(1024);
+    for(size_t i = 0; i < latin1.size(); i++) {
+        latin1[i] = i&0xff;
+    }
+    size_t utf8_length = implementation.utf8_length_from_latin1(latin1.data(), latin1.size());
+    std::vector<char> utf8(utf8_length);
+    const auto result = implementation.convert_latin1_to_utf8(latin1.data(), latin1.size(), utf8.data());
+    ASSERT_EQUAL(result, utf8_length);
+    for(size_t output_size = 0; output_size < utf8.size(); output_size++) {
+      std::vector<char> utf8_buffer(output_size);
+      size_t used_size = simdutf::convert_latin1_to_utf8_safe(latin1.data(), latin1.size(), utf8_buffer.data(), output_size);
+      for(size_t i = 0; i < used_size; i++) {
+        ASSERT_EQUAL(utf8_buffer[i], utf8[i]);
+      }
+      if(used_size < output_size) {
+        ASSERT_EQUAL(used_size, output_size - 1);
+        ASSERT_TRUE(uint8_t(utf8[used_size]) >= 0x80);
+      }
+    }
+}
+
+
 TEST_MAIN


### PR DESCRIPTION
This is an alternative PR to @ronag's PR  (who should be fully credited for the work) at https://github.com/simdutf/simdutf/pull/554

It is basically @ronag's code with 

1. A *proposed* name change... the suffix `_s` is replaced by `_safe`.
2. A simplification: we do not include the new function in the kernels, instead we use @ronag's algorithm on top of existing fast functions.
3. It adds a sanity test.