### PR TITLE
issue 578

### DIFF
--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -14,15 +14,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - {shared: ON}
-          - {shared: OFF}
+          - {shared: ON, type : Debug}
+          - {shared: OFF, type : Debug}
+          - {shared: ON, type : Release}
+          - {shared: OFF, type : Release}
     steps:
       - uses: actions/checkout@v4
       - name: Use cmake
         run: |
           mkdir build &&
           cd build &&
-          cmake -DCMAKE_CXX_FLAGS=-Werror -DSIMDUTF_ALWAYS_INCLUDE_FALLBACK=ON -DSIMDUTF_BENCHMARKS=ON  -DCMAKE_INSTALL_PREFIX:PATH=destination -DBUILD_SHARED_LIBS=${{matrix.shared}} ..  -DSIMDUTF_BENCHMARKS=OFF &&
+          cmake -DCMAKE_CXX_FLAGS=-Werror -DSIMDUTF_ALWAYS_INCLUDE_FALLBACK=ON -DSIMDUTF_BENCHMARKS=ON  -DCMAKE_INSTALL_PREFIX:PATH=destination -DBUILD_SHARED_LIBS=${{matrix.shared}} -D CMAKE_BUILD_TYPE=${{matrix.type}} ..  -DSIMDUTF_BENCHMARKS=OFF &&
           cmake --build .   &&
           ctest -j --output-on-failure &&
           cmake --install . &&

--- a/.github/workflows/ubuntu24.yml
+++ b/.github/workflows/ubuntu24.yml
@@ -1,4 +1,4 @@
-name: Ubuntu 22.04 CI (GCC 11)
+name: Ubuntu 24.04 CI (GCC 13)
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ubuntu-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         include:
@@ -24,7 +24,7 @@ jobs:
         run: |
           mkdir build &&
           cd build &&
-          cmake -DCMAKE_CXX_FLAGS=-Werror -DSIMDUTF_ALWAYS_INCLUDE_FALLBACK=ON -DCMAKE_INSTALL_PREFIX:PATH=destination -DBUILD_SHARED_LIBS=${{matrix.shared}} ..   -DSIMDUTF_BENCHMARKS=OFF &&
+          cmake -DCMAKE_CXX_FLAGS=-Werror -DSIMDUTF_ALWAYS_INCLUDE_FALLBACK=ON -DCMAKE_INSTALL_PREFIX:PATH=destination -DBUILD_SHARED_LIBS=${{matrix.shared}} -DCMAKE_BUILD_TYPE=${{matrix.type}} ..   -DSIMDUTF_BENCHMARKS=OFF &&
           cmake --build .   &&
           ctest -j --output-on-failure &&
           cmake --install . &&

--- a/include/simdutf/common_defs.h
+++ b/include/simdutf/common_defs.h
@@ -29,7 +29,8 @@
 #if defined(SIMDUTF_REGULAR_VISUAL_STUDIO)
   #define SIMDUTF_DEPRECATED __declspec(deprecated)
 
-  #define simdutf_really_inline __forceinline
+  #define simdutf_really_inline __forceinline // really inline in release mode
+  #define simdutf_always_inline __forceinline // always inline, no matter what
   #define simdutf_never_inline __declspec(noinline)
 
   #define simdutf_unused
@@ -71,7 +72,7 @@
   #else
     #define simdutf_really_inline inline
   #endif
-
+  #define simdutf_always_inline inline __attribute__((always_inline)) // always inline, no matter what
   #define SIMDUTF_DEPRECATED __attribute__((deprecated))
   #define simdutf_never_inline inline __attribute__((noinline))
 

--- a/include/simdutf/common_defs.h
+++ b/include/simdutf/common_defs.h
@@ -72,7 +72,8 @@
   #else
     #define simdutf_really_inline inline
   #endif
-  #define simdutf_always_inline inline __attribute__((always_inline)) // always inline, no matter what
+  #define simdutf_always_inline                                                \
+    inline __attribute__((always_inline)) // always inline, no matter what
   #define SIMDUTF_DEPRECATED __attribute__((deprecated))
   #define simdutf_never_inline inline __attribute__((noinline))
 

--- a/src/simdutf/haswell/simd.h
+++ b/src/simdutf/haswell/simd.h
@@ -91,7 +91,7 @@ struct base8 : base<simd8<T>> {
   simdutf_really_inline T last() const {
     return _mm256_extract_epi8(*this, 31);
   }
-  friend simdutf_really_inline Mask operator==(const simd8<T> lhs,
+  friend simdutf_always_inline Mask operator==(const simd8<T> lhs,
                                                const simd8<T> rhs) {
     return _mm256_cmpeq_epi8(lhs, rhs);
   }

--- a/src/simdutf/haswell/simd16-inl.h
+++ b/src/simdutf/haswell/simd16-inl.h
@@ -21,7 +21,7 @@ struct base16 : base<simd16<T>> {
   template <typename Pointer>
   simdutf_really_inline base16(const Pointer *ptr)
       : base16(_mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr))) {}
-  friend simdutf_really_inline Mask operator==(const simd16<T> lhs,
+  friend simdutf_always_inline Mask operator==(const simd16<T> lhs,
                                                const simd16<T> rhs) {
     return _mm256_cmpeq_epi16(lhs, rhs);
   }


### PR DESCRIPTION
Some versions of GCC  appear to get confused when compiling `operator==` in debug mode for the haswell kernel (but seemingly, not other kernels?). Though the functions are declared and defined in a region where AVX support is guaranteed, and is only used in such a context, it complains of a 'target specific option mismatch'. More recent versions of GCC (13+) do not have this problem, nor does LLVM as far as I can tell.

To get around the issue, we force inline two specific functions.

Thanks to @hansingt for the report.

Fixes https://github.com/simdutf/simdutf/issues/578