### PR TITLE
adding guards for LLVM optimization

### DIFF
--- a/src/scalar/base64.h
+++ b/src/scalar/base64.h
@@ -80,6 +80,7 @@ base64_tail_decode(char *dst, const char_type *src, size_t length,
     }
     idx = 0;
     // we need at least four characters.
+#ifdef __clang__
     // If possible, we read four characters at a time. (It is an optimization.)
     if (ignore_garbage && src + 4 <= srcend) {
       char_type c0 = src[0];
@@ -100,6 +101,7 @@ base64_tail_decode(char *dst, const char_type *src, size_t length,
       idx += (is_eight_byte(c3) && code3 <= 63);
       src += 4;
     }
+#endif
     while ((idx < 4) && (src < srcend)) {
       char_type c = *src;
       uint8_t code = to_base64[uint8_t(c)];
@@ -254,6 +256,7 @@ result base64_tail_decode_safe(
     idx = 0;
     const char_type *srccur = src;
     // We need at least four characters.
+#ifdef  __clang__
     // If possible, we read four characters at a time. (It is an optimization.)
     if (ignore_garbage && src + 4 <= srcend) {
       char_type c0 = src[0];
@@ -274,6 +277,7 @@ result base64_tail_decode_safe(
       idx += (is_eight_byte(c3) && code3 <= 63);
       src += 4;
     }
+#endif
     while (idx < 4 && src < srcend) {
       char_type c = *src;
       uint8_t code = to_base64[uint8_t(c)];

--- a/src/scalar/base64.h
+++ b/src/scalar/base64.h
@@ -256,7 +256,7 @@ result base64_tail_decode_safe(
     idx = 0;
     const char_type *srccur = src;
     // We need at least four characters.
-#ifdef  __clang__
+#ifdef __clang__
     // If possible, we read four characters at a time. (It is an optimization.)
     if (ignore_garbage && src + 4 <= srcend) {
       char_type c0 = src[0];


### PR DESCRIPTION

# Main branch


GCC 12, Intel Ice Lake

```
$  ./build/benchmarks/base64/benchmark_base64 -d ../base64data/dns/*.txt
# current system detected as icelake.
# loading files: .
# I cannot decode all the base64 data as single line, so I will try to split the data.
# Turned 1 inputs into 100000 inputs.
# volume: 35000000 bytes
# max length: 350 bytes
# number of inputs: 100000
# decode
memcpy                                   :  21.68 GB/s   2.61 GHz   0.12 c/b   0.21 i/b   1.73 i/c
# the base64 data contains spaces, so we cannot use straigth libbase64::base64_decode directly
libbase64_space_decode                   :   1.06 GB/s   3.19 GHz   2.99 c/b  14.72 i/b   4.92 i/c
openssl3.3.x                             :   0.40 GB/s   3.19 GHz   7.95 c/b  37.67 i/b   4.74 i/c
node                                     :   1.24 GB/s   3.19 GHz   2.58 c/b  13.02 i/b   5.05 i/c
simdutf::icelake                         :   8.39 GB/s   3.09 GHz   0.37 c/b   1.17 i/b   3.18 i/c
simdutf::icelake (accept garbage)        :  10.09 GB/s   3.09 GHz   0.31 c/b   0.85 i/b   2.78 i/c
simdutf::haswell                         :   4.38 GB/s   3.19 GHz   0.73 c/b   3.27 i/b   4.49 i/c
simdutf::haswell (accept garbage)        :   4.00 GB/s   3.19 GHz   0.80 c/b   2.95 i/b   3.70 i/c
simdutf::westmere                        :   1.81 GB/s   3.19 GHz   1.76 c/b   4.31 i/b   2.45 i/c
simdutf::westmere (accept garbage)       :   1.81 GB/s   3.19 GHz   1.76 c/b   3.87 i/b   2.20 i/c
simdutf::fallback                        :   1.21 GB/s   3.19 GHz   2.64 c/b   9.36 i/b   3.55 i/c
simdutf::fallback (accept garbage)       :   1.16 GB/s   3.19 GHz   2.75 c/b   9.00 i/b   3.27 i/c
```




LLVM 16, Intel Ice Lake

```
$ ./buildnewclang/benchmarks/base64/benchmark_base64 -d ../base64data/dns/*.txt
# current system detected as icelake.
# loading files: .
# I cannot decode all the base64 data as single line, so I will try to split the data.
# Turned 1 inputs into 100000 inputs.
# volume: 35000000 bytes
# max length: 350 bytes
# number of inputs: 100000
# decode
memcpy                                   :  21.42 GB/s   2.71 GHz   0.13 c/b   0.21 i/b   1.65 i/c
# the base64 data contains spaces, so we cannot use straigth libbase64::base64_decode directly
libbase64_space_decode                   :   1.11 GB/s   3.19 GHz   2.88 c/b  15.01 i/b   5.22 i/c
openssl3.3.x                             :   0.35 GB/s   3.19 GHz   9.11 c/b  41.75 i/b   4.58 i/c
node                                     :   1.19 GB/s   3.19 GHz   2.67 c/b  13.49 i/b   5.05 i/c
simdutf::icelake                         :   7.77 GB/s   3.09 GHz   0.40 c/b   1.13 i/b   2.84 i/c
simdutf::icelake (accept garbage)        :  10.15 GB/s   3.09 GHz   0.30 c/b   0.81 i/b   2.68 i/c
simdutf::haswell                         :   4.64 GB/s   3.19 GHz   0.69 c/b   3.23 i/b   4.70 i/c
simdutf::haswell (accept garbage)        :   5.35 GB/s   3.19 GHz   0.60 c/b   2.68 i/b   4.50 i/c
simdutf::westmere                        :   3.68 GB/s   3.19 GHz   0.86 c/b   4.42 i/b   5.11 i/c
simdutf::westmere (accept garbage)       :   4.37 GB/s   3.19 GHz   0.73 c/b   3.46 i/b   4.74 i/c
simdutf::fallback                        :   2.33 GB/s   3.19 GHz   1.37 c/b   6.55 i/b   4.78 i/c
simdutf::fallback (accept garbage)       :   2.45 GB/s   3.19 GHz   1.30 c/b   6.02 i/b   4.63 i/c
```


# This PR


GCC 12, Intel Ice Lake

```
$  ./build/benchmarks/base64/benchmark_base64 -d ../base64data/dns/*.txt
# current system detected as icelake.
# loading files: .
# I cannot decode all the base64 data as single line, so I will try to split the data.
# Turned 1 inputs into 100000 inputs.
# volume: 35000000 bytes
# max length: 350 bytes
# number of inputs: 100000
# decode
memcpy                                   :  19.17 GB/s   2.13 GHz   0.11 c/b   0.21 i/b   1.88 i/c
# the base64 data contains spaces, so we cannot use straigth libbase64::base64_decode directly
libbase64_space_decode                   :   1.06 GB/s   3.19 GHz   2.99 c/b  14.72 i/b   4.92 i/c
openssl3.3.x                             :   0.40 GB/s   3.19 GHz   7.96 c/b  37.67 i/b   4.73 i/c
node                                     :   1.21 GB/s   3.19 GHz   2.63 c/b  13.02 i/b   4.95 i/c
simdutf::icelake                         :   8.42 GB/s   3.09 GHz   0.37 c/b   1.17 i/b   3.19 i/c
simdutf::icelake (accept garbage)        :  10.07 GB/s   3.09 GHz   0.31 c/b   0.85 i/b   2.78 i/c
simdutf::haswell                         :   4.20 GB/s   3.19 GHz   0.76 c/b   3.13 i/b   4.13 i/c
simdutf::haswell (accept garbage)        :   4.54 GB/s   3.19 GHz   0.70 c/b   2.89 i/b   4.12 i/c
simdutf::westmere                        :   1.84 GB/s   3.19 GHz   1.74 c/b   4.18 i/b   2.41 i/c
simdutf::westmere (accept garbage)       :   1.80 GB/s   3.19 GHz   1.77 c/b   3.88 i/b   2.20 i/c
simdutf::fallback                        :   1.71 GB/s   3.19 GHz   1.86 c/b   7.37 i/b   3.96 i/c
simdutf::fallback (accept garbage)       :   1.72 GB/s   3.19 GHz   1.85 c/b   7.32 i/b   3.95 i/c
```




LLVM 16, Intel Ice Lake

```
$ ./buildnewclang/benchmarks/base64/benchmark_base64 -d ../base64data/dns/*.txt
# current system detected as icelake.
# loading files: .
# I cannot decode all the base64 data as single line, so I will try to split the data.
# Turned 1 inputs into 100000 inputs.
# volume: 35000000 bytes
# max length: 350 bytes
# number of inputs: 100000
# decode
memcpy                                   :  23.15 GB/s   2.95 GHz   0.13 c/b   0.21 i/b   1.64 i/c
# the base64 data contains spaces, so we cannot use straigth libbase64::base64_decode directly
libbase64_space_decode                   :   1.11 GB/s   3.19 GHz   2.87 c/b  15.01 i/b   5.22 i/c
openssl3.3.x                             :   0.35 GB/s   3.18 GHz   9.11 c/b  41.75 i/b   4.58 i/c
node                                     :   1.19 GB/s   3.18 GHz   2.68 c/b  13.49 i/b   5.04 i/c
simdutf::icelake                         :   8.58 GB/s   3.09 GHz   0.36 c/b   1.13 i/b   3.14 i/c
simdutf::icelake (accept garbage)        :  10.70 GB/s   3.08 GHz   0.29 c/b   0.81 i/b   2.83 i/c
simdutf::haswell                         :   4.65 GB/s   3.19 GHz   0.69 c/b   3.23 i/b   4.71 i/c
simdutf::haswell (accept garbage)        :   5.41 GB/s   3.18 GHz   0.59 c/b   2.68 i/b   4.55 i/c
simdutf::westmere                        :   3.69 GB/s   3.19 GHz   0.86 c/b   4.42 i/b   5.11 i/c
simdutf::westmere (accept garbage)       :   4.38 GB/s   3.19 GHz   0.73 c/b   3.46 i/b   4.75 i/c
simdutf::fallback                        :   2.33 GB/s   3.18 GHz   1.37 c/b   6.55 i/b   4.79 i/c
simdutf::fallback (accept garbage)       :   2.45 GB/s   3.19 GHz   1.30 c/b   6.02 i/b   4.63 i/c
```


