### PR TITLE
fix some compiler warnings

### DIFF
--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -761,7 +761,7 @@ TEST(base64_decode_webkit_like_but_random_more_cases) {
       for (size_t i = 0; i < len; i++) {
         source[i] = byte_generator(gen);
       }
-      size_t size = implementation.binary_to_base64(
+      [[maybe_unused]] const size_t size = implementation.binary_to_base64(
           source.data(), source.size(), buffer.data());
       for (size_t removed = 1; !buffer.empty() && removed <= 2; removed++) {
         buffer.pop_back();
@@ -818,7 +818,7 @@ TEST(base64_decode_webkit_like_but_random_with_spaces_more_cases) {
       for (size_t i = 0; i < len; i++) {
         source[i] = byte_generator(gen);
       }
-      size_t size = implementation.binary_to_base64(
+      [[maybe_unused]] const size_t size = implementation.binary_to_base64(
           source.data(), source.size(), buffer.data());
       buffer = add_simple_spaces(buffer, gen, 5 + len / 4);
       auto is_space = [](char c) {

--- a/tests/basic_fuzzer.cpp
+++ b/tests/basic_fuzzer.cpp
@@ -42,7 +42,7 @@ void __asan_on_error() {
   log.open("fuzzer_log.txt", std::ios::app);
   const size_t buf_size = 4 * MAX_SIZE + 3;
   char buffer[buf_size];
-  for (int i = 0; i < input.size(); i++) {
+  for (unsigned int i = 0; i < input.size(); i++) {
     SIMDUTF_PUSH_DISABLE_WARNINGS
     SIMDUTF_DISABLE_DEPRECATED_WARNING
     sprintf(buffer + 4 * i + 1, "\\x%02x", input[i]);

--- a/tests/convert_latin1_to_utf16be_tests.cpp
+++ b/tests/convert_latin1_to_utf16be_tests.cpp
@@ -27,7 +27,7 @@ TEST_LOOP(trials, convert_all_latin) {
     implementation.change_endianness_utf16(utf16be.data(), size, utf16le);
     return len;
   };
-  auto size_procedure = [&implementation](const char *latin1,
+  auto size_procedure = [&implementation]([[maybe_unused]] const char *latin1,
                                           size_t size) -> size_t {
     return implementation.utf16_length_from_latin1(size);
   };

--- a/tests/convert_latin1_to_utf16le_tests.cpp
+++ b/tests/convert_latin1_to_utf16le_tests.cpp
@@ -22,7 +22,7 @@ TEST_LOOP(trials, convert_all_latin) {
                                      char16_t *utf16) -> size_t {
     return implementation.convert_latin1_to_utf16le(latin1, size, utf16);
   };
-  auto size_procedure = [&implementation](const char *latin1,
+  auto size_procedure = [&implementation]([[maybe_unused]] const char *latin1,
                                           size_t size) -> size_t {
     return implementation.utf16_length_from_latin1(size);
   };

--- a/tests/convert_latin1_to_utf32_tests.cpp
+++ b/tests/convert_latin1_to_utf32_tests.cpp
@@ -18,7 +18,7 @@ TEST_LOOP(trials, convert_all_latin1) {
                                      char32_t *utf32) -> size_t {
     return implementation.convert_latin1_to_utf32(latin1, size, utf32);
   };
-  auto size_procedure = [&implementation](const char *latin1,
+  auto size_procedure = [&implementation]([[maybe_unused]] const char *latin1,
                                           size_t size) -> size_t {
     return implementation.utf32_length_from_latin1(size);
   };

--- a/tests/convert_utf16be_to_latin1_tests.cpp
+++ b/tests/convert_utf16be_to_latin1_tests.cpp
@@ -53,8 +53,9 @@ TEST_LOOP(trials, convert_2_UTF16_bytes) {
     return implementation.convert_utf16be_to_latin1(utf16be.data(), size,
                                                     latin1);
   };
-  auto size_procedure = [&implementation](const char16_t *utf16,
-                                          size_t size) -> size_t {
+  auto size_procedure =
+      [&implementation]([[maybe_unused]] const char16_t *utf16,
+                        size_t size) -> size_t {
     return implementation.latin1_length_from_utf16(size);
   };
   for (size_t size : input_size) {

--- a/tests/convert_utf16be_to_latin1_tests_with_errors.cpp
+++ b/tests/convert_utf16be_to_latin1_tests_with_errors.cpp
@@ -72,8 +72,9 @@ TEST_LOOP(trials, convert_2_UTF16_bytes) {
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
     return res.count;
   };
-  auto size_procedure = [&implementation](const char16_t *utf16,
-                                          size_t size) -> size_t {
+  auto size_procedure =
+      [&implementation]([[maybe_unused]] const char16_t *utf16,
+                        size_t size) -> size_t {
     return implementation.latin1_length_from_utf16(size);
   };
   for (size_t size : input_size) {

--- a/tests/convert_utf16le_to_latin1_tests.cpp
+++ b/tests/convert_utf16le_to_latin1_tests.cpp
@@ -46,8 +46,9 @@ TEST_LOOP(trials, convert_randoms) {
                                      char *latin1) -> size_t {
     return implementation.convert_utf16le_to_latin1(utf16, size, latin1);
   };
-  auto size_procedure = [&implementation](const char16_t *utf16,
-                                          size_t size) -> size_t {
+  auto size_procedure =
+      [&implementation]([[maybe_unused]] const char16_t *utf16,
+                        size_t size) -> size_t {
     return implementation.latin1_length_from_utf16(size);
   };
   for (size_t size : input_size) {
@@ -65,8 +66,9 @@ TEST_LOOP(trials, convert_1_or_2_UTF16_bytes) {
                                      char *latin1) -> size_t {
     return implementation.convert_utf16le_to_latin1(utf16, size, latin1);
   };
-  auto size_procedure = [&implementation](const char16_t *utf16,
-                                          size_t size) -> size_t {
+  auto size_procedure =
+      [&implementation]([[maybe_unused]] const char16_t *utf16,
+                        size_t size) -> size_t {
     return implementation.latin1_length_from_utf16(size);
   };
   for (size_t size : input_size) {

--- a/tests/convert_utf16le_to_latin1_tests_with_errors.cpp
+++ b/tests/convert_utf16le_to_latin1_tests_with_errors.cpp
@@ -87,8 +87,9 @@ TEST_LOOP(trials, convert_2_UTF16_bytes) {
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
     return res.count;
   };
-  auto size_procedure = [&implementation](const char16_t *utf16,
-                                          size_t size) -> size_t {
+  auto size_procedure =
+      [&implementation]([[maybe_unused]] const char16_t *utf16,
+                        size_t size) -> size_t {
     return implementation.latin1_length_from_utf16(size);
   };
   for (size_t size : input_size) {

--- a/tests/convert_utf32_to_utf16be_with_errors_tests.cpp
+++ b/tests/convert_utf32_to_utf16be_with_errors_tests.cpp
@@ -95,8 +95,9 @@ TEST(convert_fails_if_there_is_surrogate) {
 
   for (char32_t surrogate = 0xd800; surrogate <= 0xdfff; surrogate++) {
     for (size_t i = 0; i < size; i++) {
-      auto procedure = [&implementation, &i](const char32_t *utf32, size_t size,
-                                             char16_t *utf16le) -> size_t {
+      auto procedure = [&implementation,
+                        &i](const char32_t *utf32, size_t size,
+                            [[maybe_unused]] char16_t *utf16le) -> size_t {
         std::vector<char16_t> utf16be(2 * size);
         simdutf::result res =
             implementation.convert_utf32_to_utf16be_with_errors(utf32, size,
@@ -123,8 +124,9 @@ TEST(convert_fails_if_input_too_large) {
   for (size_t j = 0; j < 1000; j++) {
     uint32_t wrong_value = generator();
     for (size_t i = 0; i < size; i++) {
-      auto procedure = [&implementation, &i](const char32_t *utf32, size_t size,
-                                             char16_t *utf16le) -> size_t {
+      auto procedure = [&implementation,
+                        &i](const char32_t *utf32, size_t size,
+                            [[maybe_unused]] char16_t *utf16le) -> size_t {
         std::vector<char16_t> utf16be(2 * size);
         simdutf::result res =
             implementation.convert_utf32_to_utf16be_with_errors(utf32, size,

--- a/tests/convert_utf8_to_latin1_with_errors_tests.cpp
+++ b/tests/convert_utf8_to_latin1_with_errors_tests.cpp
@@ -372,7 +372,7 @@ TEST_LOOP(trials, too_large_input) {
 
   simdutf::tests::helpers::RandomIntRanges random({{0xff, 0x10FFFF}}, seed);
   transcode_utf8_to_latin1_test_base test(random, fix_size);
-  for (int i = 0; i < fix_size; i++) {
+  for (unsigned int i = 0; i < fix_size; i++) {
     auto byte_number = getUtf8SequenceLength(test.input_utf8[i]);
     if (byte_number != 1) {
 
@@ -403,7 +403,7 @@ TEST_LOOP(trials, header_bits_error) {
   simdutf::tests::helpers::RandomIntRanges random({{0x0000, 0xff}}, seed);
   transcode_utf8_to_latin1_test_base test(random, fix_size);
 
-  for (int i = 0; i < fix_size; i++) {
+  for (unsigned int i = 0; i < fix_size; i++) {
 
     if ((test.input_utf8[i] & 0b11000000) !=
         0b10000000) { // Only process leading bytes
@@ -426,8 +426,8 @@ TEST_LOOP(trials, header_bits_error) {
 TEST_LOOP(trials, too_short_error) {
   simdutf::tests::helpers::RandomIntRanges random({{0x00, 0xff}}, seed);
   transcode_utf8_to_latin1_test_base test(random, fix_size);
-  int leading_byte_pos = 0;
-  for (int i = 0; i < fix_size; i++) {
+  unsigned int leading_byte_pos = 0;
+  for (unsigned int i = 0; i < fix_size; i++) {
 
     if ((test.input_utf8[i] & 0b11000000) ==
         0b10000000) { // Only process continuation bytes by making them leading
@@ -459,7 +459,7 @@ TEST_LOOP(trials, too_long_error) {
       seed); // in this context, conversion to latin 1 will register everything
              // past 0xff as a TOO_LARGE error
   transcode_utf8_to_latin1_test_base test(random, fix_size);
-  for (int i = 1; i < fix_size; i++) {
+  for (unsigned int i = 1; i < fix_size; i++) {
     if (((test.input_utf8[i] & 0b11000000) !=
          0b10000000)) { // Only process leading bytes by making them
                         // continuation bytes
@@ -482,7 +482,7 @@ TEST_LOOP(trials, too_long_error) {
 TEST_LOOP(trials, overlong_error) {
   simdutf::tests::helpers::RandomIntRanges random({{0x00, 0xff}}, seed);
   transcode_utf8_to_latin1_test_base test(random, fix_size);
-  for (int i = 1; i < fix_size; i++) {
+  for (unsigned int i = 1; i < fix_size; i++) {
     if ((unsigned char)test.input_utf8[i] >=
         (unsigned char)0b11000000) { // Only non-ASCII leading bytes can be
                                      // overlong

--- a/tests/convert_utf8_to_utf16be_with_errors_tests.cpp
+++ b/tests/convert_utf8_to_utf16be_with_errors_tests.cpp
@@ -240,7 +240,7 @@ TEST_LOOP(trials, header_bits_error) {
 
   transcode_utf8_to_utf16_test_base test(random, fix_size);
 
-  for (int i = 0; i < fix_size; i++) {
+  for (unsigned int i = 0; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11000000) !=
         0b10000000) { // Only process leading bytes
       auto procedure = [&implementation,
@@ -268,8 +268,8 @@ TEST_LOOP(trials, too_short_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
   transcode_utf8_to_utf16_test_base test(random, fix_size);
-  int leading_byte_pos = 0;
-  for (int i = 0; i < fix_size; i++) {
+  unsigned int leading_byte_pos = 0;
+  for (unsigned int i = 0; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11000000) ==
         0b10000000) { // Only process continuation bytes by making them leading
                       // bytes
@@ -300,7 +300,7 @@ TEST_LOOP(trials, too_long_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
   transcode_utf8_to_utf16_test_base test(random, fix_size);
-  for (int i = 1; i < fix_size; i++) {
+  for (unsigned int i = 1; i < fix_size; i++) {
     if (((test.input_utf8[i] & 0b11000000) !=
          0b10000000)) { // Only process leading bytes by making them
                         // continuation bytes
@@ -329,7 +329,7 @@ TEST_LOOP(trials, overlong_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
   transcode_utf8_to_utf16_test_base test(random, fix_size);
-  for (int i = 1; i < fix_size; i++) {
+  for (unsigned int i = 1; i < fix_size; i++) {
     if ((unsigned char)test.input_utf8[i] >=
         (unsigned char)0b11000000) { // Only non-ASCII leading bytes can be
                                      // overlong
@@ -371,7 +371,7 @@ TEST_LOOP(trials, too_large_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
   transcode_utf8_to_utf16_test_base test(random, fix_size);
-  for (int i = 1; i < fix_size; i++) {
+  for (unsigned int i = 1; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11111000) ==
         0b11110000) { // Can only have too large error in 4-bytes case
       auto procedure = [&implementation,
@@ -401,7 +401,7 @@ TEST_LOOP(trials, surrogate_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
   transcode_utf8_to_utf16_test_base test(random, fix_size);
-  for (int i = 1; i < fix_size; i++) {
+  for (unsigned int i = 1; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11110000) ==
         0b11100000) { // Can only have surrogate error in 3-bytes case
       auto procedure = [&implementation,

--- a/tests/convert_utf8_to_utf16be_with_errors_tests.cpp
+++ b/tests/convert_utf8_to_utf16be_with_errors_tests.cpp
@@ -15,7 +15,6 @@ std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
 using simdutf::tests::helpers::transcode_utf8_to_utf16_test_base;
 
 constexpr size_t trials = 10000;
-constexpr size_t num_trials = 1000;
 constexpr size_t fix_size = 512;
 } // namespace
 TEST(issue_483) {
@@ -244,8 +243,9 @@ TEST_LOOP(trials, header_bits_error) {
   for (int i = 0; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11000000) !=
         0b10000000) { // Only process leading bytes
-      auto procedure = [&implementation, &i](const char *utf8, size_t size,
-                                             char16_t *utf16le) -> size_t {
+      auto procedure = [&implementation,
+                        &i](const char *utf8, size_t size,
+                            [[maybe_unused]] char16_t *utf16le) -> size_t {
         std::vector<char16_t> utf16be(
             2 *
             size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
@@ -273,9 +273,9 @@ TEST_LOOP(trials, too_short_error) {
     if ((test.input_utf8[i] & 0b11000000) ==
         0b10000000) { // Only process continuation bytes by making them leading
                       // bytes
-      auto procedure = [&implementation,
-                        &leading_byte_pos](const char *utf8, size_t size,
-                                           char16_t *utf16le) -> size_t {
+      auto procedure = [&implementation, &leading_byte_pos](
+                           const char *utf8, size_t size,
+                           [[maybe_unused]] char16_t *utf16le) -> size_t {
         std::vector<char16_t> utf16be(
             2 *
             size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
@@ -304,8 +304,9 @@ TEST_LOOP(trials, too_long_error) {
     if (((test.input_utf8[i] & 0b11000000) !=
          0b10000000)) { // Only process leading bytes by making them
                         // continuation bytes
-      auto procedure = [&implementation, &i](const char *utf8, size_t size,
-                                             char16_t *utf16) -> size_t {
+      auto procedure = [&implementation,
+                        &i](const char *utf8, size_t size,
+                            [[maybe_unused]] char16_t *utf16) -> size_t {
         std::vector<char16_t> utf16be(
             2 *
             size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
@@ -332,8 +333,9 @@ TEST_LOOP(trials, overlong_error) {
     if ((unsigned char)test.input_utf8[i] >=
         (unsigned char)0b11000000) { // Only non-ASCII leading bytes can be
                                      // overlong
-      auto procedure = [&implementation, &i](const char *utf8, size_t size,
-                                             char16_t *utf16le) -> size_t {
+      auto procedure = [&implementation,
+                        &i](const char *utf8, size_t size,
+                            [[maybe_unused]] char16_t *utf16le) -> size_t {
         std::vector<char16_t> utf16be(
             2 *
             size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
@@ -372,8 +374,9 @@ TEST_LOOP(trials, too_large_error) {
   for (int i = 1; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11111000) ==
         0b11110000) { // Can only have too large error in 4-bytes case
-      auto procedure = [&implementation, &i](const char *utf8, size_t size,
-                                             char16_t *utf16le) -> size_t {
+      auto procedure = [&implementation,
+                        &i](const char *utf8, size_t size,
+                            [[maybe_unused]] char16_t *utf16le) -> size_t {
         std::vector<char16_t> utf16be(
             2 *
             size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
@@ -401,8 +404,9 @@ TEST_LOOP(trials, surrogate_error) {
   for (int i = 1; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11110000) ==
         0b11100000) { // Can only have surrogate error in 3-bytes case
-      auto procedure = [&implementation, &i](const char *utf8, size_t size,
-                                             char16_t *utf16le) -> size_t {
+      auto procedure = [&implementation,
+                        &i](const char *utf8, size_t size,
+                            [[maybe_unused]] char16_t *utf16le) -> size_t {
         std::vector<char16_t> utf16be(
             2 *
             size); // Assume each UTF-8 byte is converted into two UTF-16 bytes

--- a/tests/convert_utf8_to_utf16le_with_errors_tests.cpp
+++ b/tests/convert_utf8_to_utf16le_with_errors_tests.cpp
@@ -227,7 +227,7 @@ TEST_LOOP(trials, header_bits_error) {
 
   transcode_utf8_to_utf16_test_base test(random, fix_size);
 
-  for (int i = 0; i < fix_size; i++) {
+  for (unsigned int i = 0; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11000000) !=
         0b10000000) { // Only process leading bytes
       auto procedure = [&implementation, &i](const char *utf8, size_t size,
@@ -251,8 +251,8 @@ TEST_LOOP(trials, too_short_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
   transcode_utf8_to_utf16_test_base test(random, fix_size);
-  int leading_byte_pos = 0;
-  for (int i = 0; i < fix_size; i++) {
+  unsigned int leading_byte_pos = 0;
+  for (unsigned int i = 0; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11000000) ==
         0b10000000) { // Only process continuation bytes by making them leading
                       // bytes
@@ -280,7 +280,7 @@ TEST_LOOP(trials, too_long_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
   transcode_utf8_to_utf16_test_base test(random, fix_size);
-  for (int i = 1; i < fix_size; i++) {
+  for (unsigned int i = 1; i < fix_size; i++) {
     if (((test.input_utf8[i] & 0b11000000) !=
          0b10000000)) { // Only process leading bytes by making them
                         // continuation bytes
@@ -305,7 +305,7 @@ TEST_LOOP(trials, overlong_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
   transcode_utf8_to_utf16_test_base test(random, fix_size);
-  for (int i = 1; i < fix_size; i++) {
+  for (unsigned int i = 1; i < fix_size; i++) {
     if ((unsigned char)test.input_utf8[i] >=
         (unsigned char)0b11000000) { // Only non-ASCII leading bytes can be
                                      // overlong
@@ -343,7 +343,7 @@ TEST_LOOP(trials, too_large_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
   transcode_utf8_to_utf16_test_base test(random, fix_size);
-  for (int i = 1; i < fix_size; i++) {
+  for (unsigned int i = 1; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11111000) ==
         0b11110000) { // Can only have too large error in 4-bytes case
       auto procedure = [&implementation, &i](const char *utf8, size_t size,
@@ -369,7 +369,7 @@ TEST_LOOP(trials, surrogate_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
   transcode_utf8_to_utf16_test_base test(random, fix_size);
-  for (int i = 1; i < fix_size; i++) {
+  for (unsigned int i = 1; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11110000) ==
         0b11100000) { // Can only have surrogate error in 3-bytes case
       auto procedure = [&implementation, &i](const char *utf8, size_t size,

--- a/tests/convert_utf8_to_utf32_with_errors_tests.cpp
+++ b/tests/convert_utf8_to_utf32_with_errors_tests.cpp
@@ -252,7 +252,7 @@ TEST_LOOP(trials, too_large_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
   transcode_utf8_to_utf32_test_base test(random, fix_size);
-  for (int i = 1; i < fix_size; i++) {
+  for (unsigned int i = 1; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11111000) ==
         0b11110000) { // Can only have too large error in 4-bytes case
       auto procedure = [&implementation, &i](const char *utf8, size_t size,
@@ -277,7 +277,7 @@ TEST_LOOP(trials, surrogate_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
   transcode_utf8_to_utf32_test_base test(random, fix_size);
-  for (int i = 1; i < fix_size; i++) {
+  for (unsigned int i = 1; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11110000) ==
         0b11100000) { // Can only have surrogate error in 3-bytes case
       auto procedure = [&implementation, &i](const char *utf8, size_t size,

--- a/tests/convert_valid_utf16be_to_latin1_tests.cpp
+++ b/tests/convert_valid_utf16be_to_latin1_tests.cpp
@@ -31,8 +31,9 @@ TEST_LOOP(trials, convert_2_UTF16_bytes) {
     return implementation.convert_valid_utf16be_to_latin1(utf16be.data(), size,
                                                           latin1);
   };
-  auto size_procedure = [&implementation](const char16_t *utf16,
-                                          size_t size) -> size_t {
+  auto size_procedure =
+      [&implementation]([[maybe_unused]] const char16_t *utf16,
+                        size_t size) -> size_t {
     return implementation.latin1_length_from_utf16(size);
   };
   for (size_t size : input_size) {

--- a/tests/convert_valid_utf16le_to_latin1_tests.cpp
+++ b/tests/convert_valid_utf16le_to_latin1_tests.cpp
@@ -26,8 +26,9 @@ TEST_LOOP(trials, convert_2_UTF16_bytes) {
                                      char *latin1) -> size_t {
     return implementation.convert_valid_utf16le_to_latin1(utf16, size, latin1);
   };
-  auto size_procedure = [&implementation](const char16_t *utf16,
-                                          size_t size) -> size_t {
+  auto size_procedure =
+      [&implementation]([[maybe_unused]] const char16_t *utf16,
+                        size_t size) -> size_t {
     return implementation.latin1_length_from_utf16(size);
   };
   for (size_t size : input_size) {

--- a/tests/convert_valid_utf32_to_latin1_tests.cpp
+++ b/tests/convert_valid_utf32_to_latin1_tests.cpp
@@ -48,8 +48,9 @@ TEST(convert_latin1_only) {
                                      char *latin1) -> size_t {
     return implementation.convert_valid_utf32_to_latin1(utf32, size, latin1);
   };
-  auto size_procedure = [&implementation](const char32_t *utf32,
-                                          size_t size) -> size_t {
+  auto size_procedure =
+      [&implementation]([[maybe_unused]] const char32_t *utf32,
+                        size_t size) -> size_t {
     return implementation.latin1_length_from_utf32(size);
   };
   for (size_t size : input_size) {

--- a/tests/detect_encodings_tests.cpp
+++ b/tests/detect_encodings_tests.cpp
@@ -235,7 +235,7 @@ TEST_LOOP(trials, utf32_surrogates) {
 
   for (size_t size : input_size) {
     std::vector<uint32_t> generated;
-    for (int i = 0; i < size / 4; i++) {
+    for (unsigned int i = 0; i < size / 4; i++) {
       generated.push_back((random_prefix() & 0xffff0000) + random_suffix());
     }
     auto expected = simdutf::encoding_type::UTF32_LE;
@@ -254,7 +254,7 @@ TEST_LOOP(trials, edge_surrogate) {
 
   const size_t size = 512;
   std::vector<uint16_t> generated(size / 2, 0);
-  int i = 31;
+  unsigned int i = 31;
   while (i + 32 < (size / 2) - 1) {
     char16_t W1;
     char16_t W2;

--- a/tests/helpers/test.h
+++ b/tests/helpers/test.h
@@ -39,7 +39,8 @@ struct register_test {
     puts(" OK");                                                               \
   }                                                                            \
   static simdutf::test::register_test test_register_##name(#name, name);       \
-  void test_impl_##name(const simdutf::implementation &implementation)
+  void test_impl_##name(                                                       \
+      [[maybe_unused]] const simdutf::implementation &implementation)
 
 #define TEST_LOOP(trials, name)                                                \
   void test_impl_##name(const simdutf::implementation &impl, uint32_t seed);   \
@@ -60,7 +61,7 @@ struct register_test {
   }                                                                            \
   static simdutf::test::register_test test_register_##name(#name, name);       \
   void test_impl_##name(const simdutf::implementation &implementation,         \
-                        uint32_t seed)
+                        [[maybe_unused]] uint32_t seed)
 
 #define ASSERT_EQUAL(a, b)                                                     \
   {                                                                            \

--- a/tests/random_fuzzer.cpp
+++ b/tests/random_fuzzer.cpp
@@ -36,7 +36,7 @@ void dump_case() {
   log.open(name, std::ios::app);
   const size_t buf_size = 4 * input.size() + 3;
   char *buffer = new char[buf_size];
-  for (int i = 0; i < input.size(); i++) {
+  for (unsigned int i = 0; i < input.size(); i++) {
     SIMDUTF_PUSH_DISABLE_WARNINGS
     SIMDUTF_DISABLE_DEPRECATED_WARNING
     sprintf(buffer + 4 * i + 1, "\\x%02x", input[i]);

--- a/tests/validate_ascii_basic_tests.cpp
+++ b/tests/validate_ascii_basic_tests.cpp
@@ -91,7 +91,7 @@ TEST(hard_coded) {
       "\xc3",
       "\xd4",
       "\xe5",
-      "\xf6"
+      "\xf6",
       "\xc3\xb1",
       "\xe2\x82\xa1",
       "\xf0\x90\x8c\xbc",

--- a/tests/validate_ascii_with_errors_tests.cpp
+++ b/tests/validate_ascii_with_errors_tests.cpp
@@ -23,7 +23,7 @@ TEST_LOOP(trials, error_ASCII) {
 
   auto ascii{generator.generate(512)};
 
-  for (int i = 0; i < ascii.size(); i++) {
+  for (unsigned int i = 0; i < ascii.size(); i++) {
     ascii[i] += 0b10000000;
 
     simdutf::result res = implementation.validate_ascii_with_errors(

--- a/tests/validate_utf8_with_errors_tests.cpp
+++ b/tests/validate_utf8_with_errors_tests.cpp
@@ -55,7 +55,7 @@ TEST_LOOP(num_trials, header_bits_error) {
   simdutf::tests::helpers::random_utf8 generator{seed, 1, 1, 1, 1};
   auto utf8{generator.generate(512, seed)};
 
-  for (int i = 0; i < 512; i++) {
+  for (unsigned int i = 0; i < 512; i++) {
     if ((utf8[i] & 0b11000000) != 0b10000000) { // Only process leading bytes
       const unsigned char old = utf8[i];
       utf8[i] = uint8_t(0b11111000);
@@ -81,7 +81,7 @@ TEST_LOOP(num_trials, too_short_error) {
       simdutf::result res = implementation.validate_utf8_with_errors(
           reinterpret_cast<const char *>(utf8.data()), utf8.size());
       ASSERT_EQUAL(res.error, simdutf::error_code::TOO_SHORT);
-      ASSERT_EQUAL(res.count, leading_byte_pos);
+      ASSERT_EQUAL(res.count, static_cast<unsigned>(leading_byte_pos));
       utf8[i] = old;
     } else {
       leading_byte_pos = i;
@@ -92,7 +92,7 @@ TEST_LOOP(num_trials, too_short_error) {
 TEST_LOOP(num_trials, too_long_error) {
   simdutf::tests::helpers::random_utf8 generator{seed, 1, 1, 1, 1};
   auto utf8{generator.generate(512, seed)};
-  for (int i = 1; i < 512; i++) {
+  for (unsigned int i = 1; i < 512; i++) {
     if (((utf8[i] & 0b11000000) !=
          0b10000000)) { // Only process leading bytes by making them
                         // continuation bytes
@@ -110,7 +110,7 @@ TEST_LOOP(num_trials, too_long_error) {
 TEST_LOOP(num_trials, overlong_error) {
   simdutf::tests::helpers::random_utf8 generator{seed, 1, 1, 1, 1};
   auto utf8{generator.generate(512, seed)};
-  for (int i = 1; i < 512; i++) {
+  for (unsigned int i = 1; i < 512; i++) {
     if (utf8[i] >= 0b11000000) { // Only non-ASCII leading bytes can be overlong
       const unsigned char old = utf8[i];
       const unsigned char second_old = utf8[i + 1];
@@ -139,7 +139,7 @@ TEST_LOOP(num_trials, overlong_error) {
 TEST_LOOP(num_trials, too_large_error) {
   simdutf::tests::helpers::random_utf8 generator{seed, 1, 1, 1, 1};
   auto utf8{generator.generate(512, seed)};
-  for (int i = 1; i < 512; i++) {
+  for (unsigned int i = 1; i < 512; i++) {
     if ((utf8[i] & 0b11111000) ==
         0b11110000) { // Can only have too large error in 4-bytes case
       utf8[i] += ((utf8[i] & 0b100) == 0b100)
@@ -158,7 +158,7 @@ TEST_LOOP(num_trials, too_large_error) {
 TEST_LOOP(num_trials, surrogate_error) {
   simdutf::tests::helpers::random_utf8 generator{seed, 1, 1, 1, 1};
   auto utf8{generator.generate(512, seed)};
-  for (int i = 1; i < 512; i++) {
+  for (unsigned int i = 1; i < 512; i++) {
     if ((utf8[i] & 0b11110000) ==
         0b11100000) { // Can only have surrogate error in 3-bytes case
       const unsigned char old = utf8[i];


### PR DESCRIPTION
I noticed when building with -Wall -Wextra that the tests contain code that trigger warnings.

There is one particularly interesting warning where I am not sure about the fix, see 0b2559a54dac2f5f04104c584904246a8a901357 