### PR TITLE
Fixing icelake base64 decode behavior to be similar to other routines

### DIFF
--- a/src/icelake/icelake_base64.inl.cpp
+++ b/src/icelake/icelake_base64.inl.cpp
@@ -410,6 +410,10 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
   }
 
   if (!ignore_garbage && equalsigns > 0) {
+    if (last_chunk_options == last_chunk_handling_options::strict) {
+      return {BASE64_INPUT_REMAINDER, size_t(src - srcinit),
+              size_t(dst - dstinit)};
+    }
     if ((size_t(dst - dstinit) % 3 == 0) ||
         ((size_t(dst - dstinit) % 3) + 1 + equalsigns != 4)) {
       return {INVALID_BASE64_CHARACTER, equallocation, size_t(dst - dstinit)};

--- a/src/icelake/icelake_base64.inl.cpp
+++ b/src/icelake/icelake_base64.inl.cpp
@@ -414,6 +414,10 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
       return {BASE64_INPUT_REMAINDER, size_t(src - srcinit),
               size_t(dst - dstinit)};
     }
+    if (last_chunk_options ==
+        last_chunk_handling_options::stop_before_partial) {
+      return {SUCCESS, size_t(src - srcinit), size_t(dst - dstinit)};
+    }
     if ((size_t(dst - dstinit) % 3 == 0) ||
         ((size_t(dst - dstinit) % 3) + 1 + equalsigns != 4)) {
       return {INVALID_BASE64_CHARACTER, equallocation, size_t(dst - dstinit)};

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -565,24 +565,24 @@ TEST(issue_single_bad16) {
   ASSERT_EQUAL(r.count, 0);
 }
 
-TEST(issue_icelake_fuzz_615) {
+TEST(issue_615) {
   const std::vector<char> data{' ', '=', '='};
   std::vector<char> output(100);
-  auto r =
+  const auto r1 =
       implementation.base64_to_binary(data.data(), data.size(), output.data(),
                                       simdutf::base64_default, simdutf::strict);
-  ASSERT_EQUAL(r.error, simdutf::error_code::BASE64_INPUT_REMAINDER);
-  ASSERT_EQUAL(r.count, 0);
-  r = implementation.base64_to_binary(data.data() + 1, data.size() - 1,
-                                      output.data(), simdutf::base64_default,
-                                      simdutf::strict);
-  ASSERT_EQUAL(r.error, simdutf::error_code::INVALID_BASE64_CHARACTER);
-  ASSERT_EQUAL(r.count, 0);
-  r = implementation.base64_to_binary(data.data(), data.size(), output.data(),
-                                      simdutf::base64_default,
-                                      simdutf::stop_before_partial);
-  ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
-  ASSERT_EQUAL(r.count, 0);
+  ASSERT_EQUAL(r1.error, simdutf::error_code::BASE64_INPUT_REMAINDER);
+  ASSERT_EQUAL(r1.count, 0);
+  const auto r2 = implementation.base64_to_binary(
+      data.data() + 1, data.size() - 1, output.data(), simdutf::base64_default,
+      simdutf::strict);
+  ASSERT_EQUAL(r2.error, simdutf::error_code::INVALID_BASE64_CHARACTER);
+  ASSERT_EQUAL(r2.count, 0);
+  const auto r3 = implementation.base64_to_binary(
+      data.data(), data.size(), output.data(), simdutf::base64_default,
+      simdutf::stop_before_partial);
+  ASSERT_EQUAL(r3.error, simdutf::error_code::SUCCESS);
+  ASSERT_EQUAL(r3.count, 0);
 }
 
 TEST(issue_kkk) {

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -568,16 +568,21 @@ TEST(issue_single_bad16) {
 TEST(issue_icelake_fuzz_615) {
   const std::vector<char> data{' ', '=', '='};
   std::vector<char> output(100);
-  const auto r =
+  auto r =
       implementation.base64_to_binary(data.data(), data.size(), output.data(),
                                       simdutf::base64_default, simdutf::strict);
   ASSERT_EQUAL(r.error, simdutf::error_code::BASE64_INPUT_REMAINDER);
   ASSERT_EQUAL(r.count, 0);
-  const auto r_ = implementation.base64_to_binary(
-      data.data() + 1, data.size() - 1, output.data(), simdutf::base64_default,
-      simdutf::strict);
-  ASSERT_EQUAL(r_.error, simdutf::error_code::INVALID_BASE64_CHARACTER);
-  ASSERT_EQUAL(r_.count, 0);
+  r = implementation.base64_to_binary(data.data() + 1, data.size() - 1,
+                                      output.data(), simdutf::base64_default,
+                                      simdutf::strict);
+  ASSERT_EQUAL(r.error, simdutf::error_code::INVALID_BASE64_CHARACTER);
+  ASSERT_EQUAL(r.count, 0);
+  r = implementation.base64_to_binary(data.data(), data.size(), output.data(),
+                                      simdutf::base64_default,
+                                      simdutf::stop_before_partial);
+  ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
+  ASSERT_EQUAL(r.count, 0);
 }
 
 TEST(issue_kkk) {

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -565,6 +565,21 @@ TEST(issue_single_bad16) {
   ASSERT_EQUAL(r.count, 0);
 }
 
+TEST(issue_icelake_fuzz_615) {
+  const std::vector<char> data{' ', '=', '='};
+  std::vector<char> output(100);
+  const auto r =
+      implementation.base64_to_binary(data.data(), data.size(), output.data(),
+                                      simdutf::base64_default, simdutf::strict);
+  ASSERT_EQUAL(r.error, simdutf::error_code::BASE64_INPUT_REMAINDER);
+  ASSERT_EQUAL(r.count, 0);
+  const auto r_ = implementation.base64_to_binary(
+      data.data() + 1, data.size() - 1, output.data(), simdutf::base64_default,
+      simdutf::strict);
+  ASSERT_EQUAL(r_.error, simdutf::error_code::INVALID_BASE64_CHARACTER);
+  ASSERT_EQUAL(r_.count, 0);
+}
+
 TEST(issue_kkk) {
   std::vector<char> data = {
       0x20, 0x20, 0x20, 0x20, 0x20, 0x4b, 0x4b, 0x4b, 0x4b, 0x4b, 0x4b, 0x4b,


### PR DESCRIPTION
Previously submitted change #593 causes Icelake base64 decode routine to return `INVALID_BASE64_CHARACTER` for `strict` chunk option case, which is not what the other routines return due to `base64_tail_decode`.
This has been reported in #615 by @pauldreik.

Adding the reported test and the new code change to address this behavior for Icelake base64 decode routine.
Icelake routines have the `base64_tail_decode` inlined inside the `bufferptr - buffer != 0` block above which handles most of the cases. This change adds the extra check for `strict` and `stop_with_partial` with padding scenario which should match all other implementations as well.