### PR TITLE
Improve random fuzzer script

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -103,3 +103,51 @@ git clone https://github.com/simdutf/simdutf
 simdutf/fuzz/random_fuzz.sh
 # let it run as long as you wish for
 ```
+
+## Fuzzing using qemu
+
+It is useful to use virtualization for fuzzing on architectures when it
+is for some reason difficult or impractical to run on matching hardware.
+
+The [qemu project](https://www.qemu.org/) is very capable and already used for
+CI in this project.
+
+### Fuzzing on emulated riscv64 with vector extensions
+
+Debian is used, which provides a clang version with sanitizers enabled. There
+is a [project providing prebuilt qemu images](https://people.debian.org/~gio/dqib/)
+which are easy to use.
+
+This shows how to get the fuzzers running on a debian system (tested on
+Debian Trixie running amd64):
+
+ - install qemu: `apt install qemu-system-riscv`
+ - download the qemu image: `wget https://gitlab.com/api/v4/projects/giomasce%2Fdqib/jobs/artifacts/master/download?job=convert_riscv64-virt`
+ - unpack it: `unzip "download?job=convert_riscv64-virt"`
+
+Some adoption is needed for the provided readme.txt in the unpacked
+folder:
+
+ - set the number of cpus and memory
+ - remove the `-bios` argument
+ - specify vector extensions by adding to the `-cpu` flag
+
+The following commandlines worked successfully (pick one of them):
+```
+# 128 bit simd
+qemu-system-riscv64 -machine 'virt' -cpu 'rv64,v=on,vlen=128,rvv_ta_all_1s=on,rvv_ma_all_1s=on' -m 8G -smp 5 -device virtio-blk-device,drive=hd -drive file=image.qcow2,if=none,id=hd -device virtio-net-device,netdev=net -netdev user,id=net -kernel /usr/lib/u-boot/qemu-riscv64_smode/uboot.elf -object rng-random,filename=/dev/urandom,id=rng -device virtio-rng-device,rng=rng -nographic -append "root=LABEL=rootfs console=ttyS0"
+# 256 bit simd
+qemu-system-riscv64 -machine 'virt' -cpu 'rv64,v=on,zvbb=on,vlen=256,rvv_ta_all_1s=on,rvv_ma_all_1s=on' -m 8G -smp 5 -device virtio-blk-device,drive=hd -drive file=image.qcow2,if=none,id=hd -device virtio-net-device,netdev=net -netdev user,id=net -kernel /usr/lib/u-boot/qemu-riscv64_smode/uboot.elf -object rng-random,filename=/dev/urandom,id=rng -device virtio-rng-device,rng=rng -nographic -append "root=LABEL=rootfs console=ttyS0"
+" 1024 bit simd
+qemu-system-riscv64 -machine 'virt' -cpu 'rv64,v=on,zvbb=on,vlen=1024,rvv_ta_all_1s=on,rvv_ma_all_1s=on' -m 8G -smp 5 -device virtio-blk-device,drive=hd -drive file=image.qcow2,if=none,id=hd -device virtio-net-device,netdev=net -netdev user,id=net -kernel /usr/lib/u-boot/qemu-riscv64_smode/uboot.elf -object rng-random,filename=/dev/urandom,id=rng -device virtio-rng-device,rng=rng -nographic -append "root=LABEL=rootfs console=ttyS0"
+```
+
+Once the machine has booted, login with root/root. Update the machine with `apt
+update && apt dist-upgrade` and reboot it with ctrl-x ctrl-a, then login again.
+Install necessary packages with `apt install cmake clang-19 wget unzip`
+
+Inside the machine, follow the instructions in "Continuous fuzzing" above.
+
+The speed of emulation is pretty good. The conversion fuzzer currently reaches
+about 3300 executions/second per core on real hardware (Banana Pi BPI-F3) while
+emulation with 256 bit SIMD gives roughly 2/3 of that speed.

--- a/fuzz/random_fuzz.sh
+++ b/fuzz/random_fuzz.sh
@@ -108,6 +108,18 @@ while true ; do
 
     fuzzers="base64 conversion misc roundtrip"
     for fuzzer in $(echo $fuzzers|tr ' ' '\n' |sort --random-sort); do
+	if [ ! -d  "$corpusdir/$fuzzer" ] ; then
+	    # populate with the backup corpus from oss-fuzz
+	    mkdir -p $TMPWORKDIR/ossfuzzcorpus/$fuzzer
+	    cd $TMPWORKDIR/ossfuzzcorpus/$fuzzer
+	    # in case this fails, keep going.
+	    if wget "https://storage.googleapis.com/simdutf-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/simdutf_${fuzzer}/public.zip" ;then
+		mkdir -p "$corpusdir/$fuzzer"
+		unzip -q public.zip -d "$corpusdir/$fuzzer"
+		rm public.zip
+	    fi
+	    cd $src
+	fi
 	mkdir -p "$corpusdir/$fuzzer"
 	$BENICE fuzz/out/$fuzzer -timeout=100 -max_total_time=3600 -jobs=$(nproc) -workers=$(nproc) "$corpusdir/$fuzzer"
     done

--- a/fuzz/random_fuzz.sh
+++ b/fuzz/random_fuzz.sh
@@ -86,6 +86,31 @@ else
     BENICE=""
 fi
 
+# to get vector support on riscv64, we need to specify the arch
+MARCHFLAGS=
+case $(uname -m) in
+    x86_64)
+    # debian and rocky linux amd64
+    ;;
+    amd64)
+    # freebsd amd64
+    ;;
+    aarch64)
+    # debian arm64
+    ;;
+    arm64)
+    # freebsd arm64
+    ;;
+    arm)
+    # freebsd armv7
+    ;;
+    riscv64)
+	MARCHFLAGS="-march=rv64gcv"
+	;;
+    *)
+	;;
+esac
+
 while true ; do
 
     echo "pulling the latest changes"
@@ -94,7 +119,7 @@ while true ; do
     
     export CXX=$(selectrandomclang)
     optlevel=$(selectrandomoptlevel)
-    export CXXFLAGS="$(selectsanitizerflags) -g -O${optlevel}"
+    export CXXFLAGS="$(selectsanitizerflags) -g -O${optlevel} ${MARCHFLAGS}"
     export LIB_FUZZING_ENGINE="-fsanitize=fuzzer"
     export OUT=fuzz/out
     export WORK=fuzz/work


### PR DESCRIPTION
The important thing is that I with help from @camel-cdr  got fuzzing to work for riscv inside qemu.

It also speeds up the fuzzing by downloading the backup corpus from oss-fuzz instead of starting from zero.

I have run this on riscv inside qemu for about 50 cpu hours per simd width of 128, 256 and 1024. Nothing found!
