### PR TITLE
Adding the base64 decode with garbage option code changes

### DIFF
--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -1689,8 +1689,8 @@ enum base64_options : uint64_t {
       base64_reverse_padding, /* standard base64 format without padding */
   base64_url_with_padding =
       base64_url | base64_reverse_padding, /* base64url with padding */
-  base64_default_accept_garbage = 4, /* accept garbage characters */
-  base64_url_accept_garbage = 5,     /* accept garbage characters */
+  base64_default_accept_garbage = 4,       /* accept garbage characters */
+  base64_url_accept_garbage = 5,           /* accept garbage characters */
 };
 
 // last_chunk_handling_options are used to specify the handling of the last

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -1689,6 +1689,8 @@ enum base64_options : uint64_t {
       base64_reverse_padding, /* standard base64 format without padding */
   base64_url_with_padding =
       base64_url | base64_reverse_padding, /* base64url with padding */
+  base64_default_accept_garbage = 4, /* accept garbage characters */
+  base64_url_accept_garbage = 5,     /* accept garbage characters */
 };
 
 // last_chunk_handling_options are used to specify the handling of the last

--- a/src/arm64/arm_base64.cpp
+++ b/src/arm64/arm_base64.cpp
@@ -332,6 +332,9 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
                        last_chunk_handling_options last_chunk_options) {
   const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
                                         : tables::base64::to_base64_value;
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage);
   size_t equallocation =
       srclen; // location of the first padding character if any
   // skip trailing spaces
@@ -356,7 +359,7 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
     }
   }
   if (srclen == 0) {
-    if (equalsigns > 0) {
+    if (!ignore_garbage && equalsigns > 0) {
       return {INVALID_BASE64_CHARACTER, equallocation, 0};
     }
     return {SUCCESS, 0, 0};
@@ -377,7 +380,7 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
       bool error = false;
       uint64_t badcharmask = to_base64_mask<base64_url>(&b, &error);
       if (badcharmask) {
-        if (error) {
+        if (error && !ignore_garbage) {
           src -= 64;
           while (src < srcend && scalar::base64::is_eight_byte(*src) &&
                  to_base64[uint8_t(*src)] <= 64) {
@@ -421,7 +424,8 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
     while ((bufferptr - buffer_start) % 64 != 0 && src < srcend) {
       uint8_t val = to_base64[uint8_t(*src)];
       *bufferptr = char(val);
-      if (!scalar::base64::is_eight_byte(*src) || val > 64) {
+      if ((!scalar::base64::is_eight_byte(*src) || val > 64) &&
+          !ignore_garbage) {
         return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit),
                 size_t(dst - dstinit)};
       }
@@ -463,8 +467,14 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
     // backtrack
     int leftover = int(bufferptr - buffer_start);
     while (leftover > 0) {
-      while (to_base64[uint8_t(*(src - 1))] == 64) {
-        src--;
+      if (!ignore_garbage) {
+        while (to_base64[uint8_t(*(src - 1))] == 64) {
+          src--;
+        }
+      } else {
+        while (to_base64[uint8_t(*(src - 1))] >= 64) {
+          src--;
+        }
       }
       src--;
       leftover--;
@@ -481,7 +491,7 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
       r.output_count += size_t(dst - dstinit);
     }
     if (last_chunk_options != stop_before_partial &&
-        r.error == error_code::SUCCESS && equalsigns > 0) {
+        r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
       // additional checks
       if ((r.output_count % 3 == 0) ||
           ((r.output_count % 3) + 1 + equalsigns != 4)) {
@@ -491,7 +501,7 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
     }
     return r;
   }
-  if (equalsigns > 0) {
+  if (equalsigns > 0 && !ignore_garbage) {
     if ((size_t(dst - dstinit) % 3 == 0) ||
         ((size_t(dst - dstinit) % 3) + 1 + equalsigns != 4)) {
       return {INVALID_BASE64_CHARACTER, equallocation, size_t(dst - dstinit)};

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -503,6 +503,9 @@ simdutf_warn_unused size_t implementation::maximal_binary_length_from_base64(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage);
   while (length > 0 &&
          scalar::base64::is_ascii_white_space(input[length - 1])) {
     length--;
@@ -525,7 +528,7 @@ simdutf_warn_unused result implementation::base64_to_binary(
     }
   }
   if (length == 0) {
-    if (equalsigns > 0) {
+    if (!ignore_garbage && equalsigns > 0) {
       return {INVALID_BASE64_CHARACTER, equallocation};
     }
     return {SUCCESS, 0};
@@ -533,7 +536,7 @@ simdutf_warn_unused result implementation::base64_to_binary(
   result r = scalar::base64::base64_tail_decode(
       output, input, length, equalsigns, options, last_chunk_options);
   if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0) {
+      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
     // additional checks
     if ((r.count % 3 == 0) || ((r.count % 3) + 1 + equalsigns != 4)) {
       return {INVALID_BASE64_CHARACTER, equallocation};
@@ -545,6 +548,9 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage);
   while (length > 0 &&
          scalar::base64::is_ascii_white_space(input[length - 1])) {
     length--;
@@ -567,7 +573,7 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
     }
   }
   if (length == 0) {
-    if (equalsigns > 0) {
+    if (!ignore_garbage && equalsigns > 0) {
       return {INVALID_BASE64_CHARACTER, equallocation, 0};
     }
     return {SUCCESS, 0, 0};
@@ -575,7 +581,7 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
   full_result r = scalar::base64::base64_tail_decode(
       output, input, length, equalsigns, options, last_chunk_options);
   if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0) {
+      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
     // additional checks
     if ((r.output_count % 3 == 0) ||
         ((r.output_count % 3) + 1 + equalsigns != 4)) {
@@ -593,6 +599,9 @@ simdutf_warn_unused size_t implementation::maximal_binary_length_from_base64(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage);
   while (length > 0 &&
          scalar::base64::is_ascii_white_space(input[length - 1])) {
     length--;
@@ -615,7 +624,7 @@ simdutf_warn_unused result implementation::base64_to_binary(
     }
   }
   if (length == 0) {
-    if (equalsigns > 0) {
+    if (!ignore_garbage && equalsigns > 0) {
       return {INVALID_BASE64_CHARACTER, equallocation};
     }
     return {SUCCESS, 0};
@@ -623,7 +632,7 @@ simdutf_warn_unused result implementation::base64_to_binary(
   result r = scalar::base64::base64_tail_decode(
       output, input, length, equalsigns, options, last_chunk_options);
   if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0) {
+      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
     // additional checks
     if ((r.count % 3 == 0) || ((r.count % 3) + 1 + equalsigns != 4)) {
       return {INVALID_BASE64_CHARACTER, equallocation};
@@ -635,6 +644,9 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage);
   while (length > 0 &&
          scalar::base64::is_ascii_white_space(input[length - 1])) {
     length--;
@@ -657,7 +669,7 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
     }
   }
   if (length == 0) {
-    if (equalsigns > 0) {
+    if (!ignore_garbage && equalsigns > 0) {
       return {INVALID_BASE64_CHARACTER, equallocation, 0};
     }
     return {SUCCESS, 0, 0};
@@ -665,7 +677,7 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
   full_result r = scalar::base64::base64_tail_decode(
       output, input, length, equalsigns, options, last_chunk_options);
   if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0) {
+      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
     // additional checks
     if ((r.output_count % 3 == 0) ||
         ((r.output_count % 3) + 1 + equalsigns != 4)) {

--- a/src/lasx/lasx_base64.cpp
+++ b/src/lasx/lasx_base64.cpp
@@ -412,6 +412,9 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                        last_chunk_handling_options last_chunk_options) {
   const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
                                         : tables::base64::to_base64_value;
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage);
   size_t equallocation =
       srclen; // location of the first padding character if any
   // skip trailing spaces
@@ -436,7 +439,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     }
   }
   if (srclen == 0) {
-    if (equalsigns > 0) {
+    if (!ignore_garbage && equalsigns > 0) {
       return {INVALID_BASE64_CHARACTER, equallocation, 0};
     }
     return {SUCCESS, 0, 0};
@@ -460,7 +463,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       src += 64;
       bool error = false;
       uint64_t badcharmask = to_base64_mask<base64_url>(&b, &error);
-      if (error) {
+      if (error && !ignore_garbage) {
         src -= 64;
         while (src < srcend && scalar::base64::is_eight_byte(*src) &&
                to_base64[uint8_t(*src)] <= 64) {
@@ -512,7 +515,8 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     while ((bufferptr - buffer_start) % 64 != 0 && src < srcend) {
       uint8_t val = to_base64[uint8_t(*src)];
       *bufferptr = char(val);
-      if (!scalar::base64::is_eight_byte(*src) || val > 64) {
+      if ((!scalar::base64::is_eight_byte(*src) || val > 64) &&
+          !ignore_garbage) {
         return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit),
                 size_t(dst - dstinit)};
       }
@@ -558,8 +562,14 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     // backtrack
     int leftover = int(bufferptr - buffer_start);
     while (leftover > 0) {
-      while (to_base64[uint8_t(*(src - 1))] == 64) {
-        src--;
+      if (!ignore_garbage) {
+        while (to_base64[uint8_t(*(src - 1))] == 64) {
+          src--;
+        }
+      } else {
+        while (to_base64[uint8_t(*(src - 1))] >= 64) {
+          src--;
+        }
       }
       src--;
       leftover--;
@@ -576,7 +586,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       r.output_count += size_t(dst - dstinit);
     }
     if (last_chunk_options != stop_before_partial &&
-        r.error == error_code::SUCCESS && equalsigns > 0) {
+        r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
       // additional checks
       if ((r.output_count % 3 == 0) ||
           ((r.output_count % 3) + 1 + equalsigns != 4)) {
@@ -586,7 +596,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     }
     return r;
   }
-  if (equalsigns > 0) {
+  if (equalsigns > 0 && !ignore_garbage) {
     if ((size_t(dst - dstinit) % 3 == 0) ||
         ((size_t(dst - dstinit) % 3) + 1 + equalsigns != 4)) {
       return {INVALID_BASE64_CHARACTER, equallocation, size_t(dst - dstinit)};

--- a/src/lsx/lsx_base64.cpp
+++ b/src/lsx/lsx_base64.cpp
@@ -411,6 +411,9 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
                        last_chunk_handling_options last_chunk_options) {
   const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
                                         : tables::base64::to_base64_value;
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage);
   size_t equallocation =
       srclen; // location of the first padding character if any
   // skip trailing spaces
@@ -435,7 +438,7 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
     }
   }
   if (srclen == 0) {
-    if (equalsigns > 0) {
+    if (!ignore_garbage && equalsigns > 0) {
       return {INVALID_BASE64_CHARACTER, equallocation, 0};
     }
     return {SUCCESS, 0, 0};
@@ -456,7 +459,7 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
       bool error = false;
       uint64_t badcharmask = to_base64_mask<base64_url>(&b, &error);
       if (badcharmask) {
-        if (error) {
+        if (error && !ignore_garbage) {
           src -= 64;
           while (src < srcend && scalar::base64::is_eight_byte(*src) &&
                  to_base64[uint8_t(*src)] <= 64) {
@@ -500,7 +503,8 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
     while ((bufferptr - buffer_start) % 64 != 0 && src < srcend) {
       uint8_t val = to_base64[uint8_t(*src)];
       *bufferptr = char(val);
-      if (!scalar::base64::is_eight_byte(*src) || val > 64) {
+      if ((!scalar::base64::is_eight_byte(*src) || val > 64) &&
+          !ignore_garbage) {
         return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit),
                 size_t(dst - dstinit)};
       }
@@ -542,8 +546,14 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
     // backtrack
     int leftover = int(bufferptr - buffer_start);
     while (leftover > 0) {
-      while (to_base64[uint8_t(*(src - 1))] == 64) {
-        src--;
+      if (!ignore_garbage) {
+        while (to_base64[uint8_t(*(src - 1))] == 64) {
+          src--;
+        }
+      } else {
+        while (to_base64[uint8_t(*(src - 1))] >= 64) {
+          src--;
+        }
       }
       src--;
       leftover--;
@@ -560,7 +570,7 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
       r.output_count += size_t(dst - dstinit);
     }
     if (last_chunk_options != stop_before_partial &&
-        r.error == error_code::SUCCESS && equalsigns > 0) {
+        r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
       // additional checks
       if ((r.output_count % 3 == 0) ||
           ((r.output_count % 3) + 1 + equalsigns != 4)) {
@@ -570,7 +580,7 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
     }
     return r;
   }
-  if (equalsigns > 0) {
+  if (equalsigns > 0 && !ignore_garbage) {
     if ((size_t(dst - dstinit) % 3 == 0) ||
         ((size_t(dst - dstinit) % 3) + 1 + equalsigns != 4)) {
       return {INVALID_BASE64_CHARACTER, equallocation, size_t(dst - dstinit)};

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -406,6 +406,9 @@ simdutf_warn_unused size_t implementation::maximal_binary_length_from_base64(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage);
   // skip trailing spaces
   while (length > 0 &&
          scalar::base64::is_ascii_white_space(input[length - 1])) {
@@ -429,7 +432,7 @@ simdutf_warn_unused result implementation::base64_to_binary(
     }
   }
   if (length == 0) {
-    if (equalsigns > 0) {
+    if (!ignore_garbage && equalsigns > 0) {
       return {INVALID_BASE64_CHARACTER, equallocation};
     }
     return {SUCCESS, 0};
@@ -437,7 +440,7 @@ simdutf_warn_unused result implementation::base64_to_binary(
   result r = scalar::base64::base64_tail_decode(
       output, input, length, equalsigns, options, last_chunk_options);
   if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0) {
+      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
     // additional checks
     if ((r.count % 3 == 0) || ((r.count % 3) + 1 + equalsigns != 4)) {
       return {INVALID_BASE64_CHARACTER, equallocation};
@@ -454,6 +457,9 @@ simdutf_warn_unused size_t implementation::maximal_binary_length_from_base64(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage);
   // skip trailing spaces
   while (length > 0 &&
          scalar::base64::is_ascii_white_space(input[length - 1])) {
@@ -477,7 +483,7 @@ simdutf_warn_unused result implementation::base64_to_binary(
     }
   }
   if (length == 0) {
-    if (equalsigns > 0) {
+    if (!ignore_garbage && equalsigns > 0) {
       return {INVALID_BASE64_CHARACTER, equallocation};
     }
     return {SUCCESS, 0};
@@ -485,7 +491,7 @@ simdutf_warn_unused result implementation::base64_to_binary(
   result r = scalar::base64::base64_tail_decode(
       output, input, length, equalsigns, options, last_chunk_options);
   if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0) {
+      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
     // additional checks
     if ((r.count % 3 == 0) || ((r.count % 3) + 1 + equalsigns != 4)) {
       return {INVALID_BASE64_CHARACTER, equallocation};

--- a/src/rvv/implementation.cpp
+++ b/src/rvv/implementation.cpp
@@ -92,6 +92,9 @@ simdutf_warn_unused size_t implementation::maximal_binary_length_from_base64(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage);
   while (length > 0 &&
          scalar::base64::is_ascii_white_space(input[length - 1])) {
     length--;
@@ -114,7 +117,7 @@ simdutf_warn_unused result implementation::base64_to_binary(
     }
   }
   if (length == 0) {
-    if (equalsigns > 0) {
+    if (!ignore_garbage && equalsigns > 0) {
       return {INVALID_BASE64_CHARACTER, equallocation};
     }
     return {SUCCESS, 0};
@@ -122,7 +125,7 @@ simdutf_warn_unused result implementation::base64_to_binary(
   result r = scalar::base64::base64_tail_decode(
       output, input, length, equalsigns, options, last_chunk_options);
   if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0) {
+      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
     // additional checks
     if ((r.count % 3 == 0) || ((r.count % 3) + 1 + equalsigns != 4)) {
       return {INVALID_BASE64_CHARACTER, equallocation};
@@ -134,6 +137,9 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage);
   while (length > 0 &&
          scalar::base64::is_ascii_white_space(input[length - 1])) {
     length--;
@@ -156,7 +162,7 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
     }
   }
   if (length == 0) {
-    if (equalsigns > 0) {
+    if (!ignore_garbage && equalsigns > 0) {
       return {INVALID_BASE64_CHARACTER, equallocation, 0};
     }
     return {SUCCESS, 0, 0};
@@ -164,7 +170,7 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
   full_result r = scalar::base64::base64_tail_decode(
       output, input, length, equalsigns, options, last_chunk_options);
   if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0) {
+      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
     // additional checks
     if ((r.output_count % 3 == 0) ||
         ((r.output_count % 3) + 1 + equalsigns != 4)) {
@@ -182,6 +188,9 @@ simdutf_warn_unused size_t implementation::maximal_binary_length_from_base64(
 simdutf_warn_unused result implementation::base64_to_binary(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage);
   while (length > 0 &&
          scalar::base64::is_ascii_white_space(input[length - 1])) {
     length--;
@@ -204,7 +213,7 @@ simdutf_warn_unused result implementation::base64_to_binary(
     }
   }
   if (length == 0) {
-    if (equalsigns > 0) {
+    if (!ignore_garbage && equalsigns > 0) {
       return {INVALID_BASE64_CHARACTER, equallocation};
     }
     return {SUCCESS, 0};
@@ -212,7 +221,7 @@ simdutf_warn_unused result implementation::base64_to_binary(
   result r = scalar::base64::base64_tail_decode(
       output, input, length, equalsigns, options, last_chunk_options);
   if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0) {
+      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
     // additional checks
     if ((r.count % 3 == 0) || ((r.count % 3) + 1 + equalsigns != 4)) {
       return {INVALID_BASE64_CHARACTER, equallocation};
@@ -224,6 +233,9 @@ simdutf_warn_unused result implementation::base64_to_binary(
 simdutf_warn_unused full_result implementation::base64_to_binary_details(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_options) const noexcept {
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage);
   while (length > 0 &&
          scalar::base64::is_ascii_white_space(input[length - 1])) {
     length--;
@@ -246,7 +258,7 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
     }
   }
   if (length == 0) {
-    if (equalsigns > 0) {
+    if (!ignore_garbage && equalsigns > 0) {
       return {INVALID_BASE64_CHARACTER, equallocation, 0};
     }
     return {SUCCESS, 0, 0};
@@ -254,7 +266,7 @@ simdutf_warn_unused full_result implementation::base64_to_binary_details(
   full_result r = scalar::base64::base64_tail_decode(
       output, input, length, equalsigns, options, last_chunk_options);
   if (last_chunk_options != stop_before_partial &&
-      r.error == error_code::SUCCESS && equalsigns > 0) {
+      r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
     // additional checks
     if ((r.output_count % 3 == 0) ||
         ((r.output_count % 3) + 1 + equalsigns != 4)) {

--- a/src/westmere/sse_base64.cpp
+++ b/src/westmere/sse_base64.cpp
@@ -411,6 +411,9 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                        last_chunk_handling_options last_chunk_options) {
   const uint8_t *to_base64 = base64_url ? tables::base64::to_base64_url_value
                                         : tables::base64::to_base64_value;
+  const bool ignore_garbage =
+      (options == base64_options::base64_url_accept_garbage) ||
+      (options == base64_options::base64_default_accept_garbage);
   size_t equallocation =
       srclen; // location of the first padding character if any
   // skip trailing spaces
@@ -435,7 +438,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     }
   }
   if (srclen == 0) {
-    if (equalsigns > 0) {
+    if (!ignore_garbage && equalsigns > 0) {
       return {INVALID_BASE64_CHARACTER, equallocation, 0};
     }
     return {SUCCESS, 0, 0};
@@ -459,7 +462,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       src += 64;
       uint64_t error = 0;
       uint64_t badcharmask = to_base64_mask<base64_url>(&b, &error);
-      if (error) {
+      if (error && !ignore_garbage) {
         src -= 64;
         size_t error_offset = simdutf_tzcnt_u64(error);
         return {error_code::INVALID_BASE64_CHARACTER,
@@ -507,7 +510,8 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     while ((bufferptr - buffer_start) % 64 != 0 && src < srcend) {
       uint8_t val = to_base64[uint8_t(*src)];
       *bufferptr = char(val);
-      if (!scalar::base64::is_eight_byte(*src) || val > 64) {
+      if ((!scalar::base64::is_eight_byte(*src) || val > 64) &&
+          !ignore_garbage) {
         return {error_code::INVALID_BASE64_CHARACTER, size_t(src - srcinit),
                 size_t(dst - dstinit)};
       }
@@ -553,8 +557,14 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     // backtrack
     int leftover = int(bufferptr - buffer_start);
     while (leftover > 0) {
-      while (to_base64[uint8_t(*(src - 1))] == 64) {
-        src--;
+      if (!ignore_garbage) {
+        while (to_base64[uint8_t(*(src - 1))] == 64) {
+          src--;
+        }
+      } else {
+        while (to_base64[uint8_t(*(src - 1))] >= 64) {
+          src--;
+        }
       }
       src--;
       leftover--;
@@ -571,7 +581,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       r.output_count += size_t(dst - dstinit);
     }
     if (last_chunk_options != stop_before_partial &&
-        r.error == error_code::SUCCESS && equalsigns > 0) {
+        r.error == error_code::SUCCESS && equalsigns > 0 && !ignore_garbage) {
       // additional checks
       if ((r.output_count % 3 == 0) ||
           ((r.output_count % 3) + 1 + equalsigns != 4)) {
@@ -581,7 +591,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
     }
     return r;
   }
-  if (equalsigns > 0) {
+  if (equalsigns > 0 && !ignore_garbage) {
     if ((size_t(dst - dstinit) % 3 == 0) ||
         ((size_t(dst - dstinit) % 3) + 1 + equalsigns != 4)) {
       return {INVALID_BASE64_CHARACTER, equallocation, size_t(dst - dstinit)};

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -61,6 +61,15 @@ template <typename char_type> bool is_space(char_type c) {
   return std::find(space.begin(), space.end(), c) != space.end();
 }
 
+
+template <typename char_type> bool is_non_base64_space(char_type c) {
+  return uint8_t(c) >= 128 || to_base64_value[uint8_t(c)] == 255;
+}
+
+template <typename char_type> bool is_non_base64_url_space(char_type c) {
+  return uint8_t(c) >= 128 || to_base64url_value[uint8_t(c)] == 255;
+}
+
 template <typename char_type>
 size_t add_space(std::vector<char_type> &v, std::mt19937 &gen) {
   const static std::array<char_type, 5> space = {' ', '\t', '\n', '\r', '\f'};
@@ -232,7 +241,7 @@ TEST(roundtrip_base64_with_garbage) {
         if (option ==
             simdutf::last_chunk_handling_options::stop_before_partial) {
           for (size_t i = r.count; i < buffer.size(); i++) {
-            ASSERT_TRUE(is_space(buffer[i]));
+            ASSERT_TRUE(is_non_base64_space(buffer[i]));
           }
         } else {
           ASSERT_EQUAL(r.count, buffer.size());
@@ -289,7 +298,7 @@ TEST(roundtrip_base64_url_with_garbage) {
         if (option ==
             simdutf::last_chunk_handling_options::stop_before_partial) {
           for (size_t i = r.count; i < buffer.size(); i++) {
-            ASSERT_TRUE(is_space(buffer[i]));
+            ASSERT_TRUE(is_non_base64_url_space(buffer[i]));
           }
         } else {
           ASSERT_EQUAL(r.count, buffer.size());

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -61,7 +61,6 @@ template <typename char_type> bool is_space(char_type c) {
   return std::find(space.begin(), space.end(), c) != space.end();
 }
 
-
 template <typename char_type> bool is_non_base64_space(char_type c) {
   return uint8_t(c) >= 128 || to_base64_value[uint8_t(c)] == 255;
 }
@@ -122,7 +121,8 @@ std::vector<char_type> add_simple_spaces(std::vector<char_type> &v,
 }
 
 template <typename char_type>
-size_t add_garbage(std::vector<char_type> &v, std::mt19937 &gen, const uint8_t *table) {
+size_t add_garbage(std::vector<char_type> &v, std::mt19937 &gen,
+                   const uint8_t *table) {
   auto equal_sign = std::find(v.begin(), v.end(), '=');
   size_t len = v.size();
   if (equal_sign != v.end()) {
@@ -196,7 +196,6 @@ TEST(roundtrip_base64_with_spaces) {
   }
 }
 
-
 TEST(roundtrip_base64_with_garbage) {
   for (size_t len = 0; len < 2048; len++) {
     std::vector<char> source(len, 0);
@@ -221,8 +220,8 @@ TEST(roundtrip_base64_with_garbage) {
             simdutf::last_chunk_handling_options::loose,
             simdutf::last_chunk_handling_options::stop_before_partial}) {
         simdutf::result r = implementation.base64_to_binary(
-            buffer.data(), buffer.size(), back.data(), simdutf::base64_default_accept_garbage,
-            option);
+            buffer.data(), buffer.size(), back.data(),
+            simdutf::base64_default_accept_garbage, option);
         ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
         ASSERT_EQUAL(r.count, len);
         ASSERT_TRUE(
@@ -253,7 +252,6 @@ TEST(roundtrip_base64_with_garbage) {
   }
 }
 
-
 TEST(roundtrip_base64_url_with_garbage) {
   for (size_t len = 0; len < 2048; len++) {
     std::vector<char> source(len, 0);
@@ -269,7 +267,7 @@ TEST(roundtrip_base64_url_with_garbage) {
           source.data(), source.size(), buffer.data(), simdutf::base64_url);
       buffer.resize(size);
       for (size_t i = 0; i < 5; i++) {
-        add_garbage(buffer, gen, to_base64_value);
+        add_garbage(buffer, gen, to_base64url_value);
       }
       std::vector<char> back(simdutf::maximal_binary_length_from_base64(
           buffer.data(), buffer.size()));
@@ -278,8 +276,8 @@ TEST(roundtrip_base64_url_with_garbage) {
             simdutf::last_chunk_handling_options::loose,
             simdutf::last_chunk_handling_options::stop_before_partial}) {
         simdutf::result r = implementation.base64_to_binary(
-            buffer.data(), buffer.size(), back.data(), simdutf::base64_url_accept_garbage,
-            option);
+            buffer.data(), buffer.size(), back.data(),
+            simdutf::base64_url_accept_garbage, option);
         ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
         ASSERT_EQUAL(r.count, len);
         ASSERT_TRUE(
@@ -309,7 +307,6 @@ TEST(roundtrip_base64_url_with_garbage) {
     }
   }
 }
-
 
 TEST(roundtrip_base64_with_lots_of_spaces) {
   for (size_t len = 0; len < 2048; len++) {
@@ -1884,7 +1881,6 @@ TEST(roundtrip_base64_16_with_spaces) {
   }
 }
 
-
 TEST(roundtrip_base64_16_with_garbage) {
   for (size_t len = 0; len < 2048; len++) {
     std::vector<char> source(len, 0);
@@ -1911,7 +1907,8 @@ TEST(roundtrip_base64_16_with_garbage) {
       }
       ASSERT_EQUAL(size, implementation.base64_length_from_binary(len));
       simdutf::result r = implementation.base64_to_binary(
-          buffer16.data(), buffer16.size(), back.data(), simdutf::base64_default_accept_garbage);
+          buffer16.data(), buffer16.size(), back.data(),
+          simdutf::base64_default_accept_garbage);
       ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
       ASSERT_EQUAL(r.count, len);
       if (back != source) {
@@ -1932,7 +1929,6 @@ TEST(roundtrip_base64_16_with_garbage) {
   }
 }
 
-
 TEST(roundtrip_base64_url_16_with_garbage) {
   for (size_t len = 0; len < 2048; len++) {
     std::vector<char> source(len, 0);
@@ -1951,15 +1947,17 @@ TEST(roundtrip_base64_url_16_with_garbage) {
           source.data(), source.size(), buffer.data(), simdutf::base64_url);
       buffer.resize(size);
       for (size_t i = 0; i < 5; i++) {
-        add_garbage(buffer, gen, to_base64_value);
+        add_garbage(buffer, gen, to_base64url_value);
       }
       buffer16.resize(buffer.size());
       for (size_t i = 0; i < buffer.size(); i++) {
         buffer16[i] = buffer[i];
       }
-      ASSERT_EQUAL(size, implementation.base64_length_from_binary(len));
+      ASSERT_EQUAL(size, implementation.base64_length_from_binary(
+                             len, simdutf::base64_url));
       simdutf::result r = implementation.base64_to_binary(
-          buffer16.data(), buffer16.size(), back.data(), simdutf::base64_url_accept_garbage);
+          buffer16.data(), buffer16.size(), back.data(),
+          simdutf::base64_url_accept_garbage);
       ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
       ASSERT_EQUAL(r.count, len);
       if (back != source) {

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 
 #include <memory>
+#include <sys/types.h>
 #include <tests/helpers/random_int.h>
 #include <tests/helpers/test.h>
 
@@ -112,7 +113,7 @@ std::vector<char_type> add_simple_spaces(std::vector<char_type> &v,
 }
 
 template <typename char_type>
-size_t add_garbage(std::vector<char_type> &v, std::mt19937 &gen) {
+size_t add_garbage(std::vector<char_type> &v, std::mt19937 &gen, const uint8_t *table) {
   auto equal_sign = std::find(v.begin(), v.end(), '=');
   size_t len = v.size();
   if (equal_sign != v.end()) {
@@ -123,7 +124,7 @@ size_t add_garbage(std::vector<char_type> &v, std::mt19937 &gen) {
   std::uniform_int_distribution<int> char_dist(
       0, (1 << (sizeof(char_type) * 8)) - 1);
   uint8_t c = char_dist(gen);
-  while (uint8_t(c) == c && to_base64_value[uint8_t(c)] != 255) {
+  while (uint8_t(c) == c && table[uint8_t(c)] != 255) {
     c = char_dist(gen);
   }
   v.insert(v.begin() + i, c);
@@ -185,6 +186,121 @@ TEST(roundtrip_base64_with_spaces) {
     }
   }
 }
+
+
+TEST(roundtrip_base64_with_garbage) {
+  for (size_t len = 0; len < 2048; len++) {
+    std::vector<char> source(len, 0);
+    std::vector<char> buffer;
+    buffer.resize(implementation.base64_length_from_binary(len));
+    std::mt19937 gen((std::mt19937::result_type)(seed));
+    std::uniform_int_distribution<int> byte_generator{0, 255};
+    for (size_t trial = 0; trial < 10; trial++) {
+      for (size_t i = 0; i < len; i++) {
+        source[i] = byte_generator(gen);
+      }
+      size_t size = implementation.binary_to_base64(
+          source.data(), source.size(), buffer.data());
+      buffer.resize(size);
+      for (size_t i = 0; i < 5; i++) {
+        add_garbage(buffer, gen, to_base64_value);
+      }
+      std::vector<char> back(simdutf::maximal_binary_length_from_base64(
+          buffer.data(), buffer.size()));
+      for (auto option :
+           {simdutf::last_chunk_handling_options::strict,
+            simdutf::last_chunk_handling_options::loose,
+            simdutf::last_chunk_handling_options::stop_before_partial}) {
+        simdutf::result r = implementation.base64_to_binary(
+            buffer.data(), buffer.size(), back.data(), simdutf::base64_default_accept_garbage,
+            option);
+        ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
+        ASSERT_EQUAL(r.count, len);
+        ASSERT_TRUE(
+            std::equal(back.begin(), back.begin() + len, source.begin()));
+      }
+      for (auto option :
+           {simdutf::last_chunk_handling_options::strict,
+            simdutf::last_chunk_handling_options::loose,
+            simdutf::last_chunk_handling_options::stop_before_partial}) {
+        size_t back_length = back.size();
+        auto r = simdutf::base64_to_binary_safe(
+            buffer.data(), buffer.size(), back.data(), back_length,
+            simdutf::base64_default_accept_garbage, option);
+
+        ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
+        if (option ==
+            simdutf::last_chunk_handling_options::stop_before_partial) {
+          for (size_t i = r.count; i < buffer.size(); i++) {
+            ASSERT_TRUE(is_space(buffer[i]));
+          }
+        } else {
+          ASSERT_EQUAL(r.count, buffer.size());
+        }
+        ASSERT_TRUE(std::equal(back.begin(), back.begin() + back_length,
+                               source.begin()));
+      }
+    }
+  }
+}
+
+
+TEST(roundtrip_base64_url_with_garbage) {
+  for (size_t len = 0; len < 2048; len++) {
+    std::vector<char> source(len, 0);
+    std::vector<char> buffer;
+    buffer.resize(implementation.base64_length_from_binary(len));
+    std::mt19937 gen((std::mt19937::result_type)(seed));
+    std::uniform_int_distribution<int> byte_generator{0, 255};
+    for (size_t trial = 0; trial < 10; trial++) {
+      for (size_t i = 0; i < len; i++) {
+        source[i] = byte_generator(gen);
+      }
+      size_t size = implementation.binary_to_base64(
+          source.data(), source.size(), buffer.data(), simdutf::base64_url);
+      buffer.resize(size);
+      for (size_t i = 0; i < 5; i++) {
+        add_garbage(buffer, gen, to_base64_value);
+      }
+      std::vector<char> back(simdutf::maximal_binary_length_from_base64(
+          buffer.data(), buffer.size()));
+      for (auto option :
+           {simdutf::last_chunk_handling_options::strict,
+            simdutf::last_chunk_handling_options::loose,
+            simdutf::last_chunk_handling_options::stop_before_partial}) {
+        simdutf::result r = implementation.base64_to_binary(
+            buffer.data(), buffer.size(), back.data(), simdutf::base64_url_accept_garbage,
+            option);
+        ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
+        ASSERT_EQUAL(r.count, len);
+        ASSERT_TRUE(
+            std::equal(back.begin(), back.begin() + len, source.begin()));
+      }
+      for (auto option :
+           {simdutf::last_chunk_handling_options::strict,
+            simdutf::last_chunk_handling_options::loose,
+            simdutf::last_chunk_handling_options::stop_before_partial}) {
+        size_t back_length = back.size();
+        auto r = simdutf::base64_to_binary_safe(
+            buffer.data(), buffer.size(), back.data(), back_length,
+            simdutf::base64_url_accept_garbage, option);
+
+        ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
+        if (option ==
+            simdutf::last_chunk_handling_options::stop_before_partial) {
+          for (size_t i = r.count; i < buffer.size(); i++) {
+            ASSERT_TRUE(is_space(buffer[i]));
+          }
+        } else {
+          ASSERT_EQUAL(r.count, buffer.size());
+        }
+        ASSERT_TRUE(std::equal(back.begin(), back.begin() + back_length,
+                               source.begin()));
+      }
+    }
+  }
+}
+
 
 TEST(roundtrip_base64_with_lots_of_spaces) {
   for (size_t len = 0; len < 2048; len++) {
@@ -1621,7 +1737,7 @@ TEST(doomed_base64_roundtrip) {
       size_t size = implementation.binary_to_base64(
           source.data(), source.size(), buffer.data());
       buffer.resize(size);
-      size_t location = add_garbage(buffer, gen);
+      size_t location = add_garbage(buffer, gen, to_base64_value);
       std::vector<char> back(simdutf::maximal_binary_length_from_base64(
           buffer.data(), buffer.size()));
       simdutf::result r =
@@ -1739,6 +1855,102 @@ TEST(roundtrip_base64_16_with_spaces) {
       ASSERT_EQUAL(size, implementation.base64_length_from_binary(len));
       simdutf::result r = implementation.base64_to_binary(
           buffer16.data(), buffer16.size(), back.data());
+      ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
+      ASSERT_EQUAL(r.count, len);
+      if (back != source) {
+        printf("=====input size %zu\n", len);
+        for (size_t i = 0; i < len; i++) {
+          if (back[i] != source[i]) {
+            printf("Mismatch at position %zu trial %zu\n", i, trial);
+          }
+          printf("%zu: %02x %02x\n", i, uint8_t(back[i]), uint8_t(source[i]));
+        }
+        printf("=====base64 size %zu\n", size);
+        for (size_t i = 0; i < size; i++) {
+          printf("%zu: %02x %c\n", i, uint8_t(buffer[i]), buffer[i]);
+        }
+      }
+      ASSERT_TRUE(back == source);
+    }
+  }
+}
+
+
+TEST(roundtrip_base64_16_with_garbage) {
+  for (size_t len = 0; len < 2048; len++) {
+    std::vector<char> source(len, 0);
+    std::vector<char> buffer;
+    std::vector<char16_t> buffer16;
+
+    buffer.resize(implementation.base64_length_from_binary(len));
+    std::vector<char> back(len);
+    std::mt19937 gen((std::mt19937::result_type)(seed));
+    std::uniform_int_distribution<int> byte_generator{0, 255};
+    for (size_t trial = 0; trial < 10; trial++) {
+      for (size_t i = 0; i < len; i++) {
+        source[i] = byte_generator(gen);
+      }
+      size_t size = implementation.binary_to_base64(
+          source.data(), source.size(), buffer.data());
+      buffer.resize(size);
+      for (size_t i = 0; i < 5; i++) {
+        add_garbage(buffer, gen, to_base64_value);
+      }
+      buffer16.resize(buffer.size());
+      for (size_t i = 0; i < buffer.size(); i++) {
+        buffer16[i] = buffer[i];
+      }
+      ASSERT_EQUAL(size, implementation.base64_length_from_binary(len));
+      simdutf::result r = implementation.base64_to_binary(
+          buffer16.data(), buffer16.size(), back.data(), simdutf::base64_default_accept_garbage);
+      ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
+      ASSERT_EQUAL(r.count, len);
+      if (back != source) {
+        printf("=====input size %zu\n", len);
+        for (size_t i = 0; i < len; i++) {
+          if (back[i] != source[i]) {
+            printf("Mismatch at position %zu trial %zu\n", i, trial);
+          }
+          printf("%zu: %02x %02x\n", i, uint8_t(back[i]), uint8_t(source[i]));
+        }
+        printf("=====base64 size %zu\n", size);
+        for (size_t i = 0; i < size; i++) {
+          printf("%zu: %02x %c\n", i, uint8_t(buffer[i]), buffer[i]);
+        }
+      }
+      ASSERT_TRUE(back == source);
+    }
+  }
+}
+
+
+TEST(roundtrip_base64_url_16_with_garbage) {
+  for (size_t len = 0; len < 2048; len++) {
+    std::vector<char> source(len, 0);
+    std::vector<char> buffer;
+    std::vector<char16_t> buffer16;
+
+    buffer.resize(implementation.base64_length_from_binary(len));
+    std::vector<char> back(len);
+    std::mt19937 gen((std::mt19937::result_type)(seed));
+    std::uniform_int_distribution<int> byte_generator{0, 255};
+    for (size_t trial = 0; trial < 10; trial++) {
+      for (size_t i = 0; i < len; i++) {
+        source[i] = byte_generator(gen);
+      }
+      size_t size = implementation.binary_to_base64(
+          source.data(), source.size(), buffer.data(), simdutf::base64_url);
+      buffer.resize(size);
+      for (size_t i = 0; i < 5; i++) {
+        add_garbage(buffer, gen, to_base64_value);
+      }
+      buffer16.resize(buffer.size());
+      for (size_t i = 0; i < buffer.size(); i++) {
+        buffer16[i] = buffer[i];
+      }
+      ASSERT_EQUAL(size, implementation.base64_length_from_binary(len));
+      simdutf::result r = implementation.base64_to_binary(
+          buffer16.data(), buffer16.size(), back.data(), simdutf::base64_url_accept_garbage);
       ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
       ASSERT_EQUAL(r.count, len);
       if (back != source) {


### PR DESCRIPTION
Adds the functionality described in #585 
Includes the unit tests written in #600 and the extra couple lines of fixes described there.
The tests are passing locally (on x86_64), rest architectures might need fixes if failures are detected.