### PR TITLE
Fix fuzz test failure in lsx and lasx

### DIFF
--- a/src/lasx/implementation.cpp
+++ b/src/lasx/implementation.cpp
@@ -1111,7 +1111,7 @@ simdutf_warn_unused size_t implementation::utf8_length_from_latin1(
   const uint8_t *data = reinterpret_cast<const uint8_t *>(input);
   const uint8_t *data_end = data + length;
   uint64_t result = 0;
-  while (data + 16 < data_end) {
+  while (data_end - data > 16) {
     uint64_t two_bytes = 0;
     __m128i input_vec = __lsx_vld(data, 0);
     two_bytes =

--- a/src/lasx/lasx_convert_latin1_to_utf16.cpp
+++ b/src/lasx/lasx_convert_latin1_to_utf16.cpp
@@ -9,7 +9,7 @@ lasx_convert_latin1_to_utf16le(const char *buf, size_t len,
     buf++;
   }
 
-  while (buf + 32 <= end) {
+  while (end - buf >= 32) {
     __m256i in8 = __lasx_xvld(reinterpret_cast<const uint8_t *>(buf), 0);
 
     __m256i inlow = __lasx_vext2xv_hu_bu(in8);

--- a/src/lasx/lasx_convert_latin1_to_utf32.cpp
+++ b/src/lasx/lasx_convert_latin1_to_utf32.cpp
@@ -9,7 +9,7 @@ lasx_convert_latin1_to_utf32(const char *buf, size_t len,
     buf++;
   }
 
-  while (buf + 32 <= end) {
+  while (end - buf >= 32) {
     __m256i in8 = __lasx_xvld(reinterpret_cast<const uint8_t *>(buf), 0);
 
     __m256i in32_0 = __lasx_vext2xv_wu_bu(in8);
@@ -31,7 +31,7 @@ lasx_convert_latin1_to_utf32(const char *buf, size_t len,
     buf += 32;
   }
 
-  if (buf + 16 <= end) {
+  if (end - buf >= 16) {
     __m128i in8 = __lsx_vld(reinterpret_cast<const uint8_t *>(buf), 0);
 
     __m128i zero = __lsx_vldi(0);

--- a/src/lasx/lasx_convert_latin1_to_utf8.cpp
+++ b/src/lasx/lasx_convert_latin1_to_utf8.cpp
@@ -12,7 +12,7 @@ lasx_convert_latin1_to_utf8(const char *latin1_input, size_t len,
 
   // We always write 16 bytes, of which more than the first 8 bytes
   // are valid. A safety margin of 8 is more than sufficient.
-  while (latin1_input + 16 <= end) {
+  while (end - latin1_input >= 16) {
     __m128i in8 = __lsx_vld(reinterpret_cast<const uint8_t *>(latin1_input), 0);
     uint32_t ascii_mask = __lsx_vpickve2gr_wu(__lsx_vmskgez_b(in8), 0);
     if (ascii_mask == 0xFFFF) {

--- a/src/lasx/lasx_convert_utf16_to_latin1.cpp
+++ b/src/lasx/lasx_convert_utf16_to_latin1.cpp
@@ -3,7 +3,7 @@ std::pair<const char16_t *, char *>
 lasx_convert_utf16_to_latin1(const char16_t *buf, size_t len,
                              char *latin1_output) {
   const char16_t *end = buf + len;
-  while (buf + 16 <= end) {
+  while (end - buf >= 16) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
     __m128i in1 = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 16);
     if (!match_system(big_endian)) {
@@ -31,7 +31,7 @@ lasx_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
                                          char *latin1_output) {
   const char16_t *start = buf;
   const char16_t *end = buf + len;
-  while (buf + 16 <= end) {
+  while (end - buf >= 16) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
     __m128i in1 = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 16);
     if (!match_system(big_endian)) {

--- a/src/lasx/lasx_convert_utf16_to_utf32.cpp
+++ b/src/lasx/lasx_convert_utf16_to_utf32.cpp
@@ -36,7 +36,7 @@ lasx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
   __m256i v_f800 = __lasx_xvldi(-2568); /*0xF800*/
   __m256i v_d800 = __lasx_xvldi(-2600); /*0xD800*/
 
-  while (buf + 16 <= end) {
+  while (end - buf >= 16) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint16_t *>(buf), 0);
     if (!match_system(big_endian)) {
       in = lasx_swap_bytes(in);
@@ -136,7 +136,7 @@ lasx_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
 
   __m256i v_f800 = __lasx_xvldi(-2568); /*0xF800*/
   __m256i v_d800 = __lasx_xvldi(-2600); /*0xD800*/
-  while (buf + 16 <= end) {
+  while (end - buf >= 16) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint16_t *>(buf), 0);
     if (!match_system(big_endian)) {
       in = lasx_swap_bytes(in);

--- a/src/lasx/lasx_convert_utf16_to_utf8.cpp
+++ b/src/lasx/lasx_convert_utf16_to_utf8.cpp
@@ -64,7 +64,7 @@ lasx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
   __m256i v_07ff = __lasx_xvreplgr2vr_h(uint16_t(0x7ff));
   __m256i zero = __lasx_xvldi(0);
   __m128i zero_128 = __lsx_vldi(0);
-  while (buf + 16 + safety_margin <= end) {
+  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint16_t *>(buf), 0);
     if (!match_system(big_endian)) {
       in = lasx_swap_bytes(in);
@@ -320,7 +320,7 @@ lasx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
   __m256i v_07ff = __lasx_xvreplgr2vr_h(uint16_t(0x7ff));
   __m256i zero = __lasx_xvldi(0);
   __m128i zero_128 = __lsx_vldi(0);
-  while (buf + 16 + safety_margin <= end) {
+  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint16_t *>(buf), 0);
     if (!match_system(big_endian)) {
       in = lasx_swap_bytes(in);

--- a/src/lasx/lasx_convert_utf32_to_latin1.cpp
+++ b/src/lasx/lasx_convert_utf32_to_latin1.cpp
@@ -6,7 +6,7 @@ lasx_convert_utf32_to_latin1(const char32_t *buf, size_t len,
       (__m128i)v16u8{0, 4, 8, 12, 16, 20, 24, 28, 0, 0, 0, 0, 0, 0, 0, 0});
   __m256i v_ff = __lasx_xvrepli_w(0xFF);
 
-  while (buf + 16 <= end) {
+  while (end - buf >= 16) {
     __m256i in1 = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m256i in2 = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 32);
 
@@ -39,7 +39,7 @@ lasx_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
       (__m128i)v16u8{0, 4, 8, 12, 16, 20, 24, 28, 0, 0, 0, 0, 0, 0, 0, 0});
   __m256i v_ff = __lasx_xvrepli_w(0xFF);
 
-  while (buf + 16 <= end) {
+  while (end - buf >= 16) {
     __m256i in1 = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m256i in2 = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 32);
 

--- a/src/lasx/lasx_convert_utf32_to_utf16.cpp
+++ b/src/lasx/lasx_convert_utf32_to_utf16.cpp
@@ -40,7 +40,7 @@ lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
   __m256i forbidden_bytemask = __lasx_xvrepli_h(0);
   __m256i v_d800 = __lasx_xvldi(-2600); /*0xD800*/
   __m256i v_dfff = __lasx_xvreplgr2vr_h(uint16_t(0xdfff));
-  while (buf + 16 <= end) {
+  while (end - buf >= 16) {
     __m256i in0 = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m256i in1 = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 32);
 
@@ -147,7 +147,7 @@ lasx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
   __m256i forbidden_bytemask = __lasx_xvrepli_h(0);
   __m256i v_d800 = __lasx_xvldi(-2600); /*0xD800*/
   __m256i v_dfff = __lasx_xvreplgr2vr_h(uint16_t(0xdfff));
-  while (buf + 16 <= end) {
+  while (end - buf >= 16) {
     __m256i in0 = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m256i in1 = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 32);
 

--- a/src/lasx/lasx_convert_utf32_to_utf8.cpp
+++ b/src/lasx/lasx_convert_utf32_to_utf8.cpp
@@ -42,7 +42,7 @@ lasx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (buf + 16 + safety_margin < end) {
+  while (end - buf > std::ptrdiff_t(16 + safety_margin)) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m256i nextin = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 32);
 
@@ -337,7 +337,7 @@ lasx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (buf + 16 + safety_margin < end) {
+  while (end - buf > std::ptrdiff_t(16 + safety_margin)) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m256i nextin = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 32);
 

--- a/src/lasx/lasx_convert_utf8_to_utf16.cpp
+++ b/src/lasx/lasx_convert_utf8_to_utf16.cpp
@@ -138,6 +138,15 @@ size_t convert_masked_utf8_to_utf16(const char *input,
   } else if (idx < 209) {
     // THREE (3) input code-code units
     if (input_utf8_end_of_code_point_mask == 0x888) {
+      __m128i expected_mask =
+          (__m128i)v16u8{0xf8, 0xc0, 0xc0, 0xc0, 0xf8, 0xc0, 0xc0, 0xc0,
+                         0xf8, 0xc0, 0xc0, 0xc0, 0x0,  0x0,  0x0,  0x0};
+      __m128i expected =
+          (__m128i)v16u8{0xf0, 0x80, 0x80, 0x80, 0xf0, 0x80, 0x80, 0x80,
+                         0xf0, 0x80, 0x80, 0x80, 0x0,  0x0,  0x0,  0x0};
+      __m128i check = __lsx_vseq_b(__lsx_vand_v(in, expected_mask), expected);
+      if (__lsx_bz_b(check))
+        return 12;
       // We want to take 3 4-byte UTF-8 code units and turn them into 3 4-byte
       // UTF-16 pairs. Generating surrogate pairs is a little tricky though, but
       // it is easier when we can assume they are all pairs. This version does

--- a/src/lasx/lasx_convert_utf8_to_utf32.cpp
+++ b/src/lasx/lasx_convert_utf8_to_utf32.cpp
@@ -167,8 +167,7 @@ size_t convert_masked_utf8_to_utf32(const char *input,
     __m128i ascii = __lsx_vand_v(perm, __lsx_vrepli_w(0x7F));
     __m128i middle = __lsx_vand_v(perm, __lsx_vldi(-3777 /*0x00003f00*/));
     // 00000000 00000000 0000cccc ccdddddd
-    __m128i cd =
-        __lsx_vbitsel_v(__lsx_vsrli_w(middle, 2), ascii, __lsx_vrepli_w(0x3f));
+    __m128i cd = __lsx_vor_v(__lsx_vsrli_w(middle, 2), ascii);
 
     __m128i correction = __lsx_vand_v(perm, __lsx_vldi(-3520 /*0x00400000*/));
     __m128i corrected = __lsx_vadd_b(perm, __lsx_vsrli_w(correction, 1));

--- a/src/lasx/lasx_validate_utf16.cpp
+++ b/src/lasx/lasx_validate_utf16.cpp
@@ -53,7 +53,7 @@ const char16_t *lasx_validate_utf16(const char16_t *input, size_t size) {
   const auto v_fc = simd8<uint8_t>::splat(0xfc);
   const auto v_dc = simd8<uint8_t>::splat(0xdc);
 
-  while (input + simd16<uint16_t>::ELEMENTS * 2 < end) {
+  while (end - input > simd16<uint16_t>::ELEMENTS * 2) {
     // 0. Load data: since the validation takes into account only higher
     //    byte of each word, we compress the two vectors into one which
     //    consists only the higher bytes.
@@ -134,7 +134,7 @@ const result lasx_validate_utf16_with_errors(const char16_t *input,
   const auto v_fc = simd8<uint8_t>::splat(0xfc);
   const auto v_dc = simd8<uint8_t>::splat(0xdc);
 
-  while (input + simd16<uint16_t>::ELEMENTS * 2 < end) {
+  while (end - input > simd16<uint16_t>::ELEMENTS * 2) {
     // 0. Load data: since the validation takes into account only higher
     //    byte of each word, we compress the two vectors into one which
     //    consists only the higher bytes.

--- a/src/lsx/implementation.cpp
+++ b/src/lsx/implementation.cpp
@@ -997,7 +997,7 @@ simdutf_warn_unused size_t implementation::utf8_length_from_latin1(
   const uint8_t *data = reinterpret_cast<const uint8_t *>(input);
   const uint8_t *data_end = data + length;
   uint64_t result = 0;
-  while (data + 16 < data_end) {
+  while (data_end - data > 16) {
     uint64_t two_bytes = 0;
     __m128i input_vec = __lsx_vld(data, 0);
     two_bytes =

--- a/src/lsx/lsx_convert_latin1_to_utf16.cpp
+++ b/src/lsx/lsx_convert_latin1_to_utf16.cpp
@@ -4,7 +4,7 @@ lsx_convert_latin1_to_utf16le(const char *buf, size_t len,
   const char *end = buf + len;
 
   __m128i zero = __lsx_vldi(0);
-  while (buf + 16 <= end) {
+  while (end - buf >= 16) {
     __m128i in8 = __lsx_vld(reinterpret_cast<const uint8_t *>(buf), 0);
 
     __m128i inlow = __lsx_vilvl_b(zero, in8);
@@ -24,7 +24,7 @@ lsx_convert_latin1_to_utf16be(const char *buf, size_t len,
                               char16_t *utf16_output) {
   const char *end = buf + len;
   __m128i zero = __lsx_vldi(0);
-  while (buf + 16 <= end) {
+  while (end - buf >= 16) {
     __m128i in8 = __lsx_vld(reinterpret_cast<const uint8_t *>(buf), 0);
 
     __m128i inlow = __lsx_vilvl_b(in8, zero);

--- a/src/lsx/lsx_convert_latin1_to_utf32.cpp
+++ b/src/lsx/lsx_convert_latin1_to_utf32.cpp
@@ -3,7 +3,7 @@ lsx_convert_latin1_to_utf32(const char *buf, size_t len,
                             char32_t *utf32_output) {
   const char *end = buf + len;
 
-  while (buf + 16 <= end) {
+  while (end - buf >= 16) {
     __m128i in8 = __lsx_vld(reinterpret_cast<const uint8_t *>(buf), 0);
 
     __m128i zero = __lsx_vldi(0);

--- a/src/lsx/lsx_convert_latin1_to_utf8.cpp
+++ b/src/lsx/lsx_convert_latin1_to_utf8.cpp
@@ -12,7 +12,7 @@ lsx_convert_latin1_to_utf8(const char *latin1_input, size_t len,
   __m128i zero = __lsx_vldi(0);
   // We always write 16 bytes, of which more than the first 8 bytes
   // are valid. A safety margin of 8 is more than sufficient.
-  while (latin1_input + 16 <= end) {
+  while (end - latin1_input >= 16) {
     __m128i in8 = __lsx_vld(reinterpret_cast<const uint8_t *>(latin1_input), 0);
     uint32_t ascii = __lsx_vpickve2gr_hu(__lsx_vmskgez_b(in8), 0);
     if (ascii == 0xffff) { // ASCII fast path!!!!

--- a/src/lsx/lsx_convert_utf16_to_latin1.cpp
+++ b/src/lsx/lsx_convert_utf16_to_latin1.cpp
@@ -3,7 +3,7 @@ std::pair<const char16_t *, char *>
 lsx_convert_utf16_to_latin1(const char16_t *buf, size_t len,
                             char *latin1_output) {
   const char16_t *end = buf + len;
-  while (buf + 16 <= end) {
+  while (end - buf >= 16) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
     __m128i in1 = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 16);
     if (!match_system(big_endian)) {
@@ -31,7 +31,7 @@ lsx_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
                                         char *latin1_output) {
   const char16_t *start = buf;
   const char16_t *end = buf + len;
-  while (buf + 16 <= end) {
+  while (end - buf >= 16) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
     __m128i in1 = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 16);
     if (!match_system(big_endian)) {

--- a/src/lsx/lsx_convert_utf16_to_utf32.cpp
+++ b/src/lsx/lsx_convert_utf16_to_utf32.cpp
@@ -9,7 +9,7 @@ lsx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
   __m128i v_f800 = __lsx_vldi(-2568); /*0xF800*/
   __m128i v_d800 = __lsx_vldi(-2600); /*0xD800*/
 
-  while (buf + 8 <= end) {
+  while (end - buf >= 8) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
     if (!match_system(big_endian)) {
       in = lsx_swap_bytes(in);
@@ -83,7 +83,7 @@ lsx_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
   __m128i v_f800 = __lsx_vldi(-2568); /*0xF800*/
   __m128i v_d800 = __lsx_vldi(-2600); /*0xD800*/
 
-  while (buf + 8 <= end) {
+  while (end - buf >= 8) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
     if (!match_system(big_endian)) {
       in = lsx_swap_bytes(in);

--- a/src/lsx/lsx_convert_utf16_to_utf8.cpp
+++ b/src/lsx/lsx_convert_utf16_to_utf8.cpp
@@ -61,7 +61,7 @@ lsx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
           // https://github.com/simdutf/simdutf/issues/92
 
   __m128i v_07ff = __lsx_vreplgr2vr_h(uint16_t(0x7ff));
-  while (buf + 16 + safety_margin <= end) {
+  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
     if (!match_system(big_endian)) {
       in = lsx_swap_bytes(in);
@@ -300,7 +300,7 @@ lsx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
   const size_t safety_margin =
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
-  while (buf + 16 + safety_margin <= end) {
+  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
     if (!match_system(big_endian)) {
       in = lsx_swap_bytes(in);

--- a/src/lsx/lsx_convert_utf32_to_latin1.cpp
+++ b/src/lsx/lsx_convert_utf32_to_latin1.cpp
@@ -5,7 +5,7 @@ lsx_convert_utf32_to_latin1(const char32_t *buf, size_t len,
   const v16u8 shuf_mask = {0, 4, 8, 12, 16, 20, 24, 28, 0, 0, 0, 0, 0, 0, 0, 0};
   __m128i v_ff = __lsx_vrepli_w(0xFF);
 
-  while (buf + 16 <= end) {
+  while (end - buf >= 16) {
     __m128i in1 = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m128i in2 = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 16);
 
@@ -34,7 +34,7 @@ lsx_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
   const v16u8 shuf_mask = {0, 4, 8, 12, 16, 20, 24, 28, 0, 0, 0, 0, 0, 0, 0, 0};
   __m128i v_ff = __lsx_vrepli_w(0xFF);
 
-  while (buf + 16 <= end) {
+  while (end - buf >= 16) {
     __m128i in1 = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m128i in2 = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 16);
 

--- a/src/lsx/lsx_convert_utf32_to_utf16.cpp
+++ b/src/lsx/lsx_convert_utf32_to_utf16.cpp
@@ -8,7 +8,7 @@ lsx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
   __m128i forbidden_bytemask = __lsx_vrepli_h(0);
   __m128i v_d800 = __lsx_vldi(-2600); /*0xD800*/
   __m128i v_dfff = __lsx_vreplgr2vr_h(uint16_t(0xdfff));
-  while (buf + 8 <= end) {
+  while (end - buf >= 8) {
     __m128i in0 = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m128i in1 = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 16);
 
@@ -85,7 +85,7 @@ lsx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
   __m128i v_d800 = __lsx_vldi(-2600); /*0xD800*/
   __m128i v_dfff = __lsx_vreplgr2vr_h(uint16_t(0xdfff));
 
-  while (buf + 8 <= end) {
+  while (end - buf >= 8) {
     __m128i in0 = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m128i in1 = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 16);
     // Check if no bits set above 16th

--- a/src/lsx/lsx_convert_utf32_to_utf8.cpp
+++ b/src/lsx/lsx_convert_utf32_to_utf8.cpp
@@ -13,7 +13,7 @@ lsx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (buf + 16 + safety_margin < end) {
+  while (end - buf > std::ptrdiff_t(16 + safety_margin)) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m128i nextin = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 16);
 
@@ -242,7 +242,7 @@ lsx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (buf + 16 + safety_margin < end) {
+  while (end - buf > std::ptrdiff_t(16 + safety_margin)) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m128i nextin = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 16);
 

--- a/src/lsx/lsx_convert_utf8_to_utf16.cpp
+++ b/src/lsx/lsx_convert_utf8_to_utf16.cpp
@@ -138,6 +138,15 @@ size_t convert_masked_utf8_to_utf16(const char *input,
       // of the extra memory access is less important than the early branch
       // overhead in shorter sequences.
 
+      __m128i expected_mask =
+          (__m128i)v16u8{0xf8, 0xc0, 0xc0, 0xc0, 0xf8, 0xc0, 0xc0, 0xc0,
+                         0xf8, 0xc0, 0xc0, 0xc0, 0x0,  0x0,  0x0,  0x0};
+      __m128i expected =
+          (__m128i)v16u8{0xf0, 0x80, 0x80, 0x80, 0xf0, 0x80, 0x80, 0x80,
+                         0xf0, 0x80, 0x80, 0x80, 0x0,  0x0,  0x0,  0x0};
+      __m128i check = __lsx_vseq_b(__lsx_vand_v(in, expected_mask), expected);
+      if (__lsx_bz_b(check))
+        return 12;
       // Swap byte pairs
       // 10dddddd 10cccccc|10bbbbbb 11110aaa
       // 10cccccc 10dddddd|11110aaa 10bbbbbb

--- a/src/lsx/lsx_convert_utf8_to_utf32.cpp
+++ b/src/lsx/lsx_convert_utf8_to_utf32.cpp
@@ -156,8 +156,7 @@ size_t convert_masked_utf8_to_utf32(const char *input,
     __m128i ascii = __lsx_vand_v(perm, __lsx_vrepli_w(0x7F));
     __m128i middle = __lsx_vand_v(perm, __lsx_vldi(-3777 /*0x00003f00*/));
     // 00000000 00000000 0000cccc ccdddddd
-    __m128i cd =
-        __lsx_vbitsel_v(__lsx_vsrli_w(middle, 2), ascii, __lsx_vrepli_w(0x3f));
+    __m128i cd = __lsx_vor_v(__lsx_vsrli_w(middle, 2), ascii);
 
     __m128i correction = __lsx_vand_v(perm, __lsx_vldi(-3520 /*0x00400000*/));
     __m128i corrected = __lsx_vadd_b(perm, __lsx_vsrli_w(correction, 1));

--- a/src/lsx/lsx_validate_utf16.cpp
+++ b/src/lsx/lsx_validate_utf16.cpp
@@ -53,7 +53,7 @@ const char16_t *lsx_validate_utf16(const char16_t *input, size_t size) {
   const auto v_fc = simd8<uint8_t>::splat(0xfc);
   const auto v_dc = simd8<uint8_t>::splat(0xdc);
 
-  while (input + simd16<uint16_t>::SIZE * 2 < end) {
+  while (end - input > simd16<uint16_t>::SIZE * 2) {
     // 0. Load data: since the validation takes into account only higher
     //    byte of each word, we compress the two vectors into one which
     //    consists only the higher bytes.
@@ -131,7 +131,7 @@ const result lsx_validate_utf16_with_errors(const char16_t *input,
   const auto v_fc = simd8<uint8_t>::splat(0xfc);
   const auto v_dc = simd8<uint8_t>::splat(0xdc);
 
-  while (input + simd16<uint16_t>::SIZE * 2 < end) {
+  while (end - input > simd16<uint16_t>::SIZE * 2) {
     // 0. Load data: since the validation takes into account only higher
     //    byte of each word, we compress the two vectors into one which
     //    consists only the higher bytes.


### PR DESCRIPTION
* loongarch64: fix lsx and lasx nullptr tests in fuzz testing
    Ref: PR-469
* loongarch64: fix lsx and lasx issue_631
* loongarch64: fixed vbitsel usage error
