### PR TITLE
fuzzing improvements

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -79,3 +79,27 @@ This is easiest shown with an example:
 
 Some of the fuzzers support printing out a reproducer, which makes it easy to
 convert the fuzz finding into a unit test.
+
+## Continuous fuzzing
+
+There is a script in `random_fuzz.sh` which is useful to do ad-hoc fuzzing.
+It selects a random compiler optimization level, sanitizer setup and runs the
+fuzzers for a limited time. Then it pulls from git and repeats. This way, it is
+easy to take a system and run some fuzzing. It is recommended to run it in tmux
+or gnu screen, to avoid having it interrupt in case the network goes down.
+
+The script has so far been tested on
+ - debian bookworm (amd64/icelake, aarch64)
+ - rocky linux 9 (amd64/icelake)
+ - freebsd (aarch64)
+
+We are happy to get some testing on architectures which are not fuzzed already.
+If you have a power, riscv or lsx system, it would be great if you can run this
+for a few days and report back.
+
+Assuming clang and cmake are available, testing this should be as easy as:
+```shell
+git clone https://github.com/simdutf/simdutf
+simdutf/fuzz/random_fuzz.sh
+# let it run as long as you wish for
+```

--- a/fuzz/build.sh
+++ b/fuzz/build.sh
@@ -25,16 +25,10 @@ if [ -z $SRC ] ; then
 else
     # invoked from oss fuzz
     cd $SRC/simdutf
-    if [ "$ARCHITECTURE" = "aarch64" -a $(clang++ --version |head -n1 |cut -f3 -d' ' |cut -f1 -d.) -le 14 ]; then
-	# the compiler and stdlib is clang 14 which does not
-	# support ranges well enough to compile the newer fuzzers
-	fuzzer_src_files=fuzz/roundtrip.cpp
-    fi
 fi
 
-if [ -z "$fuzzer_src_files" ] ; then
-  fuzzer_src_files=$(ls fuzz/*.cpp|grep -v -E "fuzz/(reproducer.|main)")
-fi
+fuzzer_src_files=$(ls fuzz/*.cpp|grep -v -E "fuzz/(reproducer.|main)")
+
 
 
 cmake -B build -S . \

--- a/fuzz/build.sh
+++ b/fuzz/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # this is the entry point for oss-fuzz.
 #

--- a/fuzz/helpers/common.h
+++ b/fuzz/helpers/common.h
@@ -121,8 +121,11 @@ static_assert(FNV1A_hash::fnv1ahash_impl(std::string_view{""}) ==
               0xcbf29ce484222325);
 static_assert(FNV1A_hash::fnv1ahash_impl(std::string_view{"xyz"}) ==
               0xbff4aa198026f420);
+#if !defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE > 12
+// work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=113294
 static_assert(FNV1A_hash::fnv1ahash_impl(std::string{"xyz"}) ==
               0xbff4aa198026f420);
+#endif
 static_assert(FNV1A_hash::fnv1ahash_impl(std::string_view{"\xFF"}) ==
               0xaf64724c8602eb6e);
 static_assert(FNV1A_hash::fnv1ahash_impl(std::string_view{

--- a/fuzz/random_fuzz.sh
+++ b/fuzz/random_fuzz.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+#
+# this is a helper script that repeatedly:
+# - pulls the latest changes from upstream using git pull (assumes you are on an appropriate branch)
+# - selects random compiler optimization
+# - selects random selection of sanitizers
+# - selects a random clang compiler
+# - builds the fuzzers
+# - runs each fuzzer for a limited time, in random order
+#
+# it is intended to run in a screen/tmux session
+# continuously. every once in a while, see if it has
+# stopped (indicating compilation failure or a fuzzing finding)
+
+set -eux
+
+src=$(dirname "$0")/..
+src=$(readlink -f "$src")
+
+TMPWORKDIR=$(mktemp -d)
+
+# store the corpus dir somewhere "permanent" and not inside the checked out
+# git dir since that tends to get cleaned
+corpusdir=/var/tmp/$(whoami)/simdutf/corpus/
+
+selectrandomoptlevel() {
+    echo "g 0 1 2 3 z s" |tr ' ' '\n' |sort --random-sort |head -n1
+}
+
+selectrandomclang() {
+    # on a debian/ubuntu system with ccache installed,
+    # looking for compilers in /usr/lib/ccache/ is the best place.
+    #
+    # on rocky linux, clang++ and clang++-$VER are in /usr/bin
+    #
+    # on the freebsd system I have access to, the compilers are in /usr/local/bin
+    # and named clang++$VER (note the lack of dash before $VER!) as well
+    # as /usr/bin/clang++ . There is also a clang++-devel in /usr/local/bin
+    compilerlist=$TMPWORKDIR/clangcandidates
+    echo clang++ >$compilerlist
+    echo clang++-devel >>$compilerlist
+    for ver in $(seq 15 40); do
+	echo clang++-$ver >>$compilerlist
+	echo clang++$ver >>$compilerlist
+    done
+    echo '#include <stddef.h> // for size_t (rather than std::size_t)
+          #include <stdint.h> // for uint8_t (rather than std::uint8_t)
+          extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size){return 0;}
+          ' > $TMPWORKDIR/testprog.cpp
+    for candidate in $(sort --random-sort $compilerlist); do
+	# only include candidates which exist and support fuzzer and sanitizers
+	if $candidate -std=c++20 -fsanitize=fuzzer-no-link,address,undefined -o $TMPWORKDIR/testprog.o -c $TMPWORKDIR/testprog.cpp  >/dev/null 2>&1 && \
+		$candidate -fsanitize=fuzzer,address,undefined -o $TMPWORKDIR/testprog $TMPWORKDIR/testprog.o >/dev/null 2>&1; then
+	    if [ -e /usr/lib/ccache/$candidate ]; then
+		echo /usr/lib/ccache/$candidate
+	    elif [ -e /usr/local/libexec/ccache/$candidate ]; then
+                echo /usr/local/libexec/ccache/$candidate
+	    else
+		echo $candidate
+	    fi
+	    return
+	fi
+    done	
+}
+
+selectsanitizerflags() {
+    echo \
+	"-fsanitize=fuzzer-no-link,address,undefined -fsanitize-trap=undefined
+-fsanitize=fuzzer-no-link,address
+-fsanitize=fuzzer-no-link,undefined -fsanitize-trap=undefined
+-fsanitize=fuzzer-no-link" | sort --random-sort |head -n1
+}
+
+# on bsd, put the fuzzing in low priority. on linux, use nice.
+if which idprio >/dev/null 2>&1 ; then
+    # idprio is by default a privileged operation, try it out to see if we can use it.
+    if idprio 5 true >/dev/null 2>&1; then
+	BENICE="idprio 5"
+    else
+	# nope. use nice instead.
+	BENICE="nice -n19"
+    fi
+elif which nice >/dev/null 2>&1 ; then
+    BENICE="nice -n19"
+else
+    BENICE=""
+fi
+
+while true ; do
+
+    echo "pulling the latest changes"
+    cd "$src"
+    git pull
+    
+    export CXX=$(selectrandomclang)
+    optlevel=$(selectrandomoptlevel)
+    export CXXFLAGS="$(selectsanitizerflags) -g -O${optlevel}"
+    export LIB_FUZZING_ENGINE="-fsanitize=fuzzer"
+    export OUT=fuzz/out
+    export WORK=fuzz/work
+    mkdir -p $OUT $WORK
+    
+    rm -rf build/
+    # we will run in oss-fuzz mode, so we can set CXXFLAGS from here.
+    # do that by pointing out one directory above the repo root
+    export SRC=$(pwd)/..
+    $BENICE fuzz/build.sh
+
+    fuzzers="base64 conversion misc roundtrip"
+    for fuzzer in $(echo $fuzzers|tr ' ' '\n' |sort --random-sort); do
+	mkdir -p "$corpusdir/$fuzzer"
+	$BENICE fuzz/out/$fuzzer -timeout=100 -max_total_time=3600 -jobs=$(nproc) -workers=$(nproc) "$corpusdir/$fuzzer"
+    done
+done


### PR DESCRIPTION
This adds a helper script for running fuzzing - the existing one which is for oss-fuzz.sh is somewhat hard coded to debian.

The new one makes more effort to find a working clang installation. I tested it on freebsd, rocky linux and debian so far.

It also randomizes the optimization flags, which is useful to trigger different behaviour.