### PR TITLE
Add test for fuzzer finding on riscv using rvv_vl_half_avl=on

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -142,6 +142,10 @@ qemu-system-riscv64 -machine 'virt' -cpu 'rv64,v=on,zvbb=on,vlen=256,rvv_ta_all_
 qemu-system-riscv64 -machine 'virt' -cpu 'rv64,v=on,zvbb=on,vlen=1024,rvv_ta_all_1s=on,rvv_ma_all_1s=on' -m 8G -smp 5 -device virtio-blk-device,drive=hd -drive file=image.qcow2,if=none,id=hd -device virtio-net-device,netdev=net -netdev user,id=net -kernel /usr/lib/u-boot/qemu-riscv64_smode/uboot.elf -object rng-random,filename=/dev/urandom,id=rng -device virtio-rng-device,rng=rng -nographic -append "root=LABEL=rootfs console=ttyS0"
 ```
 
+Note: with a recent qemu (9.2.0 works fine), it is possible to append
+`,rvv_vl_half_avl=on` to the back of the -cpu option and exercise the code
+somewhat differently.
+
 Once the machine has booted, login with root/root. Update the machine with `apt
 update && apt dist-upgrade` and reboot it with ctrl-x ctrl-a, then login again.
 Install necessary packages with `apt install cmake clang-19 wget unzip`

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -155,3 +155,14 @@ Inside the machine, follow the instructions in "Continuous fuzzing" above.
 The speed of emulation is pretty good. The conversion fuzzer currently reaches
 about 3300 executions/second per core on real hardware (Banana Pi BPI-F3) while
 emulation with 256 bit SIMD gives roughly 2/3 of that speed.
+
+### Fuzzing on emulated s390x
+
+Use the same approach as described in the riscv64 section above, but use the 390x image instead. Boot with the following line instead of what is proposed in the readme.txt (tune memory and number of cores flags to your liking):
+
+```
+wget 'https://gitlab.com/api/v4/projects/giomasce%2Fdqib/jobs/artifacts/master/download?job=convert_s390x-virt'
+unzip 'download?job=convert_s390x-virt'
+cd dqib_s390x-virt
+qemu-system-s390x -machine s390-ccw-virtio -cpu max,zpci=on -m 4G -smp 2 -drive file=image.qcow2 -device virtio-net-ccw,netdev=net -netdev user,id=net,hostfwd=tcp::2222-:22 -kernel kernel -initrd initrd -nographic -append root=LABEL=rootfs console=ttyAMA0
+```

--- a/src/rvv/rvv_utf8_to.inl.cpp
+++ b/src/rvv/rvv_utf8_to.inl.cpp
@@ -40,6 +40,7 @@ simdutf_really_inline static size_t rvv_utf8_to_common(char const *src,
   const vuint8m1_t err3tbl =
       __riscv_vreinterpret_v_u64m1_u8m1(__riscv_vle64_v_u64m1(err3m, 2));
 
+  size_t vl8m1 = __riscv_vsetvlmax_e8m1();
   size_t vl8m2 = __riscv_vsetvlmax_e8m2();
   vbool4_t m4even = __riscv_vmseq_vx_u8m2_b4(
       __riscv_vand_vx_u8m2(__riscv_vid_v_u8m2(vl8m2), 1, vl8m2), 0, vl8m2);
@@ -232,7 +233,7 @@ simdutf_really_inline static size_t rvv_utf8_to_common(char const *src,
      * us to terminate early. */
     {
       size_t vlOutm2 = vlOut, vlDst;
-      vlOut = __riscv_vsetvl_e8m1(vlOut);
+      vlOut = __riscv_vsetvl_e8m1(vlOut < vl8m1 ? vlOut : vl8m1);
       SIMDUTF_RVV_UTF8_TO_COMMON_M1(0)
       if (vlOutm2 == vlOut) {
         vlOut = vlDst;


### PR DESCRIPTION
Note, this is preliminary!

This adds a test which exposes a problem on riscv, when run with the rvv_vl_half_avl=on flag passed to qemu. the entire cpu flag is `-cpu 'rv64,v=on,zvbb=on,vlen=256,rvv_ta_all_1s=on,rvv_ma_all_1s=on,rvv_vl_half_avl=on'`

When trying to recreate the fuzzer finding, I ran into unit tests failing:
```
root@debian:~/code/simdutf/build# tests/convert_valid_utf8_to_utf16le_tests 
Checking implementation rvv
Running 'issue xxx'...  OK
Running 'convert pure ASCII'... .................................................................................................... OK
Running 'convert 1 or 2 UTF8 bytes'... .................................................................................................... OK
Running 'convert 1 or 2 or 3 UTF8 bytes'... .................................................................................................... OK
Running 'convert 3 UTF8 bytes'... .................................................................................................... OK
Running 'convert 3 or 4 UTF8 bytes'... .................................................................................................... OK
Running 'convert null 4 UTF8 bytes'... .wrong saved bytes value: procedure returned 158 bytes, it should be 161
expected test(procedure) to be true, it's false
file /root/code/simdutf/tests/convert_valid_utf8_to_utf16le_tests.cpp:155, function test_impl_convert_null_4_UTF8_bytes 
```