### PR TITLE
add test case for buffer write overflow in convert_utf8_to_utf16be (arm64)

### DIFF
--- a/tests/convert_utf8_to_utf16be_with_errors_tests.cpp
+++ b/tests/convert_utf8_to_utf16be_with_errors_tests.cpp
@@ -17,6 +17,37 @@ using simdutf::tests::helpers::transcode_utf8_to_utf16_test_base;
 constexpr size_t trials = 10000;
 constexpr size_t fix_size = 512;
 } // namespace
+
+TEST(issue_631) {
+  // this test case caused an out of bounds write on arm64
+  alignas(1) const unsigned char data[] = {
+      0x20, 0xbf, 0xbf, 0xb0, 0x20, 0xb2, 0xb2, 0xb2, 0x20, 0xbf, 0x86,
+      0x9b, 0x20, 0x20, 0x20, 0x20, 0xff, 0x20, 0x20, 0x20, 0x20, 0x20,
+      0xb0, 0xb0, 0xb0, 0x20, 0xb2, 0xb2, 0xb2, 0x20, 0xbf, 0x86, 0x9b,
+      0x20, 0xb0, 0xb0, 0xb0, 0x20, 0xb2, 0xb2, 0xb2, 0x20, 0xbf, 0x86,
+      0x9b, 0x20, 0x20, 0x20, 0x20, 0x20, 0xb2, 0xb2, 0xb2, 0x20, 0xbf,
+      0x86, 0x9b, 0x20, 0xb2, 0xb2, 0xb2, 0x20, 0x20, 0x86, 0x9b, 0x20,
+      0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20};
+  constexpr std::size_t data_len_bytes = sizeof(data);
+  constexpr std::size_t data_len = data_len_bytes / sizeof(char);
+  const auto validation1 =
+      implementation.validate_utf8_with_errors((const char *)data, data_len);
+  ASSERT_EQUAL(validation1.count, 1);
+  ASSERT_EQUAL(validation1.error, simdutf::error_code::TOO_LONG);
+
+  const bool validation2 =
+      implementation.validate_utf8((const char *)data, data_len);
+  ASSERT_EQUAL(validation1.error == simdutf::error_code::SUCCESS, validation2);
+
+  const auto outlen =
+      implementation.utf16_length_from_utf8((const char *)data, data_len);
+  ASSERT_EQUAL(outlen, 36);
+  std::vector<char16_t> output(outlen);
+  const auto r = implementation.convert_utf8_to_utf16be(
+      (const char *)data, data_len, output.data());
+  ASSERT_EQUAL(r, 0);
+}
+
 TEST(issue_483) {
   const unsigned char data[] = {
       0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,


### PR DESCRIPTION
I found this by running on the freebsd arm64 system (thanks @clausecker !)
It also reproduces on debian arm64.

this is the error output on freebsd:
```
Running 'issue XXXX'... =================================================================
==62362==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x507000000068 at pc 0x0000003b06e8 bp 0xffffffffcf20 sp 0xffffffffcf18
WRITE of size 2 at 0x507000000068 thread T0
    #0 0x3b06e4 in unsigned long simdutf::arm64::(anonymous namespace)::convert_masked_utf8_to_utf16<(simdutf::endianness)1>(char const*, unsigned long, char16_t*&) /home/pauldreik/code/simdutf/src/arm64/arm_convert_utf8_to_utf16.cpp
    #1 0x37bcd8 in unsigned long simdutf::arm64::(anonymous namespace)::utf8_to_utf16::validating_transcoder::convert<(simdutf::endianness)1>(char const*, unsigned long, char16_t*) /home/pauldreik/code/simdutf/src/generic/utf8_to_utf16/utf8_to_utf16.h:194:18
    #2 0x37bcd8 in simdutf::arm64::implementation::convert_utf8_to_utf16be(char const*, unsigned long, char16_t*) const /home/pauldreik/code/simdutf/src/arm64/implementation.cpp:382:20
    #3 0x33e814 in test_impl_issue_XXXX(simdutf::implementation const&) /home/pauldreik/code/simdutf/tests/convert_utf8_to_utf16be_with_errors_tests.cpp:45:33
    #4 0x33e154 in issue_XXXX(simdutf::implementation const&) /home/pauldreik/code/simdutf/tests/convert_utf8_to_utf16be_with_errors_tests.cpp:21:1
    #5 0x34f12c in (anonymous namespace)::run((anonymous namespace)::CommandLine const&) /home/pauldreik/code/simdutf/tests/helpers/test.cpp:179:9
    #6 0x34f12c in simdutf::test::main(int, char**) /home/pauldreik/code/simdutf/tests/helpers/test.cpp:207:3
    #7 0x4089c570 in __libc_start1 /usr/src/lib/libc/csu/libc_start1.c:172:7
    #8 0x2874b0 in _start /usr/src/lib/csu/aarch64/crt1_s.S:62
```

this is the error output on debian:
```
Running 'issue XXXX'... =================================================================
==759811==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x607000000069 at pc 0xaaaace21250c bp 0xffffe96fecb0 sp 0xffffe96feca8
WRITE of size 12 at 0x607000000069 thread T0
    #0 0xaaaace212508 in unsigned long simdutf::arm64::(anonymous namespace)::convert_masked_utf8_to_utf16<(simdutf::endianness)1>(char const*, unsigned long, char16_t*&) /home/fuzzer/code/simdutf/src/arm64/arm_convert_utf8_to_utf16.cpp:186:25
    #1 0xaaaace1d33ec in unsigned long simdutf::arm64::(anonymous namespace)::utf8_to_utf16::validating_transcoder::convert<(simdutf::endianness)1>(char const*, unsigned long, char16_t*) /home/fuzzer/code/simdutf/src/generic/utf8_to_utf16/utf8_to_utf16.h:193:29
    #2 0xaaaace1d33ec in simdutf::arm64::implementation::convert_utf8_to_utf16be(char const*, unsigned long, char16_t*) const /home/fuzzer/code/simdutf/src/arm64/implementation.cpp:382:20
    #3 0xaaaace181374 in test_impl_issue_XXXX(simdutf::implementation const&) /home/fuzzer/code/simdutf/tests/convert_utf8_to_utf16be_with_errors_tests.cpp:45:33
    #4 0xaaaace180e2c in issue_XXXX(simdutf::implementation const&) /home/fuzzer/code/simdutf/tests/convert_utf8_to_utf16be_with_errors_tests.cpp:21:1
    #5 0xaaaace19f3c4 in simdutf::test::test_entry::operator()(simdutf::implementation const&) /home/fuzzer/code/simdutf/tests/helpers/test.h:18:58
    #6 0xaaaace19f3c4 in (anonymous namespace)::run((anonymous namespace)::CommandLine const&) /home/fuzzer/code/simdutf/tests/helpers/test.cpp:179:9
    #7 0xaaaace19f3c4 in simdutf::test::main(int, char**) /home/fuzzer/code/simdutf/tests/helpers/test.cpp:207:3
    #8 0xffff92c6773c in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #9 0xffff92c67814 in __libc_start_main csu/../csu/libc-start.c:360:3
    #10 0xaaaace0a836c in _start (/home/fuzzer/code/simdutf/build/tests/convert_utf8_to_utf16be_with_errors_tests+0x5836c) (BuildId: 9ef29024501f33d0cc71a0f8ed06f92ca455a72e)
```