### PR TITLE
Sort out including scalar/* files

### DIFF
--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -152,9 +152,6 @@ convert_utf8_1_to_2_byte_to_utf16(uint8x16_t in, size_t shufutf8_idx) {
 #include "generic/utf8_to_latin1/utf8_to_latin1.h"
 #include "generic/utf8_to_latin1/valid_utf8_to_latin1.h"
 
-// placeholder scalars
-#include "scalar/latin1.h"
-
 //
 // Implementation-specific overrides
 //

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -1,36 +1,5 @@
 #include "simdutf/fallback/begin.h"
 
-#include "scalar/utf8_to_utf16/valid_utf8_to_utf16.h"
-#include "scalar/utf8_to_utf16/utf8_to_utf16.h"
-
-#include "scalar/utf8_to_utf32/valid_utf8_to_utf32.h"
-#include "scalar/utf8_to_utf32/utf8_to_utf32.h"
-
-#include "scalar/utf8_to_latin1/valid_utf8_to_latin1.h"
-#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
-
-#include "scalar/utf16_to_utf8/valid_utf16_to_utf8.h"
-#include "scalar/utf16_to_utf8/utf16_to_utf8.h"
-
-#include "scalar/utf16_to_utf32/valid_utf16_to_utf32.h"
-#include "scalar/utf16_to_utf32/utf16_to_utf32.h"
-
-#include "scalar/utf32_to_utf8/valid_utf32_to_utf8.h"
-#include "scalar/utf32_to_utf8/utf32_to_utf8.h"
-
-#include "scalar/utf32_to_utf16/valid_utf32_to_utf16.h"
-#include "scalar/utf32_to_utf16/utf32_to_utf16.h"
-
-#include "scalar/ascii.h"
-#include "scalar/base64.h"
-#include "scalar/utf8.h"
-#include "scalar/utf16.h"
-#include "scalar/latin1.h"
-#include "scalar/utf8_to_latin1/valid_utf8_to_latin1.h"
-#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
-#include <cstdint>
-#include <cstring>
-
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
 

--- a/src/generic/utf16.h
+++ b/src/generic/utf16.h
@@ -1,4 +1,3 @@
-#include "scalar/utf16.h"
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
 namespace {

--- a/src/generic/utf8.h
+++ b/src/generic/utf8.h
@@ -1,5 +1,3 @@
-#include "scalar/utf8.h"
-
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
 namespace {

--- a/src/generic/utf8_to_latin1/utf8_to_latin1.h
+++ b/src/generic/utf8_to_latin1/utf8_to_latin1.h
@@ -1,5 +1,3 @@
-#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
-
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
 namespace {

--- a/src/generic/utf8_to_latin1/valid_utf8_to_latin1.h
+++ b/src/generic/utf8_to_latin1/valid_utf8_to_latin1.h
@@ -1,5 +1,3 @@
-#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
-
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
 namespace {

--- a/src/generic/utf8_to_utf16/utf8_to_utf16.h
+++ b/src/generic/utf8_to_utf16/utf8_to_utf16.h
@@ -1,5 +1,3 @@
-#include "scalar/utf8_to_utf16/utf8_to_utf16.h"
-
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
 namespace {

--- a/src/generic/utf8_to_utf16/valid_utf8_to_utf16.h
+++ b/src/generic/utf8_to_utf16/valid_utf8_to_utf16.h
@@ -1,5 +1,3 @@
-#include "scalar/utf8_to_utf16/utf8_to_utf16.h"
-
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
 namespace {

--- a/src/generic/utf8_to_utf32/utf8_to_utf32.h
+++ b/src/generic/utf8_to_utf32/utf8_to_utf32.h
@@ -1,5 +1,3 @@
-#include "scalar/utf8_to_utf32/utf8_to_utf32.h"
-
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
 namespace {

--- a/src/generic/utf8_to_utf32/valid_utf8_to_utf32.h
+++ b/src/generic/utf8_to_utf32/valid_utf8_to_utf32.h
@@ -1,5 +1,3 @@
-#include "scalar/utf8_to_utf32/valid_utf8_to_utf32.h"
-
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
 namespace {

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -1,15 +1,3 @@
-#include "tables/utf8_to_utf16_tables.h"
-#include "scalar/utf8_to_utf16/valid_utf8_to_utf16.h"
-#include "scalar/utf8_to_utf16/utf8_to_utf16.h"
-#include "scalar/utf8_to_utf32/valid_utf8_to_utf32.h"
-#include "scalar/utf8_to_utf32/utf8_to_utf32.h"
-#include "tables/utf16_to_utf8_tables.h"
-#include "scalar/utf8.h"
-#include "scalar/utf16.h"
-#include "scalar/latin1.h"
-#include "scalar/utf8_to_latin1/valid_utf8_to_latin1.h"
-#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
-
 #include "simdutf/haswell/begin.h"
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -2,16 +2,6 @@
 #include <utility>
 #include "simdutf/icelake/intrinsics.h"
 
-#include "scalar/utf16_to_utf8/valid_utf16_to_utf8.h"
-#include "scalar/utf16_to_utf8/utf16_to_utf8.h"
-#include "scalar/utf8_to_utf16/valid_utf8_to_utf16.h"
-#include "scalar/utf8_to_utf16/utf8_to_utf16.h"
-#include "scalar/utf8.h"
-#include "scalar/utf16.h"
-#include "scalar/latin1.h"
-#include "scalar/utf8_to_latin1/valid_utf8_to_latin1.h"
-#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
-
 #include "simdutf/icelake/begin.h"
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -28,24 +28,6 @@ template <typename T> std::string toBinaryString(T b) {
 } // namespace
 } // namespace simdutf
 
-// Implementations
-// The best choice should always come first!
-#include "simdutf/arm64.h"
-#include "simdutf/icelake.h"
-#include "simdutf/haswell.h"
-#include "simdutf/westmere.h"
-#include "simdutf/ppc64.h"
-#include "simdutf/rvv.h"
-#include "simdutf/lsx.h"
-#include "simdutf/lasx.h"
-#include "simdutf/fallback.h" // have it always last.
-
-#include "scalar/utf8.h"
-#include "scalar/utf16.h"
-#include "scalar/utf32.h"
-#include "scalar/base64.h"
-#include "scalar/latin1_to_utf8/latin1_to_utf8.h"
-
 namespace simdutf {
 bool implementation::supported_by_runtime_system() const {
   uint32_t required_instruction_sets = this->required_instruction_sets();

--- a/src/lasx/implementation.cpp
+++ b/src/lasx/implementation.cpp
@@ -159,13 +159,9 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
 #include "generic/utf8_to_utf32/valid_utf8_to_utf32.h"
 #include "generic/utf8_to_utf32/utf8_to_utf32.h"
 
-#include "scalar/utf32_to_utf16/valid_utf32_to_utf16.h"
-#include "scalar/utf32_to_utf16/utf32_to_utf16.h"
-
 // other functions
 #include "generic/utf8.h"
 #include "generic/utf16.h"
-#include "scalar/latin1.h"
 
 //
 // Implementation-specific overrides

--- a/src/lsx/implementation.cpp
+++ b/src/lsx/implementation.cpp
@@ -159,13 +159,9 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
 #include "generic/utf8_to_utf32/valid_utf8_to_utf32.h"
 #include "generic/utf8_to_utf32/utf8_to_utf32.h"
 
-#include "scalar/utf32_to_utf16/valid_utf32_to_utf16.h"
-#include "scalar/utf32_to_utf16/utf32_to_utf16.h"
-
 // other functions
 #include "generic/utf8.h"
 #include "generic/utf16.h"
-#include "scalar/latin1.h"
 
 //
 // Implementation-specific overrides

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -1,21 +1,3 @@
-#include "scalar/latin1.h"
-#include "scalar/utf16.h"
-#include "scalar/utf8.h"
-#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
-#include "scalar/utf8_to_latin1/valid_utf8_to_latin1.h"
-
-#include "scalar/utf16_to_utf8/utf16_to_utf8.h"
-#include "scalar/utf16_to_utf8/valid_utf16_to_utf8.h"
-
-#include "scalar/utf16_to_utf32/utf16_to_utf32.h"
-#include "scalar/utf16_to_utf32/valid_utf16_to_utf32.h"
-
-#include "scalar/utf32_to_utf8/utf32_to_utf8.h"
-#include "scalar/utf32_to_utf8/valid_utf32_to_utf8.h"
-
-#include "scalar/utf32_to_utf16/utf32_to_utf16.h"
-#include "scalar/utf32_to_utf16/valid_utf32_to_utf16.h"
-
 #include "simdutf/ppc64/begin.h"
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {

--- a/src/rvv/implementation.cpp
+++ b/src/rvv/implementation.cpp
@@ -1,21 +1,3 @@
-#include "scalar/latin1.h"
-#include "scalar/utf16.h"
-#include "scalar/utf8.h"
-#include "scalar/utf8_to_latin1/utf8_to_latin1.h"
-#include "scalar/utf8_to_latin1/valid_utf8_to_latin1.h"
-
-#include "scalar/utf16_to_utf8/utf16_to_utf8.h"
-#include "scalar/utf16_to_utf8/valid_utf16_to_utf8.h"
-
-#include "scalar/utf16_to_utf32/utf16_to_utf32.h"
-#include "scalar/utf16_to_utf32/valid_utf16_to_utf32.h"
-
-#include "scalar/utf32_to_utf8/utf32_to_utf8.h"
-#include "scalar/utf32_to_utf8/valid_utf32_to_utf8.h"
-
-#include "scalar/utf32_to_utf16/utf32_to_utf16.h"
-#include "scalar/utf32_to_utf16/valid_utf32_to_utf16.h"
-
 #include "simdutf/rvv/begin.h"
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {

--- a/src/simdutf.cpp
+++ b/src/simdutf.cpp
@@ -1,7 +1,6 @@
 #include "simdutf.h"
 // We include base64_tables once.
 #include "tables/base64_tables.h"
-#include "implementation.cpp"
 #include "encoding_types.cpp"
 #include "error.cpp"
 // The large tables should be included once and they
@@ -9,6 +8,21 @@
 #include "tables/utf8_to_utf16_tables.h"
 #include "tables/utf16_to_utf8_tables.h"
 // End of tables.
+
+// Implementations: they need to be setup before including
+// scalar/* code, as the scalar code is sometimes enabled
+// only for peculiar build targets.
+
+// The best choice should always come first!
+#include "simdutf/arm64.h"
+#include "simdutf/icelake.h"
+#include "simdutf/haswell.h"
+#include "simdutf/westmere.h"
+#include "simdutf/ppc64.h"
+#include "simdutf/rvv.h"
+#include "simdutf/lsx.h"
+#include "simdutf/lasx.h"
+#include "simdutf/fallback.h" // have it always last.
 
 // The scalar routines should be included once.
 #include "scalar/ascii.h"
@@ -47,6 +61,8 @@
 #include "scalar/utf8_to_latin1/valid_utf8_to_latin1.h"
 #include "scalar/utf16_to_latin1/valid_utf16_to_latin1.h"
 #include "scalar/utf32_to_latin1/valid_utf32_to_latin1.h"
+
+#include "implementation.cpp"
 
 SIMDUTF_PUSH_DISABLE_WARNINGS
 SIMDUTF_DISABLE_UNDESIRED_WARNINGS


### PR DESCRIPTION
Per our comment, include scalar/* files exactly once. Before including these files, include implementation headers, thanks to that we may disable/enable certain common code onwards.