### PR TITLE
fixing issue 583

### DIFF
--- a/benchmarks/base64/benchmark_base64.cpp
+++ b/benchmarks/base64/benchmark_base64.cpp
@@ -223,6 +223,8 @@ void bench(std::vector<std::vector<char>> &data, uint8_t mode) {
 
   case roundtripurl: {
     printf("# roundtrip (url)\n");
+    printf("# roundtrip considers the input as binary data, not as text.\n");
+    printf("# We convert it to base64 and then decode it back.\n");
     for (auto &e : simdutf::get_available_implementations()) {
       if (!e->supported_by_runtime_system()) {
         continue;
@@ -251,6 +253,8 @@ void bench(std::vector<std::vector<char>> &data, uint8_t mode) {
   }
   case roundtrip: {
     printf("# roundtrip\n");
+    printf("# roundtrip considers the input as binary data, not as text.\n");
+    printf("# We convert it to base64 and then decode it back.\n");
     pretty_print(
         data.size(), volume, "libbase64", bench([&data, &buffer1, &buffer2]() {
           for (const std::vector<char> &source : data) {

--- a/include/simdutf/error.h
+++ b/include/simdutf/error.h
@@ -24,6 +24,8 @@ enum error_code {
                             // base64 string.
   BASE64_INPUT_REMAINDER,   // The base64 input terminates with a single
                             // character, excluding padding (=).
+  BASE64_EXTRA_BITS,        // The base64 input terminates with non-zero
+                            // padding bits.
   OUTPUT_BUFFER_TOO_SMALL,  // The provided buffer is too small.
   OTHER                     // Not related to validation/transcoding.
 };

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -1698,7 +1698,7 @@ enum : base64_options {
 enum last_chunk_handling_options : uint64_t {
   loose = 0, /* standard base64 format, decode partial final chunk */
   strict =
-      1, /* error when the last chunk is partial, 2 or 3 chars, and unpadded */
+      1, /* error when the last chunk is partial, 2 or 3 chars, and unpadded, or non-zero bit padding */
   stop_before_partial =
       2, /* if the last chunk is partial (2 or 3 chars), ignore it (no error) */
 };
@@ -1738,9 +1738,9 @@ simdutf_warn_unused size_t maximal_binary_length_from_base64(
  *
  * See https://infra.spec.whatwg.org/#forgiving-base64-decode
  *
- * This function will fail in case of invalid input. There are two possible
- * reasons for failure: the input contains a number of base64 characters that
- * when divided by 4, leaves a single remainder character
+ * This function will fail in case of invalid input. When last_chunk_options = loose,
+ * there are two possible reasons for failure: the input contains a number of
+ * base64 characters that when divided by 4, leaves a single remainder character
  * (BASE64_INPUT_REMAINDER), or the input contains a character that is not a
  * valid base64 character (INVALID_BASE64_CHARACTER).
  *
@@ -1830,9 +1830,9 @@ size_t binary_to_base64(const char *input, size_t length, char *output,
  *
  * See https://infra.spec.whatwg.org/#forgiving-base64-decode
  *
- * This function will fail in case of invalid input. There are two possible
- * reasons for failure: the input contains a number of base64 characters that
- * when divided by 4, leaves a single remainder character
+ * This function will fail in case of invalid input. When last_chunk_options = loose,
+ * there are two possible reasons for failure: the input contains a number of
+ * base64 characters that when divided by 4, leaves a single remainder character
  * (BASE64_INPUT_REMAINDER), or the input contains a character that is not a
  * valid base64 character (INVALID_BASE64_CHARACTER).
  *
@@ -1892,9 +1892,9 @@ base64_to_binary(const char16_t *input, size_t length, char *output,
  *
  * See https://infra.spec.whatwg.org/#forgiving-base64-decode
  *
- * This function will fail in case of invalid input. There are three possible
- * reasons for failure: the input contains a number of base64 characters that
- * when divided by 4, leaves a single remainder character
+ * This function will fail in case of invalid input. When last_chunk_options = loose,
+ * there are three possible reasons for failure: the input contains a number of base64
+ * characters that when divided by 4, leaves a single remainder character
  * (BASE64_INPUT_REMAINDER), the input contains a character that is not a valid
  * base64 character (INVALID_BASE64_CHARACTER), or the output buffer is too
  * small (OUTPUT_BUFFER_TOO_SMALL).
@@ -3393,9 +3393,9 @@ public:
    *
    * See https://infra.spec.whatwg.org/#forgiving-base64-decode
    *
-   * This function will fail in case of invalid input. There are two possible
-   * reasons for failure: the input contains a number of base64 characters that
-   * when divided by 4, leaves a single remainder character
+   * This function will fail in case of invalid input. When last_chunk_options = loose,
+   * there are two possible reasons for failure: the input contains a number of
+   * base64 characters that when divided by 4, leaves a single remainder character
    * (BASE64_INPUT_REMAINDER), or the input contains a character that is not a
    * valid base64 character (INVALID_BASE64_CHARACTER).
    *
@@ -3431,9 +3431,9 @@ public:
    *
    * See https://infra.spec.whatwg.org/#forgiving-base64-decode
    *
-   * This function will fail in case of invalid input. There are two possible
-   * reasons for failure: the input contains a number of base64 characters that
-   * when divided by 4, leaves a single remainder character
+   * This function will fail in case of invalid input. When last_chunk_options = loose,
+   * there are two possible reasons for failure: the input contains a number of
+   * base64 characters that when divided by 4, leaves a single remainder character
    * (BASE64_INPUT_REMAINDER), or the input contains a character that is not a
    * valid base64 character (INVALID_BASE64_CHARACTER).
    *

--- a/riscv/README.md
+++ b/riscv/README.md
@@ -1,4 +1,4 @@
-# RISC-V 
+# RISC-V
 
 We assume that you have a docker or docker-like system.
 

--- a/src/scalar/base64.h
+++ b/src/scalar/base64.h
@@ -100,6 +100,9 @@ base64_tail_decode(char *dst, const char_type *src, size_t length,
         if (idx == 2) {
           uint32_t triple =
               (uint32_t(buffer[0]) << 3 * 6) + (uint32_t(buffer[1]) << 2 * 6);
+          if((last_chunk_options == last_chunk_handling_options::strict) && (triple&0xffff)) {
+            return {BASE64_EXTRA_BITS, size_t(src - srcinit)};
+          }
           if (match_system(endianness::BIG)) {
             triple <<= 8;
             std::memcpy(dst, &triple, 1);
@@ -113,6 +116,9 @@ base64_tail_decode(char *dst, const char_type *src, size_t length,
           uint32_t triple = (uint32_t(buffer[0]) << 3 * 6) +
                             (uint32_t(buffer[1]) << 2 * 6) +
                             (uint32_t(buffer[2]) << 1 * 6);
+          if((last_chunk_options == last_chunk_handling_options::strict) && (triple&0xff)) {
+            return {BASE64_EXTRA_BITS, size_t(src - srcinit)};
+          }
           if (match_system(endianness::BIG)) {
             triple <<= 8;
             std::memcpy(dst, &triple, 2);
@@ -252,6 +258,9 @@ result base64_tail_decode_safe(
           uint32_t triple = 0;
           if (idx == 2) {
             triple = (uint32_t(buffer[0]) << 18) + (uint32_t(buffer[1]) << 12);
+            if((last_chunk_options == last_chunk_handling_options::strict) && (triple&0xffff)) {
+              return {BASE64_EXTRA_BITS, size_t(src - srcinit)};
+            }
             // Extract the first byte
             triple >>= 16;
             dst[0] = static_cast<char>(triple & 0xFF);
@@ -259,6 +268,9 @@ result base64_tail_decode_safe(
           } else if (idx == 3) {
             triple = (uint32_t(buffer[0]) << 18) + (uint32_t(buffer[1]) << 12) +
                      (uint32_t(buffer[2]) << 6);
+            if((last_chunk_options == last_chunk_handling_options::strict) && (triple&0xff)) {
+              return {BASE64_EXTRA_BITS, size_t(src - srcinit)};
+            }
             // Extract the first two bytes
             triple >>= 8;
             dst[0] = static_cast<char>((triple >> 8) & 0xFF);

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -124,6 +124,36 @@ size_t add_garbage(std::vector<char_type> &v, std::mt19937 &gen) {
   return i;
 }
 
+
+TEST(base64_decode_strict_cases) {
+  std::vector<std::pair<std::string, uint64_t>> test_cases = {
+      {"ZXhhZg==", simdutf::error_code::SUCCESS},
+      {"YWE=", simdutf::error_code::SUCCESS},
+      {"YWF=", simdutf::error_code::BASE64_EXTRA_BITS},
+      {"ZXhhZh==", simdutf::error_code::BASE64_EXTRA_BITS},
+      {"ZXhhZg", simdutf::error_code::BASE64_INPUT_REMAINDER},
+      {"ZXhhZh", simdutf::error_code::BASE64_INPUT_REMAINDER},
+      {"Z   X  h  h   Z h =   =", simdutf::error_code::BASE64_EXTRA_BITS},
+      {"ZX  h  hZg", simdutf::error_code::BASE64_INPUT_REMAINDER},
+      {"ZXh  hZ  h", simdutf::error_code::BASE64_INPUT_REMAINDER},
+      };
+  std::vector<char> buffer(1024);
+  for (auto &p : test_cases) {
+    auto input = p.first;
+    auto expected_error = p.second;
+    simdutf::result result = implementation.base64_to_binary(input.data(), 
+      input.size(), buffer.data(), simdutf::base64_default, simdutf::last_chunk_handling_options::strict);
+    ASSERT_EQUAL(result.error, expected_error);
+    size_t written = buffer.size();
+    result = simdutf::base64_to_binary_safe(
+          input.data(), input.size(),
+          buffer.data(), written,
+          simdutf::base64_default, simdutf::last_chunk_handling_options::strict);
+    ASSERT_EQUAL(result.error, expected_error);
+  }
+}
+
+
 TEST(issue_single_bad16) {
   std::vector<char16_t> data = {0x3d};
   ASSERT_EQUAL(data.size(), 1);


### PR DESCRIPTION
In the strict mode, we return a new error (BASE64_EXTRA_BITS) when there are non-zero padding bits. It was a bug not do return an error.

Fixes https://github.com/simdutf/simdutf/issues/583