### PR TITLE
Optimize icelake latin1 to utf32 for small inputs using masked AVX512 instructions

### DIFF
--- a/src/icelake/icelake_convert_latin1_to_utf32.inl.cpp
+++ b/src/icelake/icelake_convert_latin1_to_utf32.inl.cpp
@@ -1,20 +1,23 @@
-std::pair<const char *, char32_t *>
-avx512_convert_latin1_to_utf32(const char *buf, size_t len,
-                               char32_t *utf32_output) {
-  size_t rounded_len = len & ~0xF; // Round down to nearest multiple of 16
-
-  for (size_t i = 0; i < rounded_len; i += 16) {
+void avx512_convert_latin1_to_utf32(const char *buf, size_t len,
+                                    char32_t *utf32_output) {
+  while (len >= 16) {
     // Load 16 Latin1 characters into a 128-bit register
-    __m128i in = _mm_loadu_si128((__m128i *)&buf[i]);
+    __m128i in = _mm_loadu_si128((__m128i *)buf);
 
     // Zero extend each set of 8 Latin1 characters to 16 32-bit integers using
     // vpmovzxbd
     __m512i out = _mm512_cvtepu8_epi32(in);
 
     // Store the results back to memory
-    _mm512_storeu_si512((__m512i *)&utf32_output[i], out);
+    _mm512_storeu_si512((__m512i *)utf32_output, out);
+
+    len -= 16;
+    buf += 16;
+    utf32_output += 16;
   }
 
-  // Return pointers pointing to where we left off
-  return std::make_pair(buf + rounded_len, utf32_output + rounded_len);
+  __mmask16 mask = __mmask16((1 << len) - 1);
+  __m128i in = _mm_maskz_loadu_epi8(mask, buf);
+  __m512i out = _mm512_cvtepu8_epi32(in);
+  _mm512_mask_storeu_epi32((__m512i *)utf32_output, mask, out);
 }

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -519,21 +519,8 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf32(
     const char *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char *, char32_t *> ret =
-      avx512_convert_latin1_to_utf32(buf, len, utf32_output);
-  if (ret.first == nullptr) {
-    return 0;
-  }
-  size_t converted_chars = ret.second - utf32_output;
-  if (ret.first != buf + len) {
-    const size_t scalar_converted_chars = scalar::latin1_to_utf32::convert(
-        ret.first, len - (ret.first - buf), ret.second);
-    if (scalar_converted_chars == 0) {
-      return 0;
-    }
-    converted_chars += scalar_converted_chars;
-  }
-  return converted_chars;
+  avx512_convert_latin1_to_utf32(buf, len, utf32_output);
+  return len;
 }
 
 simdutf_warn_unused size_t implementation::convert_utf8_to_latin1(

--- a/tests/convert_latin1_to_utf32_tests.cpp
+++ b/tests/convert_latin1_to_utf32_tests.cpp
@@ -22,10 +22,13 @@ TEST_LOOP(trials, convert_all_latin1) {
                                           size_t size) -> size_t {
     return implementation.utf32_length_from_latin1(size);
   };
-  simdutf::tests::helpers::transcode_latin1_to_utf32_test_base test(generator,
-                                                                    256);
-  ASSERT_TRUE(test(procedure));
-  ASSERT_TRUE(test.check_size(size_procedure));
+  // Check varying length inputs for upto 16 bytes
+  for (size_t i = 240; i <= 256; i++) {
+    simdutf::tests::helpers::transcode_latin1_to_utf32_test_base test(generator,
+                                                                      i);
+    ASSERT_TRUE(test(procedure));
+    ASSERT_TRUE(test.check_size(size_procedure));
+  }
 }
 
 TEST_MAIN


### PR DESCRIPTION
Compute the final chunk using masked AVX512 instructions.
Add unit test for varying lengths instead of just fixed length 256 to cover the last block.