### PR TITLE
fix illegal names using double underscores

### DIFF
--- a/tests/validate_utf16be_basic_tests.cpp
+++ b/tests/validate_utf16be_basic_tests.cpp
@@ -12,8 +12,7 @@
 
 constexpr size_t trials = 1000;
 
-TEST_LOOP(trials,
-          validate_utf16be__returns_true_for_valid_input__single_words) {
+TEST_LOOP(trials, validate_utf16be_returns_true_for_valid_input_single_words) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
   const auto utf16{generator.generate(512, seed)};
   std::vector<char16_t> flipped(utf16.size());
@@ -23,9 +22,8 @@ TEST_LOOP(trials,
       reinterpret_cast<const char16_t *>(flipped.data()), flipped.size()));
 }
 
-TEST_LOOP(
-    trials,
-    validate_utf16be__returns_true_for_valid_input__surrogate_pairs_short) {
+TEST_LOOP(trials,
+          validate_utf16be_returns_true_for_valid_input_surrogate_pairs_short) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
   const auto utf16{generator.generate(8)};
   std::vector<char16_t> flipped(utf16.size());
@@ -37,7 +35,7 @@ TEST_LOOP(
 }
 
 TEST_LOOP(trials,
-          validate_utf16be__returns_true_for_valid_input__surrogate_pairs) {
+          validate_utf16be_returns_true_for_valid_input_surrogate_pairs) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
   const auto utf16{generator.generate(512)};
   std::vector<char16_t> flipped(utf16.size());
@@ -49,7 +47,7 @@ TEST_LOOP(trials,
 }
 
 // mixed = either 16-bit or 32-bit codewords
-TEST(validate_utf16be__returns_true_for_valid_input__mixed) {
+TEST(validate_utf16be_returns_true_for_valid_input_mixed) {
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 1};
   const auto utf16{generator.generate(512)};
@@ -61,7 +59,7 @@ TEST(validate_utf16be__returns_true_for_valid_input__mixed) {
       reinterpret_cast<const char16_t *>(flipped.data()), flipped.size()));
 }
 
-TEST(validate_utf16be__returns_true_for_empty_string) {
+TEST(validate_utf16be_returns_true_for_empty_string) {
   const char16_t *buf = (char16_t *)"";
 
   ASSERT_TRUE(implementation.validate_utf16be(buf, 0));
@@ -83,7 +81,7 @@ TEST(validate_utf16be__returns_true_for_empty_string) {
 // todo: port this test for big-endian platforms.
 #else
 TEST_LOOP(
-    10, validate_utf16be__returns_false_when_input_has_wrong_first_word_value) {
+    10, validate_utf16be_returns_false_when_input_has_wrong_first_word_value) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
   auto utf16{generator.generate(128)};
   const size_t len = utf16.size();
@@ -115,7 +113,7 @@ TEST_LOOP(
 #if SIMDUTF_IS_BIG_ENDIAN
 // todo: port this test for big-endian platforms.
 #else
-TEST(validate_utf16be__returns_false_when_input_has_wrong_second_word_value) {
+TEST(validate_utf16be_returns_false_when_input_has_wrong_second_word_value) {
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
   auto utf16{generator.generate(128)};
@@ -156,7 +154,7 @@ TEST(validate_utf16be__returns_false_when_input_has_wrong_second_word_value) {
 #if SIMDUTF_IS_BIG_ENDIAN
 // todo: port this test for big-endian platforms.
 #else
-TEST(validate_utf16be__returns_false_when_input_is_truncated) {
+TEST(validate_utf16be_returns_false_when_input_is_truncated) {
   const char16_t valid_surrogate_W1 = 0x00d8;
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};

--- a/tests/validate_utf16be_with_errors_tests.cpp
+++ b/tests/validate_utf16be_with_errors_tests.cpp
@@ -12,8 +12,7 @@
 
 constexpr size_t trials = 1000;
 
-TEST_LOOP(trials,
-          validate_utf16be__returns_true_for_valid_input__single_words) {
+TEST_LOOP(trials, validate_utf16be_returns_true_for_valid_input_single_words) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
   const auto utf16{generator.generate(512, seed)};
   std::vector<char16_t> flipped(utf16.size());
@@ -26,9 +25,8 @@ TEST_LOOP(trials,
   ASSERT_EQUAL(res.count, utf16.size());
 }
 
-TEST_LOOP(
-    trials,
-    validate_utf16be__returns_true_for_valid_input__surrogate_pairs_short) {
+TEST_LOOP(trials,
+          validate_utf16be_returns_true_for_valid_input_surrogate_pairs_short) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
   const auto utf16{generator.generate(8)};
   std::vector<char16_t> flipped(utf16.size());
@@ -42,7 +40,7 @@ TEST_LOOP(
 }
 
 TEST_LOOP(trials,
-          validate_utf16be__returns_true_for_valid_input__surrogate_pairs) {
+          validate_utf16be_returns_true_for_valid_input_surrogate_pairs) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
   const auto utf16{generator.generate(512)};
   std::vector<char16_t> flipped(utf16.size());
@@ -56,7 +54,7 @@ TEST_LOOP(trials,
 }
 
 // mixed = either 16-bit or 32-bit codewords
-TEST(validate_utf16be__returns_true_for_valid_input__mixed) {
+TEST(validate_utf16be_returns_true_for_valid_input_mixed) {
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 1};
   const auto utf16{generator.generate(512)};
@@ -70,7 +68,7 @@ TEST(validate_utf16be__returns_true_for_valid_input__mixed) {
   ASSERT_EQUAL(res.count, utf16.size());
 }
 
-TEST(validate_utf16be__returns_true_for_empty_string) {
+TEST(validate_utf16be_returns_true_for_empty_string) {
   const char16_t *buf = (char16_t *)"";
 
   simdutf::result res = implementation.validate_utf16be_with_errors(
@@ -116,7 +114,7 @@ TEST(provoke_integer_wraparound_in_icelake) {
 // todo: port this test for big-endian platforms.
 #else
 TEST_LOOP(
-    10, validate_utf16be__returns_false_when_input_has_wrong_first_word_value) {
+    10, validate_utf16be_returns_false_when_input_has_wrong_first_word_value) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
   auto utf16{generator.generate(128)};
   const size_t len = utf16.size();
@@ -150,7 +148,7 @@ TEST_LOOP(
 #if SIMDUTF_IS_BIG_ENDIAN
 // todo: port this test for big-endian platforms.
 #else
-TEST(validate_utf16be__returns_false_when_input_has_wrong_second_word_value) {
+TEST(validate_utf16be_returns_false_when_input_has_wrong_second_word_value) {
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
   auto utf16{generator.generate(128)};
@@ -193,7 +191,7 @@ TEST(validate_utf16be__returns_false_when_input_has_wrong_second_word_value) {
 #if SIMDUTF_IS_BIG_ENDIAN
 // todo: port this test for big-endian platforms.
 #else
-TEST(validate_utf16be__returns_false_when_input_is_truncated) {
+TEST(validate_utf16be_returns_false_when_input_is_truncated) {
   const char16_t valid_surrogate_W1 = 0x00d8;
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};

--- a/tests/validate_utf16le_basic_tests.cpp
+++ b/tests/validate_utf16le_basic_tests.cpp
@@ -33,8 +33,7 @@ TEST(issue92) {
   ASSERT_EQUAL(measured_size, size);
 }
 
-TEST_LOOP(trials,
-          validate_utf16le__returns_true_for_valid_input__single_words) {
+TEST_LOOP(trials, validate_utf16le_returns_true_for_valid_input_single_words) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
   const auto utf16{generator.generate(512, seed)};
 
@@ -42,9 +41,8 @@ TEST_LOOP(trials,
       reinterpret_cast<const char16_t *>(utf16.data()), utf16.size()));
 }
 
-TEST_LOOP(
-    trials,
-    validate_utf16le__returns_true_for_valid_input__surrogate_pairs_short) {
+TEST_LOOP(trials,
+          validate_utf16le_returns_true_for_valid_input_surrogate_pairs_short) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
   const auto utf16{generator.generate(8)};
 
@@ -53,7 +51,7 @@ TEST_LOOP(
 }
 
 TEST_LOOP(trials,
-          validate_utf16le__returns_true_for_valid_input__surrogate_pairs) {
+          validate_utf16le_returns_true_for_valid_input_surrogate_pairs) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
   const auto utf16{generator.generate(512)};
 
@@ -62,7 +60,7 @@ TEST_LOOP(trials,
 }
 
 // mixed = either 16-bit or 32-bit codewords
-TEST(validate_utf16le__returns_true_for_valid_input__mixed) {
+TEST(validate_utf16le_returns_true_for_valid_input_mixed) {
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 1};
   const auto utf16{generator.generate(512)};
@@ -71,7 +69,7 @@ TEST(validate_utf16le__returns_true_for_valid_input__mixed) {
       reinterpret_cast<const char16_t *>(utf16.data()), utf16.size()));
 }
 
-TEST(validate_utf16le__returns_true_for_empty_string) {
+TEST(validate_utf16le_returns_true_for_empty_string) {
   const char16_t *buf = (char16_t *)"";
 
   ASSERT_TRUE(implementation.validate_utf16le(buf, 0));
@@ -93,7 +91,7 @@ TEST(validate_utf16le__returns_true_for_empty_string) {
 // todo: port this test for big-endian platforms.
 #else
 TEST_LOOP(
-    10, validate_utf16le__returns_false_when_input_has_wrong_first_word_value) {
+    10, validate_utf16le_returns_false_when_input_has_wrong_first_word_value) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
   auto utf16{generator.generate(128)};
   const char16_t *buf = reinterpret_cast<const char16_t *>(utf16.data());
@@ -121,7 +119,7 @@ TEST_LOOP(
 #if SIMDUTF_IS_BIG_ENDIAN
 // todo: port this test for big-endian platforms.
 #else
-TEST(validate_utf16le__returns_false_when_input_has_wrong_second_word_value) {
+TEST(validate_utf16le_returns_false_when_input_has_wrong_second_word_value) {
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
   auto utf16{generator.generate(128)};
@@ -155,7 +153,7 @@ TEST(validate_utf16le__returns_false_when_input_has_wrong_second_word_value) {
 #if SIMDUTF_IS_BIG_ENDIAN
 // todo: port this test for big-endian platforms.
 #else
-TEST(validate_utf16le__returns_false_when_input_is_truncated) {
+TEST(validate_utf16le_returns_false_when_input_is_truncated) {
   const char16_t valid_surrogate_W1 = 0xd800;
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
@@ -174,7 +172,7 @@ TEST(validate_utf16le__returns_false_when_input_is_truncated) {
 #if SIMDUTF_IS_BIG_ENDIAN
 // t odo: port this test for big-endian platforms.
 #else
-TEST(validate_utf16le__extensive_tests) {
+TEST(validate_utf16le_extensive_tests) {
   #ifdef RUN_IN_SPIKE_SIMULATOR
   printf("skipping, cannot be run under Spike");
   return;

--- a/tests/validate_utf16le_with_errors_tests.cpp
+++ b/tests/validate_utf16le_with_errors_tests.cpp
@@ -15,7 +15,7 @@ constexpr size_t trials = 1000;
 
 TEST_LOOP(
     trials,
-    validate_utf16le_with_errors__returns_success_for_valid_input__single_words) {
+    validate_utf16le_with_errors_returns_success_for_valid_input_single_words) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
   const auto utf16{generator.generate(512, seed)};
 
@@ -28,7 +28,7 @@ TEST_LOOP(
 
 TEST_LOOP(
     trials,
-    validate_utf16le_with_errors__returns_success_for_valid_input__surrogate_pairs_short) {
+    validate_utf16le_with_errors_returns_success_for_valid_input_surrogate_pairs_short) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
   const auto utf16{generator.generate(8)};
 
@@ -41,7 +41,7 @@ TEST_LOOP(
 
 TEST_LOOP(
     trials,
-    validate_utf16le_with_errors__returns_success_for_valid_input__surrogate_pairs) {
+    validate_utf16le_with_errors_returns_success_for_valid_input_surrogate_pairs) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
   const auto utf16{generator.generate(512)};
 
@@ -73,7 +73,7 @@ TEST(provoke_integer_wraparound_in_icelake) {
 }
 
 // mixed = either 16-bit or 32-bit codewords
-TEST(validate_utf16le_with_errors__returns_success_for_valid_input__mixed) {
+TEST(validate_utf16le_with_errors_returns_success_for_valid_input_mixed) {
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 1};
   const auto utf16{generator.generate(512)};
@@ -85,7 +85,7 @@ TEST(validate_utf16le_with_errors__returns_success_for_valid_input__mixed) {
   ASSERT_EQUAL(res.count, utf16.size());
 }
 
-TEST(validate_utf16le_with_errors__returns_success_for_empty_string) {
+TEST(validate_utf16le_with_errors_returns_success_for_empty_string) {
   const char16_t *buf = (char16_t *)"";
 
   simdutf::result res = implementation.validate_utf16le_with_errors(
@@ -112,7 +112,7 @@ TEST(validate_utf16le_with_errors__returns_success_for_empty_string) {
 #else
 TEST_LOOP(
     10,
-    validate_utf16le_with_errors__returns_error_when_input_has_wrong_first_word_value) {
+    validate_utf16le_with_errors_returns_error_when_input_has_wrong_first_word_value) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
 
   auto utf16{generator.generate(128)};
@@ -146,7 +146,7 @@ TEST_LOOP(
 // todo: port this test for big-endian platforms.
 #else
 TEST(
-    validate_utf16le_with_errors__returns_error_when_input_has_wrong_second_word_value) {
+    validate_utf16le_with_errors_returns_error_when_input_has_wrong_second_word_value) {
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
   auto utf16{generator.generate(128)};
@@ -187,7 +187,7 @@ TEST(
 #if SIMDUTF_IS_BIG_ENDIAN
 // todo: port this test for big-endian platforms.
 #else
-TEST(validate_utf16le_with_errors__returns_error_when_input_is_truncated) {
+TEST(validate_utf16le_with_errors_returns_error_when_input_is_truncated) {
   const char16_t valid_surrogate_W1 = 0xd800;
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
@@ -210,7 +210,7 @@ TEST(validate_utf16le_with_errors__returns_error_when_input_is_truncated) {
 #if SIMDUTF_IS_BIG_ENDIAN
 // todo: port this test for big-endian platforms.
 #else
-TEST(validate_utf16le_with_errors__extensive_tests) {
+TEST(validate_utf16le_with_errors_extensive_tests) {
   #ifdef RUN_IN_SPIKE_SIMULATOR
   printf("skipping, cannot be run under Spike");
   return;

--- a/tests/validate_utf32_basic_tests.cpp
+++ b/tests/validate_utf32_basic_tests.cpp
@@ -5,7 +5,7 @@
 #include <tests/helpers/random_utf32.h>
 #include <tests/helpers/test.h>
 
-TEST_LOOP(1000, validate_utf32__returns_true_for_valid_input) {
+TEST_LOOP(1000, validate_utf32_returns_true_for_valid_input) {
   simdutf::tests::helpers::random_utf32 generator{seed};
   const auto utf32{generator.generate(256, seed)};
 
@@ -13,13 +13,13 @@ TEST_LOOP(1000, validate_utf32__returns_true_for_valid_input) {
       reinterpret_cast<const char32_t *>(utf32.data()), utf32.size()));
 }
 
-TEST(validate_utf32__returns_true_for_empty_string) {
+TEST(validate_utf32_returns_true_for_empty_string) {
   const char32_t *buf = (char32_t *)"";
 
   ASSERT_TRUE(implementation.validate_utf32(buf, 0));
 }
 
-TEST_LOOP(10, validate_utf32__returns_false_when_input_in_forbidden_range) {
+TEST_LOOP(10, validate_utf32_returns_false_when_input_in_forbidden_range) {
   simdutf::tests::helpers::random_utf32 generator{seed};
   auto utf32{generator.generate(128)};
   const char32_t *buf = reinterpret_cast<const char32_t *>(utf32.data());
@@ -37,7 +37,7 @@ TEST_LOOP(10, validate_utf32__returns_false_when_input_in_forbidden_range) {
   }
 }
 
-TEST_LOOP(1000, validate_utf32__returns_false_when_input_too_large) {
+TEST_LOOP(1000, validate_utf32_returns_false_when_input_too_large) {
   simdutf::tests::helpers::random_utf32 generator{seed};
 
   std::uniform_int_distribution<uint32_t> bad_range{0x110000, 0xffffffff};

--- a/tests/validate_utf32_with_errors_tests.cpp
+++ b/tests/validate_utf32_with_errors_tests.cpp
@@ -18,7 +18,7 @@ TEST(issue_531) {
   ASSERT_EQUAL(validation1.count, 0);
 }
 
-TEST_LOOP(1000, validate_utf32_with_errors__returns_success_for_valid_input) {
+TEST_LOOP(1000, validate_utf32_with_errors_returns_success_for_valid_input) {
   simdutf::tests::helpers::random_utf32 generator{seed};
   const auto utf32{generator.generate(256, seed)};
 
@@ -29,7 +29,7 @@ TEST_LOOP(1000, validate_utf32_with_errors__returns_success_for_valid_input) {
   ASSERT_EQUAL(res.count, utf32.size());
 }
 
-TEST(validate_utf32_with_errors__returns_success_for_empty_string) {
+TEST(validate_utf32_with_errors_returns_success_for_empty_string) {
   const char32_t *buf = (char32_t *)"";
 
   simdutf::result res = implementation.validate_utf32_with_errors(buf, 0);
@@ -40,7 +40,7 @@ TEST(validate_utf32_with_errors__returns_success_for_empty_string) {
 
 TEST_LOOP(
     10,
-    validate_utf32_with_errors__returns_error_when_input_in_forbidden_range) {
+    validate_utf32_with_errors_returns_error_when_input_in_forbidden_range) {
   simdutf::tests::helpers::random_utf32 generator{seed};
 
   auto utf32{generator.generate(128)};
@@ -62,7 +62,7 @@ TEST_LOOP(
   }
 }
 
-TEST_LOOP(10, validate_utf32_with_errors__returns_error_when_input_too_large) {
+TEST_LOOP(10, validate_utf32_with_errors_returns_error_when_input_too_large) {
   simdutf::tests::helpers::random_utf32 generator{seed};
 
   std::uniform_int_distribution<uint32_t> bad_range{0x110000, 0xffffffff};


### PR DESCRIPTION
using __ anywhere in an identifier is reserved for use by the implementation.