### PR TITLE
Simplify calculating length latin1 <=> UTF16/UTF32

### DIFF
--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -3980,7 +3980,9 @@ public:
    * @return the number of bytes required to encode the UTF-16 string as Latin1
    */
   simdutf_warn_unused virtual size_t
-  utf16_length_from_latin1(size_t length) const noexcept = 0;
+  utf16_length_from_latin1(size_t length) const noexcept {
+    return length;
+  }
 
   /**
    * Convert possibly broken UTF-32 string into UTF-16LE string.
@@ -4156,7 +4158,9 @@ public:
    * @return the number of bytes required to encode the UTF-32 string as Latin1
    */
   simdutf_warn_unused virtual size_t
-  latin1_length_from_utf32(size_t length) const noexcept = 0;
+  latin1_length_from_utf32(size_t length) const noexcept {
+    return length;
+  }
 
   /**
    * Compute the number of bytes that this UTF-8 string would require in Latin1
@@ -4188,7 +4192,9 @@ public:
    * Latin1
    */
   simdutf_warn_unused virtual size_t
-  latin1_length_from_utf16(size_t length) const noexcept = 0;
+  latin1_length_from_utf16(size_t length) const noexcept {
+    return length;
+  }
 
   /**
    * Compute the number of two-byte code units that this UTF-32 string would
@@ -4216,7 +4222,9 @@ public:
    * @return the number of bytes required to encode the UTF-32 string as Latin1
    */
   simdutf_warn_unused virtual size_t
-  utf32_length_from_latin1(size_t length) const noexcept = 0;
+  utf32_length_from_latin1(size_t length) const noexcept {
+    return length;
+  }
 
   /**
    * Compute the number of bytes that this UTF-16LE string would require in

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -982,16 +982,6 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf8(
   return count_utf8(buf, len);
 }
 
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf16(size_t length) const noexcept {
-  return scalar::utf16::latin1_length_from_utf16(length);
-}
-
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf32(size_t length) const noexcept {
-  return scalar::utf32::latin1_length_from_utf32(length);
-}
-
 simdutf_warn_unused size_t implementation::utf8_length_from_latin1(
     const char *input, size_t length) const noexcept {
   // See
@@ -1023,16 +1013,6 @@ simdutf_warn_unused size_t implementation::utf8_length_from_utf16le(
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16be(
     const char16_t *input, size_t length) const noexcept {
   return utf16::utf8_length_from_utf16<endianness::BIG>(input, length);
-}
-
-simdutf_warn_unused size_t
-implementation::utf16_length_from_latin1(size_t length) const noexcept {
-  return scalar::latin1::utf16_length_from_latin1(length);
-}
-
-simdutf_warn_unused size_t
-implementation::utf32_length_from_latin1(size_t length) const noexcept {
-  return scalar::latin1::utf32_length_from_latin1(length);
 }
 
 simdutf_warn_unused size_t implementation::utf32_length_from_utf16le(

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -402,16 +402,6 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf8(
   return scalar::utf8::count_code_points(buf, len);
 }
 
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf16(size_t length) const noexcept {
-  return scalar::utf16::latin1_length_from_utf16(length);
-}
-
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf32(size_t length) const noexcept {
-  return length;
-}
-
 simdutf_warn_unused size_t implementation::utf8_length_from_latin1(
     const char *input, size_t length) const noexcept {
   size_t answer = length;
@@ -465,11 +455,6 @@ simdutf_warn_unused size_t implementation::utf32_length_from_utf16be(
   return scalar::utf16::utf32_length_from_utf16<endianness::BIG>(input, length);
 }
 
-simdutf_warn_unused size_t
-implementation::utf16_length_from_latin1(size_t length) const noexcept {
-  return scalar::latin1::utf16_length_from_latin1(length);
-}
-
 simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
     const char *input, size_t length) const noexcept {
   return scalar::utf8::utf16_length_from_utf8(input, length);
@@ -483,11 +468,6 @@ simdutf_warn_unused size_t implementation::utf8_length_from_utf32(
 simdutf_warn_unused size_t implementation::utf16_length_from_utf32(
     const char32_t *input, size_t length) const noexcept {
   return scalar::utf32::utf16_length_from_utf32(input, length);
-}
-
-simdutf_warn_unused size_t
-implementation::utf32_length_from_latin1(size_t length) const noexcept {
-  return scalar::latin1::utf32_length_from_latin1(length);
 }
 
 simdutf_warn_unused size_t implementation::utf32_length_from_utf8(

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -997,16 +997,6 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf8(
   return count_utf8(buf, len);
 }
 
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf16(size_t length) const noexcept {
-  return scalar::utf16::latin1_length_from_utf16(length);
-}
-
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf32(size_t length) const noexcept {
-  return scalar::utf32::latin1_length_from_utf32(length);
-}
-
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16le(
     const char16_t *input, size_t length) const noexcept {
   return utf16::utf8_length_from_utf16<endianness::LITTLE>(input, length);
@@ -1027,19 +1017,9 @@ simdutf_warn_unused size_t implementation::utf32_length_from_utf16be(
   return utf16::utf32_length_from_utf16<endianness::BIG>(input, length);
 }
 
-simdutf_warn_unused size_t
-implementation::utf16_length_from_latin1(size_t length) const noexcept {
-  return scalar::latin1::utf16_length_from_latin1(length);
-}
-
 simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
     const char *input, size_t length) const noexcept {
   return utf8::utf16_length_from_utf8(input, length);
-}
-
-simdutf_warn_unused size_t
-implementation::utf32_length_from_latin1(size_t length) const noexcept {
-  return scalar::latin1::utf32_length_from_latin1(length);
 }
 
 simdutf_warn_unused size_t implementation::utf8_length_from_latin1(

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -1323,16 +1323,6 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf8(
   return count_utf8(buf, len);
 }
 
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf16(size_t length) const noexcept {
-  return scalar::utf16::latin1_length_from_utf16(length);
-}
-
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf32(size_t length) const noexcept {
-  return scalar::utf32::latin1_length_from_utf32(length);
-}
-
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16le(
     const char16_t *input, size_t length) const noexcept {
   const char16_t *ptr = input;
@@ -1422,16 +1412,6 @@ simdutf_warn_unused size_t implementation::utf32_length_from_utf16le(
 simdutf_warn_unused size_t implementation::utf32_length_from_utf16be(
     const char16_t *input, size_t length) const noexcept {
   return implementation::count_utf16be(input, length);
-}
-
-simdutf_warn_unused size_t
-implementation::utf16_length_from_latin1(size_t length) const noexcept {
-  return scalar::latin1::utf16_length_from_latin1(length);
-}
-
-simdutf_warn_unused size_t
-implementation::utf32_length_from_latin1(size_t length) const noexcept {
-  return scalar::latin1::utf32_length_from_latin1(length);
 }
 
 simdutf_warn_unused size_t implementation::utf8_length_from_latin1(

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -575,16 +575,6 @@ public:
   }
 
   simdutf_warn_unused size_t
-  latin1_length_from_utf16(size_t len) const noexcept override {
-    return set_best()->latin1_length_from_utf16(len);
-  }
-
-  simdutf_warn_unused size_t
-  latin1_length_from_utf32(size_t len) const noexcept override {
-    return set_best()->latin1_length_from_utf32(len);
-  }
-
-  simdutf_warn_unused size_t
   utf8_length_from_latin1(const char *buf, size_t len) const noexcept override {
     return set_best()->utf8_length_from_latin1(buf, len);
   }
@@ -597,16 +587,6 @@ public:
   simdutf_warn_unused size_t utf8_length_from_utf16be(
       const char16_t *buf, size_t len) const noexcept override {
     return set_best()->utf8_length_from_utf16be(buf, len);
-  }
-
-  simdutf_warn_unused size_t
-  utf16_length_from_latin1(size_t len) const noexcept override {
-    return set_best()->utf16_length_from_latin1(len);
-  }
-
-  simdutf_warn_unused size_t
-  utf32_length_from_latin1(size_t len) const noexcept override {
-    return set_best()->utf32_length_from_latin1(len);
   }
 
   simdutf_warn_unused size_t utf32_length_from_utf16le(
@@ -1066,15 +1046,6 @@ public:
   }
 
   simdutf_warn_unused size_t
-  latin1_length_from_utf16(size_t) const noexcept override {
-    return 0;
-  }
-
-  simdutf_warn_unused size_t
-  latin1_length_from_utf32(size_t) const noexcept override {
-    return 0;
-  }
-  simdutf_warn_unused size_t
   utf8_length_from_latin1(const char *, size_t) const noexcept override {
     return 0;
   }
@@ -1100,18 +1071,10 @@ public:
   }
 
   simdutf_warn_unused size_t
-  utf32_length_from_latin1(size_t) const noexcept override {
-    return 0;
-  }
-
-  simdutf_warn_unused size_t
   utf16_length_from_utf8(const char *, size_t) const noexcept override {
     return 0;
   }
-  simdutf_warn_unused size_t
-  utf16_length_from_latin1(size_t) const noexcept override {
-    return 0;
-  }
+
   simdutf_warn_unused size_t
   utf8_length_from_utf32(const char32_t *, size_t) const noexcept override {
     return 0;
@@ -1708,12 +1671,6 @@ simdutf_warn_unused size_t latin1_length_from_utf8(const char *buf,
                                                    size_t len) noexcept {
   return get_default_implementation()->latin1_length_from_utf8(buf, len);
 }
-simdutf_warn_unused size_t latin1_length_from_utf16(size_t len) noexcept {
-  return get_default_implementation()->latin1_length_from_utf16(len);
-}
-simdutf_warn_unused size_t latin1_length_from_utf32(size_t len) noexcept {
-  return get_default_implementation()->latin1_length_from_utf32(len);
-}
 simdutf_warn_unused size_t utf8_length_from_latin1(const char *buf,
                                                    size_t len) noexcept {
   return get_default_implementation()->utf8_length_from_latin1(buf, len);
@@ -1753,9 +1710,6 @@ simdutf_warn_unused size_t utf32_length_from_utf16be(const char16_t *input,
 simdutf_warn_unused size_t utf16_length_from_utf8(const char *input,
                                                   size_t length) noexcept {
   return get_default_implementation()->utf16_length_from_utf8(input, length);
-}
-simdutf_warn_unused size_t utf16_length_from_latin1(size_t length) noexcept {
-  return get_default_implementation()->utf16_length_from_latin1(length);
 }
 simdutf_warn_unused size_t utf8_length_from_utf32(const char32_t *input,
                                                   size_t length) noexcept {

--- a/src/lasx/implementation.cpp
+++ b/src/lasx/implementation.cpp
@@ -1109,16 +1109,6 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf8(
   return count_utf8(buf, len);
 }
 
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf16(size_t length) const noexcept {
-  return length;
-}
-
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf32(size_t length) const noexcept {
-  return length;
-}
-
 simdutf_warn_unused size_t implementation::utf8_length_from_latin1(
     const char *input, size_t length) const noexcept {
   const uint8_t *data = reinterpret_cast<const uint8_t *>(input);
@@ -1144,16 +1134,6 @@ simdutf_warn_unused size_t implementation::utf8_length_from_utf16le(
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16be(
     const char16_t *input, size_t length) const noexcept {
   return utf16::utf8_length_from_utf16<endianness::BIG>(input, length);
-}
-
-simdutf_warn_unused size_t
-implementation::utf16_length_from_latin1(size_t length) const noexcept {
-  return length;
-}
-
-simdutf_warn_unused size_t
-implementation::utf32_length_from_latin1(size_t length) const noexcept {
-  return length;
 }
 
 simdutf_warn_unused size_t implementation::utf32_length_from_utf16le(

--- a/src/lsx/implementation.cpp
+++ b/src/lsx/implementation.cpp
@@ -995,16 +995,6 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf8(
   return count_utf8(buf, len);
 }
 
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf16(size_t length) const noexcept {
-  return length;
-}
-
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf32(size_t length) const noexcept {
-  return length;
-}
-
 simdutf_warn_unused size_t implementation::utf8_length_from_latin1(
     const char *input, size_t length) const noexcept {
   const uint8_t *data = reinterpret_cast<const uint8_t *>(input);
@@ -1030,16 +1020,6 @@ simdutf_warn_unused size_t implementation::utf8_length_from_utf16le(
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16be(
     const char16_t *input, size_t length) const noexcept {
   return utf16::utf8_length_from_utf16<endianness::BIG>(input, length);
-}
-
-simdutf_warn_unused size_t
-implementation::utf16_length_from_latin1(size_t length) const noexcept {
-  return length;
-}
-
-simdutf_warn_unused size_t
-implementation::utf32_length_from_latin1(size_t length) const noexcept {
-  return length;
 }
 
 simdutf_warn_unused size_t implementation::utf32_length_from_utf16le(

--- a/src/rvv/rvv_length_from.inl.cpp
+++ b/src/rvv/rvv_length_from.inl.cpp
@@ -19,26 +19,6 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf8(
   return utf32_length_from_utf8(src, len);
 }
 
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf16(size_t len) const noexcept {
-  return len;
-}
-
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf32(size_t len) const noexcept {
-  return len;
-}
-
-simdutf_warn_unused size_t
-implementation::utf16_length_from_latin1(size_t len) const noexcept {
-  return len;
-}
-
-simdutf_warn_unused size_t
-implementation::utf32_length_from_latin1(size_t len) const noexcept {
-  return len;
-}
-
 simdutf_warn_unused size_t implementation::utf32_length_from_utf8(
     const char *src, size_t len) const noexcept {
   size_t count = 0;

--- a/src/scalar/latin1.h
+++ b/src/scalar/latin1.h
@@ -6,11 +6,6 @@ namespace scalar {
 namespace {
 namespace latin1 {
 
-inline size_t utf32_length_from_latin1(size_t len) {
-  // We are not BOM aware.
-  return len; // a utf32 unit will always represent 1 latin1 character
-}
-
 inline size_t utf8_length_from_latin1(const char *buf, size_t len) {
   const uint8_t *c = reinterpret_cast<const uint8_t *>(buf);
   size_t answer = 0;
@@ -21,8 +16,6 @@ inline size_t utf8_length_from_latin1(const char *buf, size_t len) {
   }
   return answer + len;
 }
-
-inline size_t utf16_length_from_latin1(size_t len) { return len; }
 
 } // namespace latin1
 } // unnamed namespace

--- a/src/scalar/utf16.h
+++ b/src/scalar/utf16.h
@@ -106,8 +106,6 @@ inline size_t utf32_length_from_utf16(const char16_t *p, size_t len) {
   return counter;
 }
 
-inline size_t latin1_length_from_utf16(size_t len) { return len; }
-
 simdutf_really_inline void
 change_endianness_utf16(const char16_t *input, size_t size, char16_t *output) {
   for (size_t i = 0; i < size; i++) {

--- a/src/scalar/utf32.h
+++ b/src/scalar/utf32.h
@@ -60,11 +60,6 @@ inline size_t utf16_length_from_utf32(const char32_t *buf, size_t len) {
   return counter;
 }
 
-inline size_t latin1_length_from_utf32(size_t len) {
-  // We are not BOM aware.
-  return len; // a utf32 codepoint will always represent 1 latin1 character
-}
-
 inline simdutf_warn_unused uint32_t swap_bytes(const uint32_t word) {
   return ((word >> 24) & 0xff) |      // move byte 3 to byte 0
          ((word << 8) & 0xff0000) |   // move byte 1 to byte 2

--- a/src/simdutf/arm64/implementation.h
+++ b/src/simdutf/arm64/implementation.h
@@ -178,14 +178,6 @@ public:
   simdutf_warn_unused size_t
   latin1_length_from_utf8(const char *input, size_t length) const noexcept;
   simdutf_warn_unused size_t
-  latin1_length_from_utf16(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  latin1_length_from_utf32(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  utf32_length_from_latin1(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  utf16_length_from_latin1(size_t length) const noexcept;
-  simdutf_warn_unused size_t
   utf8_length_from_latin1(const char *input, size_t length) const noexcept;
   simdutf_warn_unused size_t maximal_binary_length_from_base64(
       const char *input, size_t length) const noexcept;

--- a/src/simdutf/fallback/implementation.h
+++ b/src/simdutf/fallback/implementation.h
@@ -177,14 +177,6 @@ public:
   simdutf_warn_unused size_t
   latin1_length_from_utf8(const char *input, size_t length) const noexcept;
   simdutf_warn_unused size_t
-  latin1_length_from_utf16(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  latin1_length_from_utf32(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  utf32_length_from_latin1(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  utf16_length_from_latin1(size_t length) const noexcept;
-  simdutf_warn_unused size_t
   utf8_length_from_latin1(const char *input, size_t length) const noexcept;
   simdutf_warn_unused size_t maximal_binary_length_from_base64(
       const char *input, size_t length) const noexcept;

--- a/src/simdutf/haswell/implementation.h
+++ b/src/simdutf/haswell/implementation.h
@@ -179,14 +179,6 @@ public:
   simdutf_warn_unused size_t
   latin1_length_from_utf8(const char *input, size_t length) const noexcept;
   simdutf_warn_unused size_t
-  latin1_length_from_utf16(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  latin1_length_from_utf32(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  utf32_length_from_latin1(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  utf16_length_from_latin1(size_t length) const noexcept;
-  simdutf_warn_unused size_t
   utf8_length_from_latin1(const char *input, size_t length) const noexcept;
   simdutf_warn_unused virtual size_t
   maximal_binary_length_from_base64(const char *input,

--- a/src/simdutf/icelake/implementation.h
+++ b/src/simdutf/icelake/implementation.h
@@ -186,14 +186,6 @@ public:
   simdutf_warn_unused size_t
   latin1_length_from_utf8(const char *input, size_t length) const noexcept;
   simdutf_warn_unused size_t
-  latin1_length_from_utf16(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  latin1_length_from_utf32(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  utf32_length_from_latin1(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  utf16_length_from_latin1(size_t length) const noexcept;
-  simdutf_warn_unused size_t
   utf8_length_from_latin1(const char *input, size_t length) const noexcept;
   simdutf_warn_unused size_t maximal_binary_length_from_base64(
       const char *input, size_t length) const noexcept;

--- a/src/simdutf/lasx/implementation.h
+++ b/src/simdutf/lasx/implementation.h
@@ -179,14 +179,6 @@ public:
   simdutf_warn_unused size_t
   latin1_length_from_utf8(const char *input, size_t length) const noexcept;
   simdutf_warn_unused size_t
-  latin1_length_from_utf16(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  latin1_length_from_utf32(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  utf32_length_from_latin1(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  utf16_length_from_latin1(size_t length) const noexcept;
-  simdutf_warn_unused size_t
   utf8_length_from_latin1(const char *input, size_t length) const noexcept;
   simdutf_warn_unused size_t maximal_binary_length_from_base64(
       const char *input, size_t length) const noexcept;

--- a/src/simdutf/lsx/implementation.h
+++ b/src/simdutf/lsx/implementation.h
@@ -178,14 +178,6 @@ public:
   simdutf_warn_unused size_t
   latin1_length_from_utf8(const char *input, size_t length) const noexcept;
   simdutf_warn_unused size_t
-  latin1_length_from_utf16(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  latin1_length_from_utf32(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  utf32_length_from_latin1(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  utf16_length_from_latin1(size_t length) const noexcept;
-  simdutf_warn_unused size_t
   utf8_length_from_latin1(const char *input, size_t length) const noexcept;
   simdutf_warn_unused size_t maximal_binary_length_from_base64(
       const char *input, size_t length) const noexcept;

--- a/src/simdutf/rvv/implementation.h
+++ b/src/simdutf/rvv/implementation.h
@@ -179,14 +179,6 @@ public:
                                                     size_t len) const noexcept;
   simdutf_warn_unused size_t latin1_length_from_utf8(const char *buf,
                                                      size_t len) const noexcept;
-  simdutf_warn_unused size_t
-  latin1_length_from_utf16(size_t len) const noexcept;
-  simdutf_warn_unused size_t
-  latin1_length_from_utf32(size_t len) const noexcept;
-  simdutf_warn_unused size_t
-  utf32_length_from_latin1(size_t len) const noexcept;
-  simdutf_warn_unused size_t
-  utf16_length_from_latin1(size_t len) const noexcept;
   simdutf_warn_unused size_t utf8_length_from_latin1(const char *buf,
                                                      size_t len) const noexcept;
   simdutf_warn_unused size_t maximal_binary_length_from_base64(

--- a/src/simdutf/westmere/implementation.h
+++ b/src/simdutf/westmere/implementation.h
@@ -179,14 +179,6 @@ public:
   simdutf_warn_unused size_t
   latin1_length_from_utf8(const char *input, size_t length) const noexcept;
   simdutf_warn_unused size_t
-  latin1_length_from_utf16(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  latin1_length_from_utf32(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  utf32_length_from_latin1(size_t length) const noexcept;
-  simdutf_warn_unused size_t
-  utf16_length_from_latin1(size_t length) const noexcept;
-  simdutf_warn_unused size_t
   utf8_length_from_latin1(const char *input, size_t length) const noexcept;
   simdutf_warn_unused size_t maximal_binary_length_from_base64(
       const char *input, size_t length) const noexcept;

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -1021,16 +1021,6 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf8(
   return count_utf8(buf, len);
 }
 
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf16(size_t length) const noexcept {
-  return scalar::utf16::latin1_length_from_utf16(length);
-}
-
-simdutf_warn_unused size_t
-implementation::latin1_length_from_utf32(size_t length) const noexcept {
-  return scalar::utf32::latin1_length_from_utf32(length);
-}
-
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16le(
     const char16_t *input, size_t length) const noexcept {
   return utf16::utf8_length_from_utf16<endianness::LITTLE>(input, length);
@@ -1039,16 +1029,6 @@ simdutf_warn_unused size_t implementation::utf8_length_from_utf16le(
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16be(
     const char16_t *input, size_t length) const noexcept {
   return utf16::utf8_length_from_utf16<endianness::BIG>(input, length);
-}
-
-simdutf_warn_unused size_t
-implementation::utf16_length_from_latin1(size_t length) const noexcept {
-  return scalar::latin1::utf16_length_from_latin1(length);
-}
-
-simdutf_warn_unused size_t
-implementation::utf32_length_from_latin1(size_t length) const noexcept {
-  return scalar::latin1::utf32_length_from_latin1(length);
 }
 
 simdutf_warn_unused size_t implementation::utf8_length_from_latin1(


### PR DESCRIPTION
All these methods simply return the length of input string, as we don't check for a BOM marker.