### PR TITLE
Extract ASCII validation into a separate file

### DIFF
--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -139,6 +139,7 @@ convert_utf8_1_to_2_byte_to_utf16(uint8x16_t in, size_t shufutf8_idx) {
 #include "generic/buf_block_reader.h"
 #include "generic/utf8_validation/utf8_lookup4_algorithm.h"
 #include "generic/utf8_validation/utf8_validator.h"
+#include "generic/ascii_validation.h"
 // transcoding from UTF-8 to UTF-16
 #include "generic/utf8_to_utf16/utf8_to_utf16.h"
 #include "generic/utf8_to_utf16/valid_utf8_to_utf16.h"
@@ -200,12 +201,12 @@ simdutf_warn_unused result implementation::validate_utf8_with_errors(
 
 simdutf_warn_unused bool
 implementation::validate_ascii(const char *buf, size_t len) const noexcept {
-  return arm64::utf8_validation::generic_validate_ascii(buf, len);
+  return arm64::ascii_validation::generic_validate_ascii(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_ascii_with_errors(
     const char *buf, size_t len) const noexcept {
-  return arm64::utf8_validation::generic_validate_ascii_with_errors(buf, len);
+  return arm64::ascii_validation::generic_validate_ascii_with_errors(buf, len);
 }
 
 simdutf_warn_unused bool

--- a/src/generic/ascii_validation.h
+++ b/src/generic/ascii_validation.h
@@ -1,0 +1,63 @@
+namespace simdutf {
+namespace SIMDUTF_IMPLEMENTATION {
+namespace {
+namespace ascii_validation {
+
+template <class checker>
+bool generic_validate_ascii(const uint8_t *input, size_t length) {
+  buf_block_reader<64> reader(input, length);
+  uint8_t blocks[64]{};
+  simd::simd8x64<uint8_t> running_or(blocks);
+  while (reader.has_full_block()) {
+    simd::simd8x64<uint8_t> in(reader.full_block());
+    running_or |= in;
+    reader.advance();
+  }
+  uint8_t block[64]{};
+  reader.get_remainder(block);
+  simd::simd8x64<uint8_t> in(block);
+  running_or |= in;
+  return running_or.is_ascii();
+}
+
+bool generic_validate_ascii(const char *input, size_t length) {
+  return generic_validate_ascii<utf8_checker>(
+      reinterpret_cast<const uint8_t *>(input), length);
+}
+
+template <class checker>
+result generic_validate_ascii_with_errors(const uint8_t *input, size_t length) {
+  buf_block_reader<64> reader(input, length);
+  size_t count{0};
+  while (reader.has_full_block()) {
+    simd::simd8x64<uint8_t> in(reader.full_block());
+    if (!in.is_ascii()) {
+      result res = scalar::ascii::validate_with_errors(
+          reinterpret_cast<const char *>(input + count), length - count);
+      return result(res.error, count + res.count);
+    }
+    reader.advance();
+
+    count += 64;
+  }
+  uint8_t block[64]{};
+  reader.get_remainder(block);
+  simd::simd8x64<uint8_t> in(block);
+  if (!in.is_ascii()) {
+    result res = scalar::ascii::validate_with_errors(
+        reinterpret_cast<const char *>(input + count), length - count);
+    return result(res.error, count + res.count);
+  } else {
+    return result(error_code::SUCCESS, length);
+  }
+}
+
+result generic_validate_ascii_with_errors(const char *input, size_t length) {
+  return generic_validate_ascii_with_errors<utf8_checker>(
+      reinterpret_cast<const uint8_t *>(input), length);
+}
+
+} // namespace ascii_validation
+} // unnamed namespace
+} // namespace SIMDUTF_IMPLEMENTATION
+} // namespace simdutf

--- a/src/generic/utf8_validation/utf8_validator.h
+++ b/src/generic/utf8_validation/utf8_validator.h
@@ -78,60 +78,6 @@ result generic_validate_utf8_with_errors(const char *input, size_t length) {
       reinterpret_cast<const uint8_t *>(input), length);
 }
 
-template <class checker>
-bool generic_validate_ascii(const uint8_t *input, size_t length) {
-  buf_block_reader<64> reader(input, length);
-  uint8_t blocks[64]{};
-  simd::simd8x64<uint8_t> running_or(blocks);
-  while (reader.has_full_block()) {
-    simd::simd8x64<uint8_t> in(reader.full_block());
-    running_or |= in;
-    reader.advance();
-  }
-  uint8_t block[64]{};
-  reader.get_remainder(block);
-  simd::simd8x64<uint8_t> in(block);
-  running_or |= in;
-  return running_or.is_ascii();
-}
-
-bool generic_validate_ascii(const char *input, size_t length) {
-  return generic_validate_ascii<utf8_checker>(
-      reinterpret_cast<const uint8_t *>(input), length);
-}
-
-template <class checker>
-result generic_validate_ascii_with_errors(const uint8_t *input, size_t length) {
-  buf_block_reader<64> reader(input, length);
-  size_t count{0};
-  while (reader.has_full_block()) {
-    simd::simd8x64<uint8_t> in(reader.full_block());
-    if (!in.is_ascii()) {
-      result res = scalar::ascii::validate_with_errors(
-          reinterpret_cast<const char *>(input + count), length - count);
-      return result(res.error, count + res.count);
-    }
-    reader.advance();
-
-    count += 64;
-  }
-  uint8_t block[64]{};
-  reader.get_remainder(block);
-  simd::simd8x64<uint8_t> in(block);
-  if (!in.is_ascii()) {
-    result res = scalar::ascii::validate_with_errors(
-        reinterpret_cast<const char *>(input + count), length - count);
-    return result(res.error, count + res.count);
-  } else {
-    return result(error_code::SUCCESS, length);
-  }
-}
-
-result generic_validate_ascii_with_errors(const char *input, size_t length) {
-  return generic_validate_ascii_with_errors<utf8_checker>(
-      reinterpret_cast<const uint8_t *>(input), length);
-}
-
 } // namespace utf8_validation
 } // unnamed namespace
 } // namespace SIMDUTF_IMPLEMENTATION

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -77,6 +77,7 @@ must_be_2_3_continuation(const simd8<uint8_t> prev2,
 #include "generic/buf_block_reader.h"
 #include "generic/utf8_validation/utf8_lookup4_algorithm.h"
 #include "generic/utf8_validation/utf8_validator.h"
+#include "generic/ascii_validation.h"
 // transcoding from UTF-8 to UTF-16
 #include "generic/utf8_to_utf16/valid_utf8_to_utf16.h"
 #include "generic/utf8_to_utf16/utf8_to_utf16.h"
@@ -215,12 +216,13 @@ simdutf_warn_unused result implementation::validate_utf8_with_errors(
 
 simdutf_warn_unused bool
 implementation::validate_ascii(const char *buf, size_t len) const noexcept {
-  return haswell::utf8_validation::generic_validate_ascii(buf, len);
+  return haswell::ascii_validation::generic_validate_ascii(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_ascii_with_errors(
     const char *buf, size_t len) const noexcept {
-  return haswell::utf8_validation::generic_validate_ascii_with_errors(buf, len);
+  return haswell::ascii_validation::generic_validate_ascii_with_errors(buf,
+                                                                       len);
 }
 
 simdutf_warn_unused bool

--- a/src/lasx/implementation.cpp
+++ b/src/lasx/implementation.cpp
@@ -148,6 +148,7 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
 #include "generic/buf_block_reader.h"
 #include "generic/utf8_validation/utf8_lookup4_algorithm.h"
 #include "generic/utf8_validation/utf8_validator.h"
+#include "generic/ascii_validation.h"
 
 // transcoding from UTF-8 to Latin 1
 #include "generic/utf8_to_latin1/utf8_to_latin1.h"
@@ -212,12 +213,12 @@ simdutf_warn_unused result implementation::validate_utf8_with_errors(
 
 simdutf_warn_unused bool
 implementation::validate_ascii(const char *buf, size_t len) const noexcept {
-  return lasx::utf8_validation::generic_validate_ascii(buf, len);
+  return lasx::ascii_validation::generic_validate_ascii(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_ascii_with_errors(
     const char *buf, size_t len) const noexcept {
-  return lasx::utf8_validation::generic_validate_ascii_with_errors(buf, len);
+  return lasx::ascii_validation::generic_validate_ascii_with_errors(buf, len);
 }
 
 simdutf_warn_unused bool

--- a/src/lsx/implementation.cpp
+++ b/src/lsx/implementation.cpp
@@ -148,6 +148,7 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
 #include "generic/buf_block_reader.h"
 #include "generic/utf8_validation/utf8_lookup4_algorithm.h"
 #include "generic/utf8_validation/utf8_validator.h"
+#include "generic/ascii_validation.h"
 
 // transcoding from UTF-8 to Latin 1
 #include "generic/utf8_to_latin1/utf8_to_latin1.h"
@@ -212,12 +213,12 @@ simdutf_warn_unused result implementation::validate_utf8_with_errors(
 
 simdutf_warn_unused bool
 implementation::validate_ascii(const char *buf, size_t len) const noexcept {
-  return lsx::utf8_validation::generic_validate_ascii(buf, len);
+  return lsx::ascii_validation::generic_validate_ascii(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_ascii_with_errors(
     const char *buf, size_t len) const noexcept {
-  return lsx::utf8_validation::generic_validate_ascii_with_errors(buf, len);
+  return lsx::ascii_validation::generic_validate_ascii_with_errors(buf, len);
 }
 
 simdutf_warn_unused bool

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -65,6 +65,7 @@ must_be_2_3_continuation(const simd8<uint8_t> prev2,
 #include "generic/buf_block_reader.h"
 #include "generic/utf8_validation/utf8_lookup4_algorithm.h"
 #include "generic/utf8_validation/utf8_validator.h"
+#include "generic/ascii_validation.h"
 // transcoding from UTF-8 to UTF-16
 #include "generic/utf8_to_utf16/valid_utf8_to_utf16.h"
 #include "generic/utf8_to_utf16/utf8_to_utf16.h"
@@ -238,13 +239,13 @@ simdutf_warn_unused result implementation::validate_utf8_with_errors(
 
 simdutf_warn_unused bool
 implementation::validate_ascii(const char *buf, size_t len) const noexcept {
-  return westmere::utf8_validation::generic_validate_ascii(buf, len);
+  return westmere::ascii_validation::generic_validate_ascii(buf, len);
 }
 
 simdutf_warn_unused result implementation::validate_ascii_with_errors(
     const char *buf, size_t len) const noexcept {
-  return westmere::utf8_validation::generic_validate_ascii_with_errors(buf,
-                                                                       len);
+  return westmere::ascii_validation::generic_validate_ascii_with_errors(buf,
+                                                                        len);
 }
 
 simdutf_warn_unused bool


### PR DESCRIPTION
This is just a technical change required by #637 (selective amalgamation). For instance, if we want just ASCII & UTF-16 support, there's no need to include UTF-8 stuff.