### PR TITLE
add test to demonstrate base64_to_binary icelake difference

### DIFF
--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -565,6 +565,16 @@ TEST(issue_single_bad16) {
   ASSERT_EQUAL(r.count, 0);
 }
 
+TEST(issue_FIXME) {
+  const std::vector<char> data{' ', '=', '='};
+  std::vector<char> output(100);
+  const auto r =
+      implementation.base64_to_binary(data.data(), data.size(), output.data(),
+                                      simdutf::base64_default, simdutf::strict);
+  ASSERT_EQUAL(r.error, simdutf::error_code::BASE64_INPUT_REMAINDER);
+  ASSERT_EQUAL(r.count, 0);
+}
+
 TEST(issue_kkk) {
   std::vector<char> data = {
       0x20, 0x20, 0x20, 0x20, 0x20, 0x4b, 0x4b, 0x4b, 0x4b, 0x4b, 0x4b, 0x4b,


### PR DESCRIPTION
this test case was found by the fuzzer.

on icelake, it returns: count=1, error=INVALID_BASE64_CHARACTER

on the other x86 implementations it returns: count=0, error=BASE64_INPUT_REMAINDER

