### PR TITLE
further work on issue 440

### DIFF
--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -1695,13 +1695,11 @@ enum : base64_options {
 
 // last_chunk_handling_options are used to specify the handling of the last
 // chunk in base64 decoding.
-// TODO(franciscogthiesen) - Verify if we want to keep this as a separate option
-// or add it to base64_options. For more details, see:
 // https://tc39.es/proposal-arraybuffer-base64/spec/#sec-frombase64
 enum last_chunk_handling_options : uint64_t {
-  loose = 0,               /* standard base64 format (with padding) */
-  strict = 1,              /* ignore the last chunk if it is not a full chunk */
-  stop_before_partial = 2, /* pad the last chunk if it is not a full chunk */
+  loose = 0,               /* standard base64 format, decode partial final chunk */
+  strict = 1,              /* error when the last chunk is partial, 2 or 3 chars, and unpadded */
+  stop_before_partial = 2, /* if the last chunk is partial (2 or 3 chars), ignore it (no error) */
 };
 
 /**


### PR DESCRIPTION
This PR hopefully fixes a C++11 build issue.

Further, I think that we might have a standard interpretation issue. The handling of the chunk is currently done in a function that is called after we have removed the padding characters ('='), so it is not aware of the padding characters. (We should be able to pass the information if it is needed.)

I added some tests from WebKit. Maybe more could be added.

I expect this PR to current fail in CI, that's normal.