### PR TITLE
fix with random fuzzers for alignment issues

### DIFF
--- a/fuzz/roundtrip.cpp
+++ b/fuzz/roundtrip.cpp
@@ -222,7 +222,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
      */
     // We copy to avoid alignment issues.
     std::unique_ptr<char16_t[]> utf16_source{new char16_t[source.size() / 2]};
-    if(source.data() != nullptr) {
+    if (source.data() != nullptr) {
       std::memcpy(utf16_source.get(), source.data(), source.size() / 2 * 2);
     }
 

--- a/fuzz/roundtrip.cpp
+++ b/fuzz/roundtrip.cpp
@@ -221,8 +221,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
      * Transcoding from UTF-16LE to UTF-8.
      */
     // We copy to avoid alignment issues.
-    std::unique_ptr<char16_t> utf16_source{new char16_t[source.size() / 2]};
-    std::memcpy(utf16_source.get(), source.c_str(), source.size());
+    std::unique_ptr<char16_t[]> utf16_source{new char16_t[source.size() / 2]};
+    if(source.data() != nullptr) {
+      std::memcpy(utf16_source.get(), source.data(), source.size() / 2 * 2);
+    }
 
     // Get new source data here as this will allow the fuzzer to optimize it's
     // input for UTF16-LE.

--- a/fuzz/roundtrip.cpp
+++ b/fuzz/roundtrip.cpp
@@ -220,120 +220,127 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     /**
      * Transcoding from UTF-16LE to UTF-8.
      */
-    // We copy to avoid alignment issues.
-    std::unique_ptr<char16_t[]> utf16_source{new char16_t[source.size() / 2]};
-    if (source.data() != nullptr) {
-      std::memcpy(utf16_source.get(), source.data(), source.size() / 2 * 2);
-    }
-
-    // Get new source data here as this will allow the fuzzer to optimize it's
-    // input for UTF16-LE.
-    source = fdp.ConsumeRandomLengthString(kMaxStringSize);
-    bool validutf16le =
-        e->validate_utf16le(utf16_source.get(), source.size() / 2);
-    auto rutf16le =
-        e->validate_utf16le_with_errors(utf16_source.get(), source.size() / 2);
-    if (validutf16le !=
-        (rutf16le.error == simdutf::SUCCESS)) { // they should agree
-      print_input(source, e);
-      abort();
-    }
-    if (validutf16le) {
-      // We need a buffer of size where to write the UTF-16 words.
-      size_t expected_utf8words =
-          e->utf8_length_from_utf16le(utf16_source.get(), source.size() / 2);
-      std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
-      size_t utf8words = e->convert_utf16le_to_utf8(
-          utf16_source.get(), source.size() / 2, utf8_output.get());
-      // It wrote utf16words * sizeof(char16_t) bytes.
-      bool validutf8 = e->validate_utf8(utf8_output.get(), utf8words);
-      if (!validutf8) {
+    {
+      // Get new source data here as this will allow the fuzzer to optimize it's
+      // input for UTF16-LE.
+      source = fdp.ConsumeRandomLengthString(kMaxStringSize);
+      // We copy to avoid alignment issues.
+      std::unique_ptr<char16_t[]> utf16_source{new char16_t[source.size() / 2]};
+      if (source.data() != nullptr) {
+        std::memcpy(utf16_source.get(), source.data(), source.size() / 2 * 2);
+      }
+      bool validutf16le =
+          e->validate_utf16le(utf16_source.get(), source.size() / 2);
+      auto rutf16le = e->validate_utf16le_with_errors(utf16_source.get(),
+                                                      source.size() / 2);
+      if (validutf16le !=
+          (rutf16le.error == simdutf::SUCCESS)) { // they should agree
         print_input(source, e);
         abort();
       }
-      // convert it back:
-      // We need a buffer of size where to write the UTF-16 words.
-      size_t expected_utf16words =
-          e->utf16_length_from_utf8(utf8_output.get(), utf8words);
-      std::unique_ptr<char16_t[]> utf16_output{
-          new char16_t[expected_utf16words]};
-      // convert to UTF-8
-      size_t utf16words = e->convert_utf8_to_utf16le(
-          utf8_output.get(), utf8words, utf16_output.get());
-      for (size_t i = 0; i < source.size() / 2; i++) {
-        if (utf16_output.get()[i] != (utf16_source.get())[i]) {
+      if (validutf16le) {
+        // We need a buffer of size where to write the UTF-16 words.
+        size_t expected_utf8words =
+            e->utf8_length_from_utf16le(utf16_source.get(), source.size() / 2);
+        std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
+        size_t utf8words = e->convert_utf16le_to_utf8(
+            utf16_source.get(), source.size() / 2, utf8_output.get());
+        // It wrote utf16words * sizeof(char16_t) bytes.
+        bool validutf8 = e->validate_utf8(utf8_output.get(), utf8words);
+        if (!validutf8) {
           print_input(source, e);
           abort();
         }
-      }
-    } else {
-      // invalid input!!!
-      // We need a buffer of size where to write the UTF-16 words.
-      size_t expected_utf8words =
-          e->utf8_length_from_utf16le(utf16_source.get(), source.size() / 2);
-      std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
-      size_t utf8words = e->convert_utf16le_to_utf8(
-          utf16_source.get(), source.size() / 2, utf8_output.get());
-      if (utf8words != 0) {
-        print_input(source, e);
-        abort();
+        // convert it back:
+        // We need a buffer of size where to write the UTF-16 words.
+        size_t expected_utf16words =
+            e->utf16_length_from_utf8(utf8_output.get(), utf8words);
+        std::unique_ptr<char16_t[]> utf16_output{
+            new char16_t[expected_utf16words]};
+        // convert to UTF-8
+        size_t utf16words = e->convert_utf8_to_utf16le(
+            utf8_output.get(), utf8words, utf16_output.get());
+        for (size_t i = 0; i < source.size() / 2; i++) {
+          if (utf16_output.get()[i] != (utf16_source.get())[i]) {
+            print_input(source, e);
+            abort();
+          }
+        }
+      } else {
+        // invalid input!!!
+        // We need a buffer of size where to write the UTF-16 words.
+        size_t expected_utf8words =
+            e->utf8_length_from_utf16le(utf16_source.get(), source.size() / 2);
+        std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
+        size_t utf8words = e->convert_utf16le_to_utf8(
+            utf16_source.get(), source.size() / 2, utf8_output.get());
+        if (utf8words != 0) {
+          print_input(source, e);
+          abort();
+        }
       }
     }
 
     /**
      * Transcoding from UTF-16BE to UTF-8.
      */
-    // Get new source data here as this will allow the fuzzer to optimize it's
-    // input for UTF16-BE.
-    source = fdp.ConsumeRandomLengthString(kMaxStringSize);
-    bool validutf16be =
-        e->validate_utf16be(utf16_source.get(), source.size() / 2);
-    auto rutf16be =
-        e->validate_utf16be_with_errors(utf16_source.get(), source.size() / 2);
-    if (validutf16be !=
-        (rutf16be.error == simdutf::SUCCESS)) { // they should agree
-      print_input(source, e);
-      abort();
-    }
-    if (validutf16be) {
-      // We need a buffer of size where to write the UTF-16 words.
-      size_t expected_utf8words =
-          e->utf8_length_from_utf16be(utf16_source.get(), source.size() / 2);
-      std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
-      size_t utf8words = e->convert_utf16be_to_utf8(
-          utf16_source.get(), source.size() / 2, utf8_output.get());
-      // It wrote utf16words * sizeof(char16_t) bytes.
-      bool validutf8 = e->validate_utf8(utf8_output.get(), utf8words);
-      if (!validutf8) {
+    {
+      // Get new source data here as this will allow the fuzzer to optimize it's
+      // input for UTF16-BE.
+      source = fdp.ConsumeRandomLengthString(kMaxStringSize);
+      std::unique_ptr<char16_t[]> utf16_source{new char16_t[source.size() / 2]};
+      if (source.data() != nullptr) {
+        std::memcpy(utf16_source.get(), source.data(), source.size() / 2 * 2);
+      }
+      bool validutf16be =
+          e->validate_utf16be(utf16_source.get(), source.size() / 2);
+      auto rutf16be = e->validate_utf16be_with_errors(utf16_source.get(),
+                                                      source.size() / 2);
+      if (validutf16be !=
+          (rutf16be.error == simdutf::SUCCESS)) { // they should agree
         print_input(source, e);
         abort();
       }
-      // convert it back:
-      // We need a buffer of size where to write the UTF-16 words.
-      size_t expected_utf16words =
-          e->utf16_length_from_utf8(utf8_output.get(), utf8words);
-      std::unique_ptr<char16_t[]> utf16_output{
-          new char16_t[expected_utf16words]};
-      // convert to UTF-8
-      size_t utf16words = e->convert_utf8_to_utf16be(
-          utf8_output.get(), utf8words, utf16_output.get());
-      for (size_t i = 0; i < source.size() / 2; i++) {
-        if (utf16_output.get()[i] != (utf16_source.get())[i]) {
+      if (validutf16be) {
+        // We need a buffer of size where to write the UTF-16 words.
+        size_t expected_utf8words =
+            e->utf8_length_from_utf16be(utf16_source.get(), source.size() / 2);
+        std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
+        size_t utf8words = e->convert_utf16be_to_utf8(
+            utf16_source.get(), source.size() / 2, utf8_output.get());
+        // It wrote utf16words * sizeof(char16_t) bytes.
+        bool validutf8 = e->validate_utf8(utf8_output.get(), utf8words);
+        if (!validutf8) {
           print_input(source, e);
           abort();
         }
-      }
-    } else {
-      // invalid input!!!
-      // We need a buffer of size where to write the UTF-16 words.
-      size_t expected_utf8words =
-          e->utf8_length_from_utf16be(utf16_source.get(), source.size() / 2);
-      std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
-      size_t utf8words = e->convert_utf16be_to_utf8(
-          utf16_source.get(), source.size() / 2, utf8_output.get());
-      if (utf8words != 0) {
-        print_input(source, e);
-        abort();
+        // convert it back:
+        // We need a buffer of size where to write the UTF-16 words.
+        size_t expected_utf16words =
+            e->utf16_length_from_utf8(utf8_output.get(), utf8words);
+        std::unique_ptr<char16_t[]> utf16_output{
+            new char16_t[expected_utf16words]};
+        // convert to UTF-8
+        size_t utf16words = e->convert_utf8_to_utf16be(
+            utf8_output.get(), utf8words, utf16_output.get());
+        for (size_t i = 0; i < source.size() / 2; i++) {
+          if (utf16_output.get()[i] != (utf16_source.get())[i]) {
+            print_input(source, e);
+            abort();
+          }
+        }
+      } else {
+        // invalid input!!!
+        // We need a buffer of size where to write the UTF-16 words.
+        size_t expected_utf8words =
+            e->utf8_length_from_utf16be(utf16_source.get(), source.size() / 2);
+        std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
+        size_t utf8words = e->convert_utf16be_to_utf8(
+            utf16_source.get(), source.size() / 2, utf8_output.get());
+        if (utf8words != 0) {
+          print_input(source, e);
+          abort();
+        }
       }
     }
 

--- a/fuzz/roundtrip.cpp
+++ b/fuzz/roundtrip.cpp
@@ -229,8 +229,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     source = fdp.ConsumeRandomLengthString(kMaxStringSize);
     bool validutf16le =
         e->validate_utf16le(utf16_source.get(), source.size() / 2);
-    auto rutf16le = e->validate_utf16le_with_errors(utf16_source.get(),
-                                                    source.size() / 2);
+    auto rutf16le =
+        e->validate_utf16le_with_errors(utf16_source.get(), source.size() / 2);
     if (validutf16le !=
         (rutf16le.error == simdutf::SUCCESS)) { // they should agree
       print_input(source, e);
@@ -238,8 +238,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     }
     if (validutf16le) {
       // We need a buffer of size where to write the UTF-16 words.
-      size_t expected_utf8words = e->utf8_length_from_utf16le(
-          utf16_source.get(), source.size() / 2);
+      size_t expected_utf8words =
+          e->utf8_length_from_utf16le(utf16_source.get(), source.size() / 2);
       std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
       size_t utf8words = e->convert_utf16le_to_utf8(
           utf16_source.get(), source.size() / 2, utf8_output.get());
@@ -267,8 +267,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     } else {
       // invalid input!!!
       // We need a buffer of size where to write the UTF-16 words.
-      size_t expected_utf8words = e->utf8_length_from_utf16le(
-          utf16_source.get(), source.size() / 2);
+      size_t expected_utf8words =
+          e->utf8_length_from_utf16le(utf16_source.get(), source.size() / 2);
       std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
       size_t utf8words = e->convert_utf16le_to_utf8(
           utf16_source.get(), source.size() / 2, utf8_output.get());
@@ -286,8 +286,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     source = fdp.ConsumeRandomLengthString(kMaxStringSize);
     bool validutf16be =
         e->validate_utf16be(utf16_source.get(), source.size() / 2);
-    auto rutf16be = e->validate_utf16be_with_errors(utf16_source.get(),
-                                                    source.size() / 2);
+    auto rutf16be =
+        e->validate_utf16be_with_errors(utf16_source.get(), source.size() / 2);
     if (validutf16be !=
         (rutf16be.error == simdutf::SUCCESS)) { // they should agree
       print_input(source, e);
@@ -295,8 +295,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     }
     if (validutf16be) {
       // We need a buffer of size where to write the UTF-16 words.
-      size_t expected_utf8words = e->utf8_length_from_utf16be(
-          utf16_source.get(), source.size() / 2);
+      size_t expected_utf8words =
+          e->utf8_length_from_utf16be(utf16_source.get(), source.size() / 2);
       std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
       size_t utf8words = e->convert_utf16be_to_utf8(
           utf16_source.get(), source.size() / 2, utf8_output.get());
@@ -324,8 +324,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     } else {
       // invalid input!!!
       // We need a buffer of size where to write the UTF-16 words.
-      size_t expected_utf8words = e->utf8_length_from_utf16be(
-          utf16_source.get(), source.size() / 2);
+      size_t expected_utf8words =
+          e->utf8_length_from_utf16be(utf16_source.get(), source.size() / 2);
       std::unique_ptr<char[]> utf8_output{new char[expected_utf8words]};
       size_t utf8words = e->convert_utf16be_to_utf8(
           utf16_source.get(), source.size() / 2, utf8_output.get());

--- a/tests/random_fuzzer.cpp
+++ b/tests/random_fuzzer.cpp
@@ -54,7 +54,8 @@ void dump_case() {
 void __asan_on_error() { dump_case(); }
 }
 
-bool check_alignment(void* ptr, std::size_t alignment) {
+template <typename T>
+bool check_alignment(T* ptr, size_t alignment) {
   uintptr_t address = reinterpret_cast<uintptr_t>(ptr);
   return (address % alignment == 0);
 }

--- a/tests/random_fuzzer.cpp
+++ b/tests/random_fuzzer.cpp
@@ -710,7 +710,9 @@ bool fuzz_running(size_t N) {
     for (size_t k = 0; k < size; k++) {
       input[k] = char(distribution(generator));
     }
-    if (!run_test(input.data(), size)) {
+    if(!(reinterpret_cast<input.data()>(p) % std::alignment_of<char32_t>::value)) {
+      fprintf(stderr, "Misaligned input data, skipping\n");
+    } else if (!run_test(input.data(), size)) {
       return false;
     }
   }

--- a/tests/random_fuzzer.cpp
+++ b/tests/random_fuzzer.cpp
@@ -54,8 +54,7 @@ void dump_case() {
 void __asan_on_error() { dump_case(); }
 }
 
-template <typename T>
-bool check_alignment(T* ptr, size_t alignment) {
+template <typename T> bool check_alignment(T *ptr, size_t alignment) {
   uintptr_t address = reinterpret_cast<uintptr_t>(ptr);
   return (address % alignment == 0);
 }
@@ -79,12 +78,14 @@ int validate_tests(const char *databytes, size_t size_in_bytes) {
       result = e->validate_utf8_with_errors(
           reinterpret_cast<const char *>(data), size);
     }
-    if (check_alignment(data, 2) && std::is_same<T, char16_t>::value == true && bigendian) {
+    if (check_alignment(data, 2) && std::is_same<T, char16_t>::value == true &&
+        bigendian) {
       message = "utf16be";
       result = e->validate_utf16be_with_errors(
           reinterpret_cast<const char16_t *>(data), size);
     }
-    if (check_alignment(data, 2) && std::is_same<T, char16_t>::value == true && !bigendian) {
+    if (check_alignment(data, 2) && std::is_same<T, char16_t>::value == true &&
+        !bigendian) {
       message = "utf16le";
       result = e->validate_utf16le_with_errors(
           reinterpret_cast<const char16_t *>(data), size);
@@ -716,7 +717,7 @@ bool fuzz_running(size_t N) {
     for (size_t k = 0; k < size; k++) {
       input[k] = char(distribution(generator));
     }
-    if(!check_alignment(input.data(), 4)) {
+    if (!check_alignment(input.data(), 4)) {
       fprintf(stderr, "Misaligned input data, skipping\n");
     } else if (!run_test(input.data(), size)) {
       return false;


### PR DESCRIPTION
Some our tests cast char* pointers to char16_t* or char32_t* pointers without checking the alignment. This can trigger undefined behaviour. Let us be more careful.