### PR TITLE
completing the implementation a bit

### DIFF
--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -1735,7 +1735,7 @@ public:
    * @param len the length of the string in bytes.
    * @return true if and only if the string is valid base64.
    */
-  simdutf_warn_unused virtual result validate_base64(const char *buf, size_t len) const noexcept = 0;
+  simdutf_warn_unused virtual bool validate_base64(const char *buf, size_t len) const noexcept = 0;
 
   /**
    * Validate the UTF-16LE string.This function may be best when you expect

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -885,7 +885,9 @@ size_t implementation::binary_to_base64(const char * input, size_t length, char*
   return encode_base64(output, input, length, options);
 }
 
-
+bool implementation::validate_base64(const char * input, size_t length) const noexcept {
+  return scalar::base64::validate_base64(input, length);
+}
 } // namespace SIMDUTF_IMPLEMENTATION
 } // namespace simdutf
 

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -456,6 +456,10 @@ simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t leng
 size_t implementation::binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept {
   return scalar::base64::tail_encode_base64(output, input, length, options);
 }
+
+bool implementation::validate_base64(const char * input, size_t length) const noexcept {
+  return scalar::base64::validate_base64(input, length);
+}
 } // namespace SIMDUTF_IMPLEMENTATION
 } // namespace simdutf
 

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -831,6 +831,10 @@ size_t implementation::binary_to_base64(const char * input, size_t length, char*
     return encode_base64<false>(output, input, length, options);
   }
 }
+
+bool implementation::validate_base64(const char * input, size_t length) const noexcept {
+  return scalar::base64::validate_base64(input, length);
+}
 } // namespace SIMDUTF_IMPLEMENTATION
 } // namespace simdutf
 

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -1334,6 +1334,10 @@ size_t implementation::binary_to_base64(const char * input, size_t length, char*
   }
 }
 
+bool implementation::validate_base64(const char * input, size_t length) const noexcept {
+  return scalar::base64::validate_base64(input, length);
+}
+
 } // namespace SIMDUTF_IMPLEMENTATION
 } // namespace simdutf
 

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -176,7 +176,7 @@ public:
     return set_best()->validate_ascii_with_errors(buf, len);
   }
 
-  simdutf_warn_unused result validate_base64(const char * buf, size_t len) const noexcept final override {
+  simdutf_warn_unused bool validate_base64(const char * buf, size_t len) const noexcept final override {
     return set_best()->validate_base64(buf, len);
   }
 
@@ -849,6 +849,10 @@ public:
 
   size_t binary_to_base64(const char *, size_t, char*, base64_options) const noexcept override {
     return 0;
+  }
+
+  bool validate_base64(const char *, size_t) const noexcept override {
+    return false;
   }
 
   unsupported_implementation() : implementation("unsupported", "Unsupported CPU (no detected SIMD instructions)", 0) {}

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -382,6 +382,10 @@ simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t leng
 size_t implementation::binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept {
   return scalar::base64::binary_to_base64(input, length, output, options);
 }
+
+bool implementation::validate_base64(const char * input, size_t length) const noexcept {
+  return scalar::base64::validate_base64(input, length);
+}
 } // namespace SIMDUTF_IMPLEMENTATION
 } // namespace simdutf
 

--- a/src/rvv/implementation.cpp
+++ b/src/rvv/implementation.cpp
@@ -165,6 +165,10 @@ simdutf_warn_unused size_t implementation::base64_length_from_binary(size_t leng
 size_t implementation::binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept {
   return scalar::base64::tail_encode_base64(output, input, length, options);
 }
+
+bool implementation::validate_base64(const char * input, size_t length) const noexcept {
+  return scalar::base64::validate_base64(input, length);
+}
 } // namespace SIMDUTF_IMPLEMENTATION
 } // namespace simdutf
 

--- a/src/simdutf/arm64/implementation.h
+++ b/src/simdutf/arm64/implementation.h
@@ -95,6 +95,7 @@ public:
   simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options) const noexcept;
   simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) const noexcept;
   size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept;
+  bool validate_base64(const char * input, size_t length) const noexcept;
 };
 
 } // namespace arm64

--- a/src/simdutf/fallback/implementation.h
+++ b/src/simdutf/fallback/implementation.h
@@ -98,6 +98,7 @@ public:
   simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options) const noexcept;
   simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) const noexcept;
   size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept;
+  bool validate_base64(const char * input, size_t length) const noexcept;
 };
 } // namespace fallback
 } // namespace simdutf

--- a/src/simdutf/haswell/implementation.h
+++ b/src/simdutf/haswell/implementation.h
@@ -97,6 +97,7 @@ public:
   simdutf_warn_unused virtual result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options) const noexcept;
   simdutf_warn_unused virtual size_t base64_length_from_binary(size_t length, base64_options options) const noexcept;
   size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept;
+  bool validate_base64(const char * input, size_t length) const noexcept;
 };
 
 } // namespace haswell

--- a/src/simdutf/icelake/implementation.h
+++ b/src/simdutf/icelake/implementation.h
@@ -97,6 +97,7 @@ public:
   simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options) const noexcept;
   simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) const noexcept;
   size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept;
+  bool validate_base64(const char * input, size_t length) const noexcept;
 };
 
 } // namespace icelake

--- a/src/simdutf/ppc64/implementation.h
+++ b/src/simdutf/ppc64/implementation.h
@@ -75,6 +75,7 @@ public:
   simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options) const noexcept;
   simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) const noexcept;
   size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept;
+  bool validate_base64(const char * input, size_t length) const noexcept;
 };
 
 } // namespace ppc64

--- a/src/simdutf/rvv/implementation.h
+++ b/src/simdutf/rvv/implementation.h
@@ -99,6 +99,7 @@ public:
   simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options) const noexcept;
   simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) const noexcept;
   size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept;
+  bool validate_base64(const char * input, size_t length) const noexcept;
 private:
   const bool _supports_zvbb;
 

--- a/src/simdutf/westmere/implementation.h
+++ b/src/simdutf/westmere/implementation.h
@@ -95,6 +95,7 @@ public:
   simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options) const noexcept;
   simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options) const noexcept;
   size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options) const noexcept;
+  bool validate_base64(const char * input, size_t length) const noexcept;
 };
 
 } // namespace westmere

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -842,6 +842,11 @@ size_t implementation::binary_to_base64(const char * input, size_t length, char*
     return encode_base64<false>(output, input, length, options);
   }
 }
+
+bool implementation::validate_base64(const char * input, size_t length) const noexcept {
+  return scalar::base64::validate_base64(input, length);
+}
+
 } // namespace SIMDUTF_IMPLEMENTATION
 } // namespace simdutf
 


### PR DESCRIPTION
(This is a PR for yagiz/add-validate-base64, merging this would not affect the main branch.)

If we add a function to our kernels, we have to add it everywhere. Obviously, this makes little to no sense if we are not going also to optimize it for the different kernels (e.g., write an ARM implementation).

Note that this function is not super difficult to optimize as the base64 decoding routines already do the validation. Furthermore, they do with options (base64url, and so forth). We could reuse much of the existing code.

Importantly: this will not work if you are trying to validate a base64 string that was percent encoded. So we should clarify the motivation. It can be interesting to decode quickly a base64 string that was percent encoded, but this function won't help much for that.

On this note, the signature of the function should probably take base64 options.
