### PR TITLE
Optimize base64 decode AVX512 kernel for small input sizes

### DIFF
--- a/src/icelake/icelake_base64.inl.cpp
+++ b/src/icelake/icelake_base64.inl.cpp
@@ -88,7 +88,8 @@ size_t encode_base64(char *dst, const char *src, size_t srclen,
 }
 
 template <bool base64_url>
-static inline uint64_t to_base64_mask(block64 *b, uint64_t *error) {
+static inline uint64_t to_base64_mask(block64 *b, uint64_t *error,
+                                      uint64_t input_mask = UINT64_MAX) {
   __m512i input = b->chunks[0];
   const __m512i ascii_space_tbl = _mm512_set_epi8(
       0, 0, 13, 12, 0, 10, 9, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 13, 12, 0, 10,
@@ -127,15 +128,17 @@ static inline uint64_t to_base64_mask(block64 *b, uint64_t *error) {
 
   const __m512i translated = _mm512_permutex2var_epi8(lookup0, input, lookup1);
   const __m512i combined = _mm512_or_si512(translated, input);
-  const __mmask64 mask = _mm512_movepi8_mask(combined);
+  const __mmask64 mask = _mm512_movepi8_mask(combined) & input_mask;
   if (mask) {
-    const __mmask64 spaces = _mm512_cmpeq_epi8_mask(
-        _mm512_shuffle_epi8(ascii_space_tbl, input), input);
+    const __mmask64 spaces =
+        _mm512_cmpeq_epi8_mask(_mm512_shuffle_epi8(ascii_space_tbl, input),
+                               input) &
+        input_mask;
     *error = (mask ^ spaces);
   }
   b->chunks[0] = translated;
 
-  return mask;
+  return mask | (~input_mask);
 }
 
 static inline void copy_block(block64 *b, char *output) {
@@ -155,11 +158,29 @@ static inline void load_block(block64 *b, const char *src) {
   b->chunks[0] = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(src));
 }
 
+static inline void load_block_partial(block64 *b, const char *src,
+                                      __mmask64 input_mask) {
+  b->chunks[0] = _mm512_maskz_loadu_epi8(
+      input_mask, reinterpret_cast<const __m512i *>(src));
+}
+
 // The caller of this function is responsible to ensure that there are 128 bytes
 // available from reading at src. The data is read into a block64 structure.
 static inline void load_block(block64 *b, const char16_t *src) {
   __m512i m1 = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(src));
   __m512i m2 = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(src + 32));
+  __m512i p = _mm512_packus_epi16(m1, m2);
+  b->chunks[0] =
+      _mm512_permutexvar_epi64(_mm512_setr_epi64(0, 2, 4, 6, 1, 3, 5, 7), p);
+}
+
+static inline void load_block_partial(block64 *b, const char16_t *src,
+                                      __mmask64 input_mask) {
+  __m512i m1 = _mm512_maskz_loadu_epi16((__mmask32)input_mask,
+                                        reinterpret_cast<const __m512i *>(src));
+  __m512i m2 =
+      _mm512_maskz_loadu_epi16((__mmask32)(input_mask >> 32),
+                               reinterpret_cast<const __m512i *>(src + 32));
   __m512i p = _mm512_packus_epi16(m1, m2);
   b->chunks[0] =
       _mm512_permutexvar_epi64(_mm512_setr_epi64(0, 2, 4, 6, 1, 3, 5, 7), p);
@@ -194,6 +215,7 @@ full_result
 compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                        base64_options options,
                        last_chunk_handling_options last_chunk_options) {
+  (void)options;
   const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
                                         : tables::base64::to_base64_value;
   size_t equallocation =
@@ -271,83 +293,114 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     }
   }
 
-  char *buffer_start = buffer;
-  // Optimization note: if this is almost full, then it is worth our
-  // time, otherwise, we should just decode directly.
-  int last_block = (int)((bufferptr - buffer_start) % 64);
-  if (last_block != 0 && srcend - src + last_block >= 64) {
-
-    while ((bufferptr - buffer_start) % 64 != 0 && src < srcend) {
-      uint8_t val = to_base64[uint8_t(*src)];
-      *bufferptr = char(val);
-      if (!scalar::base64::is_eight_byte(*src) || val > 64) {
-        return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit),
-                size_t(dst - dstinit)};
-      }
-      bufferptr += (val <= 63);
-      src++;
+  int last_block_len = (int)(srcend - src);
+  if (last_block_len != 0) {
+    __mmask64 input_mask = ((__mmask64)1 << last_block_len) - 1;
+    block64 b;
+    load_block_partial(&b, src, input_mask);
+    uint64_t error = 0;
+    uint64_t badcharmask = to_base64_mask<base64_url>(&b, &error, input_mask);
+    if (error) {
+      size_t error_offset = _tzcnt_u64(error);
+      return {error_code::INVALID_BASE64_CHARACTER,
+              size_t(src - srcinit + error_offset), size_t(dst - dstinit)};
     }
+    src += last_block_len;
+    bufferptr += compress_block(&b, badcharmask, bufferptr);
   }
 
+  char *buffer_start = buffer;
   for (; buffer_start + 64 <= bufferptr; buffer_start += 64) {
     base64_decode_block(dst, buffer_start);
     dst += 48;
   }
-  if ((bufferptr - buffer_start) % 64 != 0) {
-    while (buffer_start + 4 < bufferptr) {
-      uint32_t triple = ((uint32_t(uint8_t(buffer_start[0])) << 3 * 6) +
-                         (uint32_t(uint8_t(buffer_start[1])) << 2 * 6) +
-                         (uint32_t(uint8_t(buffer_start[2])) << 1 * 6) +
-                         (uint32_t(uint8_t(buffer_start[3])) << 0 * 6))
-                        << 8;
-      triple = scalar::utf32::swap_bytes(triple);
-      std::memcpy(dst, &triple, 4);
-      dst += 3;
-      buffer_start += 4;
-    }
-    if (buffer_start + 4 <= bufferptr) {
-      uint32_t triple = ((uint32_t(uint8_t(buffer_start[0])) << 3 * 6) +
-                         (uint32_t(uint8_t(buffer_start[1])) << 2 * 6) +
-                         (uint32_t(uint8_t(buffer_start[2])) << 1 * 6) +
-                         (uint32_t(uint8_t(buffer_start[3])) << 0 * 6))
-                        << 8;
-      triple = scalar::utf32::swap_bytes(triple);
-      std::memcpy(dst, &triple, 3);
-      dst += 3;
-      buffer_start += 4;
-    }
-    // we may have 1, 2 or 3 bytes left and we need to decode them so let us
-    // backtrack
-    int leftover = int(bufferptr - buffer_start);
-    while (leftover > 0) {
-      while (to_base64[uint8_t(*(src - 1))] == 64) {
-        src--;
-      }
-      src--;
-      leftover--;
-    }
-  }
-  if (src < srcend + equalsigns) {
-    full_result r = scalar::base64::base64_tail_decode(
-        dst, src, srcend - src, equalsigns, options, last_chunk_options);
-    r.input_count += size_t(src - srcinit);
-    if (r.error == error_code::INVALID_BASE64_CHARACTER ||
-        r.error == error_code::BASE64_EXTRA_BITS) {
-      return r;
+
+  if ((bufferptr - buffer_start) != 0) {
+    size_t rem = (bufferptr - buffer_start);
+    int idx = rem % 4;
+    __mmask64 mask = ((__mmask64)1 << rem) - 1;
+    __m512i input = _mm512_maskz_loadu_epi8(mask, buffer_start);
+    size_t output_len = (rem / 4) * 3;
+    __mmask64 output_mask = mask >> (rem - output_len);
+    const __m512i merge_ab_and_bc =
+        _mm512_maddubs_epi16(input, _mm512_set1_epi32(0x01400140));
+    const __m512i merged =
+        _mm512_madd_epi16(merge_ab_and_bc, _mm512_set1_epi32(0x00011000));
+    const __m512i pack = _mm512_set_epi8(
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 60, 61, 62, 56, 57, 58,
+        52, 53, 54, 48, 49, 50, 44, 45, 46, 40, 41, 42, 36, 37, 38, 32, 33, 34,
+        28, 29, 30, 24, 25, 26, 20, 21, 22, 16, 17, 18, 12, 13, 14, 8, 9, 10, 4,
+        5, 6, 0, 1, 2);
+    const __m512i shuffled = _mm512_permutexvar_epi8(pack, merged);
+
+    if (last_chunk_options == last_chunk_handling_options::strict &&
+        (idx != 1) && ((idx + equalsigns) & 3) != 0) {
+      // The partial chunk was at src - idx
+      _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+      dst += output_len;
+      return {BASE64_INPUT_REMAINDER, size_t(src - srcinit),
+              size_t(dst - dstinit)};
+    } else if (last_chunk_options ==
+                   last_chunk_handling_options::stop_before_partial &&
+               (idx != 1) && ((idx + equalsigns) & 3) != 0) {
+      // Rewind src to before partial chunk
+      _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+      dst += output_len;
+      src -= idx;
     } else {
-      r.output_count += size_t(dst - dstinit);
-    }
-    if (last_chunk_options != stop_before_partial &&
-        r.error == error_code::SUCCESS && equalsigns > 0) {
-      // additional checks
-      if ((r.output_count % 3 == 0) ||
-          ((r.output_count % 3) + 1 + equalsigns != 4)) {
-        r.error = error_code::INVALID_BASE64_CHARACTER;
-        r.input_count = equallocation;
+      if (idx == 2) {
+        if (last_chunk_options == last_chunk_handling_options::strict) {
+          uint32_t triple = (uint32_t(bufferptr[-2]) << 3 * 6) +
+                            (uint32_t(bufferptr[-1]) << 2 * 6);
+          if (triple & 0xffff) {
+            _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+            dst += output_len;
+            return {BASE64_EXTRA_BITS, size_t(src - srcinit),
+                    size_t(dst - dstinit)};
+          }
+        }
+        output_mask = (output_mask << 1) | 1;
+        output_len += 1;
+        _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+        dst += output_len;
+      } else if (idx == 3) {
+        if (last_chunk_options == last_chunk_handling_options::strict) {
+          uint32_t triple = (uint32_t(bufferptr[-3]) << 3 * 6) +
+                            (uint32_t(bufferptr[-2]) << 2 * 6) +
+                            (uint32_t(bufferptr[-1]) << 1 * 6);
+          if (triple & 0xff) {
+            _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+            dst += output_len;
+            return {BASE64_EXTRA_BITS, size_t(src - srcinit),
+                    size_t(dst - dstinit)};
+          }
+        }
+        output_mask = (output_mask << 2) | 3;
+        output_len += 2;
+        _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+        dst += output_len;
+      } else if (idx == 1) {
+        _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+        dst += output_len;
+        return {BASE64_INPUT_REMAINDER, size_t(src - srcinit),
+                size_t(dst - dstinit)};
+      } else {
+        _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+        dst += output_len;
       }
     }
-    return r;
+
+    if (last_chunk_options != stop_before_partial && equalsigns > 0) {
+      size_t output_count = size_t(dst - dstinit);
+      if ((output_count % 3 == 0) ||
+          ((output_count % 3) + 1 + equalsigns != 4)) {
+        return {INVALID_BASE64_CHARACTER, equallocation, output_count};
+      }
+    }
+
+    return {SUCCESS, srclen, size_t(dst - dstinit)};
   }
+
   if (equalsigns > 0) {
     if ((size_t(dst - dstinit) % 3 == 0) ||
         ((size_t(dst - dstinit) % 3) + 1 + equalsigns != 4)) {


### PR DESCRIPTION
Optimize the base64 decode AVX512 routine for <64 bytes input and use Masked AVX512 instructions to process most of the <64 bytes tail.
Before the change:
```
 current system detected as icelake.
# loading files: .
# volume: 60 bytes
# max length: 60 bytes
# number of inputs: 1
# decode
memcpy                                   :   3.74 GB/s  17.75 GHz   4.75 c/b   4.15 i/b   0.87 i/c
libbase64                                :   1.98 GB/s  12.10 GHz   6.10 c/b  13.55 i/b   2.22 i/c
libbase64_space_decode                   :   1.03 GB/s   8.98 GHz   8.71 c/b  19.48 i/b   2.24 i/c
openssl3.3.x                             :   0.60 GB/s   7.58 GHz  12.63 c/b  45.42 i/b   3.60 i/c
node                                     :   1.65 GB/s  10.99 GHz   6.68 c/b  16.45 i/b   2.46 i/c
simdutf::icelake                         :   1.59 GB/s  10.17 GHz   6.40 c/b  12.62 i/b   1.97 i/c
simdutf::haswell                         :   1.54 GB/s  10.04 GHz   6.54 c/b  12.88 i/b   1.97 i/c
simdutf::westmere                        :   1.56 GB/s  10.14 GHz   6.49 c/b  12.70 i/b   1.96 i/c
simdutf::fallback                        :   1.96 GB/s  11.21 GHz   5.73 c/b  11.48 i/b   2.00 i/c
```
After the change:
```
# current system detected as icelake.
# loading files: .
# volume: 60 bytes
# max length: 60 bytes
# number of inputs: 1
# decode
memcpy                                   :   3.75 GB/s  17.65 GHz   4.71 c/b   4.15 i/b   0.88 i/c
libbase64                                :   2.03 GB/s  12.17 GHz   6.00 c/b  13.55 i/b   2.26 i/c
libbase64_space_decode                   :   1.08 GB/s   9.09 GHz   8.44 c/b  19.48 i/b   2.31 i/c
openssl3.3.x                             :   0.60 GB/s   7.59 GHz  12.76 c/b  45.42 i/b   3.56 i/c
node                                     :   1.63 GB/s  10.95 GHz   6.72 c/b  16.45 i/b   2.45 i/c
simdutf::icelake                         :   2.39 GB/s  12.46 GHz   5.22 c/b   6.30 i/b   1.21 i/c
simdutf::haswell                         :   1.53 GB/s  10.03 GHz   6.54 c/b  12.88 i/b   1.97 i/c
simdutf::westmere                        :   1.54 GB/s  10.03 GHz   6.51 c/b  12.70 i/b   1.95 i/c
simdutf::fallback                        :   1.82 GB/s  10.59 GHz   5.81 c/b  11.48 i/b   1.98 i/c
```