### PR TITLE
Optimize icelake validate_utf32 for small inputs using masked AVX512 instructions

### DIFF
--- a/src/icelake/icelake_utf32_validation.inl.cpp
+++ b/src/icelake/icelake_utf32_validation.inl.cpp
@@ -1,16 +1,16 @@
 // file included directly
 
-const char32_t *validate_utf32(const char32_t *buf, size_t len) {
-  if (len < 16) {
-    return buf;
+bool validate_utf32(const char32_t *buf, size_t len) {
+  if (len == 0) {
+    return true;
   }
-  const char32_t *end = buf + len - 16;
+  const char32_t *end = buf + len;
 
   const __m512i offset = _mm512_set1_epi32((uint32_t)0xffff2000);
   __m512i currentmax = _mm512_setzero_si512();
   __m512i currentoffsetmax = _mm512_setzero_si512();
 
-  while (buf <= end) {
+  while (buf <= end - 16) {
     __m512i utf32 = _mm512_loadu_si512((const __m512i *)buf);
     buf += 16;
     currentoffsetmax =
@@ -18,18 +18,23 @@ const char32_t *validate_utf32(const char32_t *buf, size_t len) {
     currentmax = _mm512_max_epu32(utf32, currentmax);
   }
 
+  __m512i utf32 = _mm512_maskz_loadu_epi32(1 << (end - buf), buf);
+  currentoffsetmax =
+      _mm512_max_epu32(_mm512_add_epi32(utf32, offset), currentoffsetmax);
+  currentmax = _mm512_max_epu32(utf32, currentmax);
+
   const __m512i standardmax = _mm512_set1_epi32((uint32_t)0x10ffff);
   const __m512i standardoffsetmax = _mm512_set1_epi32((uint32_t)0xfffff7ff);
   __m512i is_zero =
       _mm512_xor_si512(_mm512_max_epu32(currentmax, standardmax), standardmax);
   if (_mm512_test_epi8_mask(is_zero, is_zero) != 0) {
-    return nullptr;
+    return false;
   }
   is_zero = _mm512_xor_si512(
       _mm512_max_epu32(currentoffsetmax, standardoffsetmax), standardoffsetmax);
   if (_mm512_test_epi8_mask(is_zero, is_zero) != 0) {
-    return nullptr;
+    return false;
   }
 
-  return buf;
+  return true;
 }

--- a/src/icelake/icelake_utf32_validation.inl.cpp
+++ b/src/icelake/icelake_utf32_validation.inl.cpp
@@ -18,7 +18,7 @@ bool validate_utf32(const char32_t *buf, size_t len) {
     currentmax = _mm512_max_epu32(utf32, currentmax);
   }
 
-  __m512i utf32 = _mm512_maskz_loadu_epi32(1 << (end - buf), buf);
+  __m512i utf32 = _mm512_maskz_loadu_epi32((__mmask16)1 << (end - buf), buf);
   currentoffsetmax =
       _mm512_max_epu32(_mm512_add_epi32(utf32, offset), currentoffsetmax);
   currentmax = _mm512_max_epu32(utf32, currentmax);

--- a/src/icelake/icelake_utf32_validation.inl.cpp
+++ b/src/icelake/icelake_utf32_validation.inl.cpp
@@ -10,7 +10,7 @@ bool validate_utf32(const char32_t *buf, size_t len) {
   __m512i currentmax = _mm512_setzero_si512();
   __m512i currentoffsetmax = _mm512_setzero_si512();
 
-  while (buf <= end - 16) {
+  while (buf < end - 16) {
     __m512i utf32 = _mm512_loadu_si512((const __m512i *)buf);
     buf += 16;
     currentoffsetmax =
@@ -18,7 +18,8 @@ bool validate_utf32(const char32_t *buf, size_t len) {
     currentmax = _mm512_max_epu32(utf32, currentmax);
   }
 
-  __m512i utf32 = _mm512_maskz_loadu_epi32((__mmask16)1 << (end - buf), buf);
+  __m512i utf32 =
+      _mm512_maskz_loadu_epi32(__mmask16((1 << (end - buf)) - 1), buf);
   currentoffsetmax =
       _mm512_max_epu32(_mm512_add_epi32(utf32, offset), currentoffsetmax);
   currentmax = _mm512_max_epu32(utf32, currentmax);

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -390,14 +390,7 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
 
 simdutf_warn_unused bool
 implementation::validate_utf32(const char32_t *buf, size_t len) const noexcept {
-  const char32_t *tail = icelake::validate_utf32(buf, len);
-  if (tail) {
-    return scalar::utf32::validate(tail, len - (tail - buf));
-  } else {
-    // we come here if there was an error, or buf was nullptr which may happen
-    // for empty input.
-    return len == 0;
-  }
+  return icelake::validate_utf32(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_utf32_with_errors(

--- a/tests/validate_utf32_basic_tests.cpp
+++ b/tests/validate_utf32_basic_tests.cpp
@@ -9,6 +9,10 @@ TEST_LOOP(1000, validate_utf32_returns_true_for_valid_input) {
   simdutf::tests::helpers::random_utf32 generator{seed};
   const auto utf32{generator.generate(256, seed)};
 
+  for (size_t i = 0; i < utf32.size(); i++) {
+    ASSERT_TRUE(implementation.validate_utf32(
+        reinterpret_cast<const char32_t *>(utf32.data()), i + 1));
+  }
   ASSERT_TRUE(implementation.validate_utf32(
       reinterpret_cast<const char32_t *>(utf32.data()), utf32.size()));
 }
@@ -31,6 +35,7 @@ TEST_LOOP(10, validate_utf32_returns_false_when_input_in_forbidden_range) {
       utf32[i] = wrong_value;
 
       ASSERT_FALSE(implementation.validate_utf32(buf, len));
+      ASSERT_FALSE(implementation.validate_utf32(buf, i + 1));
 
       utf32[i] = old;
     }
@@ -54,6 +59,7 @@ TEST_LOOP(1000, validate_utf32_returns_false_when_input_too_large) {
       utf32[i] = wrong_value;
 
       ASSERT_FALSE(implementation.validate_utf32(buf, len));
+      ASSERT_FALSE(implementation.validate_utf32(buf, i + 1));
 
       utf32[i] = old;
     }


### PR DESCRIPTION
Modified the `validate_utf32` function to avoid using scalar loop for tail processing and to obtain the result using masked AVX512 instructions. Seems to speed up small inputs as observed below:
Before the changes:
```
validate_utf32+icelake, input size: 48, iterations: 1000, dataset: temp
   2.521 ins/byte,    0.542 cycle/byte,   10.139 GB/s (15.1 %),     5.492 GHz,    4.654 ins/cycle
  11.000 ins/char,    2.364 cycle/char,    2.323 Gc/s (15.1 %)     4.36 byte/char      4.7 ns
```

After the changes:
```
validate_utf32+icelake, input size: 48, iterations: 1000, dataset: temp
   1.333 ins/byte,    0.271 cycle/byte,   20.357 GB/s (1.8 %),     5.513 GHz,    4.923 ins/cycle
   5.818 ins/char,    1.182 cycle/char,    4.665 Gc/s (1.8 %)     4.36 byte/char      2.4 ns
```