### PR TITLE
fixes for Issue 661

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,6 +765,14 @@ simdutf_warn_unused size_t utf8_length_from_latin1(const char * input, size_t le
  */
 simdutf_warn_unused size_t latin1_length_from_utf8(const char * input, size_t length) noexcept;
 
+/**
+ * Compute the number of bytes that this UTF-16 string would require in Latin1 format.
+ *
+ * @param length        the length of the string in Latin1 code units (char)
+ * @return the length of the string in Latin1 code units (char) required to encode the UTF-16 string as Latin1
+ */
+simdutf_warn_unused size_t latin1_length_from_utf16(size_t length) noexcept;
+
 /*
  * Compute the number of bytes that this UTF-16LE/BE string would require in Latin1 format.
  *
@@ -882,6 +890,14 @@ simdutf_warn_unused size_t utf8_length_from_utf32(const char32_t * input, size_t
 simdutf_warn_unused size_t utf16_length_from_utf32(const char32_t * input, size_t length) noexcept;
 
 /**
+ * Compute the number of code units that this Latin1 string would require in UTF-16 format.
+ *
+ * @param length        the length of the string in Latin1 code units (char)
+ * @return the length of the string in 2-byte code units (char16_t) required to encode the Latin1 string as UTF-16
+ */
+simdutf_warn_unused size_t utf16_length_from_latin1(size_t length) noexcept;
+
+/**
  * Using native endianness; Compute the number of bytes that this UTF-16
  * string would require in UTF-32 format.
  *
@@ -929,6 +945,14 @@ simdutf_warn_unused size_t utf32_length_from_utf16le(const char16_t * input, siz
  * @return the number of bytes required to encode the UTF-16BE string as UTF-32
  */
 simdutf_warn_unused size_t utf32_length_from_utf16be(const char16_t * input, size_t length) noexcept;
+
+/**
+ * Compute the number of bytes that this Latin1 string would require in UTF-32 format.
+ *
+ * @param length        the length of the string in Latin1 code units (char)
+ * @return the length of the string in 4-byte code units (char32_t) required to encode the Latin1 string as UTF-32
+ */
+simdutf_warn_unused size_t utf32_length_from_latin1(size_t length) noexcept;
 ```
 
 

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -118,7 +118,7 @@ autodetect_encoding(
   return autodetect_encoding(reinterpret_cast<const char *>(input.data()),
                              input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Autodetect the possible encodings of the input in one pass.
@@ -143,7 +143,7 @@ detect_encodings(const detail::input_span_of_byte_like auto &input) noexcept {
   return detect_encodings(reinterpret_cast<const char *>(input.data()),
                           input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_DETECT_ENCODING
 
 #if SIMDUTF_FEATURE_UTF8 || SIMDUTF_FEATURE_DETECT_ENCODING
@@ -165,7 +165,7 @@ validate_utf8(const detail::input_span_of_byte_like auto &input) noexcept {
   return validate_utf8(reinterpret_cast<const char *>(input.data()),
                        input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 || SIMDUTF_FEATURE_DETECT_ENCODING
 
 #if SIMDUTF_FEATURE_UTF8
@@ -189,7 +189,7 @@ simdutf_really_inline simdutf_warn_unused result validate_utf8_with_errors(
   return validate_utf8_with_errors(reinterpret_cast<const char *>(input.data()),
                                    input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8
 
 #if SIMDUTF_FEATURE_ASCII
@@ -209,7 +209,7 @@ validate_ascii(const detail::input_span_of_byte_like auto &input) noexcept {
   return validate_ascii(reinterpret_cast<const char *>(input.data()),
                         input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Validate the ASCII string and stop on error. It might be faster than
@@ -232,7 +232,7 @@ simdutf_really_inline simdutf_warn_unused result validate_ascii_with_errors(
   return validate_ascii_with_errors(
       reinterpret_cast<const char *>(input.data()), input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_ASCII
 
 #if SIMDUTF_FEATURE_UTF16
@@ -257,7 +257,7 @@ simdutf_really_inline simdutf_warn_unused bool
 validate_utf16(std::span<const char16_t> input) noexcept {
   return validate_utf16(input.data(), input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
@@ -282,7 +282,7 @@ simdutf_really_inline simdutf_warn_unused bool
 validate_utf16le(std::span<const char16_t> input) noexcept {
   return validate_utf16le(input.data(), input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
 
 #if SIMDUTF_FEATURE_UTF16
@@ -307,7 +307,7 @@ simdutf_really_inline simdutf_warn_unused bool
 validate_utf16be(std::span<const char16_t> input) noexcept {
   return validate_utf16be(input.data(), input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Using native endianness; Validate the UTF-16 string and stop on error.
@@ -333,7 +333,7 @@ simdutf_really_inline simdutf_warn_unused result
 validate_utf16_with_errors(std::span<const char16_t> input) noexcept {
   return validate_utf16_with_errors(input.data(), input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Validate the UTF-16LE string and stop on error. It might be faster than
@@ -358,7 +358,7 @@ simdutf_really_inline simdutf_warn_unused result
 validate_utf16le_with_errors(std::span<const char16_t> input) noexcept {
   return validate_utf16le_with_errors(input.data(), input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Validate the UTF-16BE string and stop on error. It might be faster than
@@ -383,7 +383,7 @@ simdutf_really_inline simdutf_warn_unused result
 validate_utf16be_with_errors(std::span<const char16_t> input) noexcept {
   return validate_utf16be_with_errors(input.data(), input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
@@ -408,7 +408,7 @@ simdutf_really_inline simdutf_warn_unused bool
 validate_utf32(std::span<const char32_t> input) noexcept {
   return validate_utf32(input.data(), input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
 
 #if SIMDUTF_FEATURE_UTF32
@@ -435,7 +435,7 @@ simdutf_really_inline simdutf_warn_unused result
 validate_utf32_with_errors(std::span<const char32_t> input) noexcept {
   return validate_utf32_with_errors(input.data(), input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
@@ -460,7 +460,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_latin1_to_utf8(
       reinterpret_cast<const char *>(latin1_input.data()), latin1_input.size(),
       utf8_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert Latin1 string into UTF8 string with output limit.
@@ -490,7 +490,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_latin1_to_utf8_safe(
       input.data(), input.size(), reinterpret_cast<char *>(utf8_output.data()),
       utf8_output.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
@@ -514,7 +514,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_latin1_to_utf16le(
       reinterpret_cast<const char *>(latin1_input.data()), latin1_input.size(),
       utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert Latin1 string into UTF-16BE string.
@@ -535,7 +535,7 @@ convert_latin1_to_utf16be(const detail::input_span_of_byte_like auto &input,
   return convert_latin1_to_utf16be(reinterpret_cast<const char *>(input.data()),
                                    input.size(), output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
@@ -559,7 +559,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_latin1_to_utf32(
       reinterpret_cast<const char *>(latin1_input.data()), latin1_input.size(),
       utf32_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
@@ -586,7 +586,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_utf8_to_latin1(
                                 input.size(),
                                 reinterpret_cast<char *>(output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
@@ -612,7 +612,7 @@ convert_utf8_to_utf16(const detail::input_span_of_byte_like auto &input,
   return convert_utf8_to_utf16(reinterpret_cast<const char *>(input.data()),
                                input.size(), output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
@@ -633,7 +633,7 @@ convert_latin1_to_utf16(const detail::input_span_of_byte_like auto &input,
   return convert_latin1_to_utf16(reinterpret_cast<const char *>(input.data()),
                                  input.size(), output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
@@ -659,7 +659,7 @@ convert_utf8_to_utf16le(const detail::input_span_of_byte_like auto &utf8_input,
       reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
       utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-8 string into UTF-16BE string.
@@ -683,7 +683,7 @@ convert_utf8_to_utf16be(const detail::input_span_of_byte_like auto &utf8_input,
       reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
       utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
@@ -714,7 +714,7 @@ convert_utf8_to_latin1_with_errors(
       reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
       reinterpret_cast<char *>(latin1_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
@@ -744,7 +744,7 @@ convert_utf8_to_utf16_with_errors(
       reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
       utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-8 string into UTF-16LE string and stop on error.
@@ -771,7 +771,7 @@ convert_utf8_to_utf16le_with_errors(
       reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
       utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-8 string into UTF-16BE string and stop on error.
@@ -798,7 +798,7 @@ convert_utf8_to_utf16be_with_errors(
       reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
       utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
@@ -824,7 +824,7 @@ convert_utf8_to_utf32(const detail::input_span_of_byte_like auto &utf8_input,
       reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
       utf32_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-8 string into UTF-32 string and stop on error.
@@ -851,7 +851,7 @@ convert_utf8_to_utf32_with_errors(
       reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
       utf32_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
@@ -884,7 +884,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf8_to_latin1(
       reinterpret_cast<const char *>(valid_utf8_input.data()),
       valid_utf8_input.size(), latin1_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
@@ -908,7 +908,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf8_to_utf16(
       reinterpret_cast<const char *>(valid_utf8_input.data()),
       valid_utf8_input.size(), utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert valid UTF-8 string into UTF-16LE string.
@@ -930,7 +930,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf8_to_utf16le(
       reinterpret_cast<const char *>(valid_utf8_input.data()),
       valid_utf8_input.size(), utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert valid UTF-8 string into UTF-16BE string.
@@ -952,7 +952,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf8_to_utf16be(
       reinterpret_cast<const char *>(valid_utf8_input.data()),
       valid_utf8_input.size(), utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
@@ -976,7 +976,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf8_to_utf32(
       reinterpret_cast<const char *>(valid_utf8_input.data()),
       valid_utf8_input.size(), utf32_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
@@ -996,7 +996,7 @@ simdutf_really_inline simdutf_warn_unused size_t utf8_length_from_latin1(
   return utf8_length_from_latin1(
       reinterpret_cast<const char *>(latin1_input.data()), latin1_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Compute the number of bytes that this UTF-8 string would require in Latin1
@@ -1020,7 +1020,7 @@ simdutf_really_inline simdutf_warn_unused size_t latin1_length_from_utf8(
       reinterpret_cast<const char *>(valid_utf8_input.data()),
       valid_utf8_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
@@ -1047,7 +1047,7 @@ simdutf_really_inline simdutf_warn_unused size_t utf16_length_from_utf8(
       reinterpret_cast<const char *>(valid_utf8_input.data()),
       valid_utf8_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
@@ -1076,7 +1076,7 @@ simdutf_really_inline simdutf_warn_unused size_t utf32_length_from_utf8(
       reinterpret_cast<const char *>(valid_utf8_input.data()),
       valid_utf8_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
@@ -1105,7 +1105,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_utf16_to_utf8(
   return convert_utf16_to_utf8(utf16_input.data(), utf16_input.size(),
                                reinterpret_cast<char *>(utf8_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
@@ -1134,7 +1134,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_utf16_to_latin1(
       utf16_input.data(), utf16_input.size(),
       reinterpret_cast<char *>(latin1_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-16LE string into Latin1 string.
@@ -1162,7 +1162,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_utf16le_to_latin1(
       utf16_input.data(), utf16_input.size(),
       reinterpret_cast<char *>(latin1_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-16BE string into Latin1 string.
@@ -1188,7 +1188,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_utf16be_to_latin1(
       utf16_input.data(), utf16_input.size(),
       reinterpret_cast<char *>(latin1_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
@@ -1216,7 +1216,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_utf16le_to_utf8(
   return convert_utf16le_to_utf8(utf16_input.data(), utf16_input.size(),
                                  reinterpret_cast<char *>(utf8_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-16BE string into UTF-8 string.
@@ -1242,7 +1242,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_utf16be_to_utf8(
   return convert_utf16be_to_utf8(utf16_input.data(), utf16_input.size(),
                                  reinterpret_cast<char *>(utf8_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
@@ -1273,7 +1273,7 @@ convert_utf16_to_latin1_with_errors(
       utf16_input.data(), utf16_input.size(),
       reinterpret_cast<char *>(latin1_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-16LE string into Latin1 string.
@@ -1301,7 +1301,7 @@ convert_utf16le_to_latin1_with_errors(
       utf16_input.data(), utf16_input.size(),
       reinterpret_cast<char *>(latin1_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-16BE string into Latin1 string.
@@ -1331,7 +1331,7 @@ convert_utf16be_to_latin1_with_errors(
       utf16_input.data(), utf16_input.size(),
       reinterpret_cast<char *>(latin1_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
@@ -1363,7 +1363,7 @@ convert_utf16_to_utf8_with_errors(
       utf16_input.data(), utf16_input.size(),
       reinterpret_cast<char *>(utf8_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-16LE string into UTF-8 string and stop on error.
@@ -1392,7 +1392,7 @@ convert_utf16le_to_utf8_with_errors(
       utf16_input.data(), utf16_input.size(),
       reinterpret_cast<char *>(utf8_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-16BE string into UTF-8 string and stop on error.
@@ -1421,7 +1421,7 @@ convert_utf16be_to_utf8_with_errors(
       utf16_input.data(), utf16_input.size(),
       reinterpret_cast<char *>(utf8_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Using native endianness, convert valid UTF-16 string into UTF-8 string.
@@ -1446,7 +1446,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf16_to_utf8(
       valid_utf16_input.data(), valid_utf16_input.size(),
       reinterpret_cast<char *>(utf8_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
@@ -1479,7 +1479,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf16_to_latin1(
       valid_utf16_input.data(), valid_utf16_input.size(),
       reinterpret_cast<char *>(latin1_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert valid UTF-16LE string into Latin1 string.
@@ -1511,7 +1511,7 @@ convert_valid_utf16le_to_latin1(
       valid_utf16_input.data(), valid_utf16_input.size(),
       reinterpret_cast<char *>(latin1_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert valid UTF-16BE string into Latin1 string.
@@ -1543,7 +1543,7 @@ convert_valid_utf16be_to_latin1(
       valid_utf16_input.data(), valid_utf16_input.size(),
       reinterpret_cast<char *>(latin1_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
@@ -1571,7 +1571,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf16le_to_utf8(
       valid_utf16_input.data(), valid_utf16_input.size(),
       reinterpret_cast<char *>(utf8_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert valid UTF-16BE string into UTF-8 string.
@@ -1596,7 +1596,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf16be_to_utf8(
       valid_utf16_input.data(), valid_utf16_input.size(),
       reinterpret_cast<char *>(utf8_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
@@ -1624,7 +1624,7 @@ convert_utf16_to_utf32(std::span<const char16_t> utf16_input,
   return convert_utf16_to_utf32(utf16_input.data(), utf16_input.size(),
                                 utf32_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-16LE string into UTF-32 string.
@@ -1649,7 +1649,7 @@ convert_utf16le_to_utf32(std::span<const char16_t> utf16_input,
   return convert_utf16le_to_utf32(utf16_input.data(), utf16_input.size(),
                                   utf32_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-16BE string into UTF-32 string.
@@ -1674,7 +1674,7 @@ convert_utf16be_to_utf32(std::span<const char16_t> utf16_input,
   return convert_utf16be_to_utf32(utf16_input.data(), utf16_input.size(),
                                   utf32_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Using native endianness, convert possibly broken UTF-16 string into
@@ -1702,7 +1702,7 @@ convert_utf16_to_utf32_with_errors(std::span<const char16_t> utf16_input,
   return convert_utf16_to_utf32_with_errors(
       utf16_input.data(), utf16_input.size(), utf32_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-16LE string into UTF-32 string and stop on error.
@@ -1730,7 +1730,7 @@ convert_utf16le_to_utf32_with_errors(
   return convert_utf16le_to_utf32_with_errors(
       utf16_input.data(), utf16_input.size(), utf32_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-16BE string into UTF-32 string and stop on error.
@@ -1758,7 +1758,7 @@ convert_utf16be_to_utf32_with_errors(
   return convert_utf16be_to_utf32_with_errors(
       utf16_input.data(), utf16_input.size(), utf32_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Using native endianness, convert valid UTF-16 string into UTF-32 string.
@@ -1783,7 +1783,7 @@ convert_valid_utf16_to_utf32(std::span<const char16_t> valid_utf16_input,
   return convert_valid_utf16_to_utf32(
       valid_utf16_input.data(), valid_utf16_input.size(), utf32_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert valid UTF-16LE string into UTF-32 string.
@@ -1807,7 +1807,7 @@ convert_valid_utf16le_to_utf32(std::span<const char16_t> valid_utf16_input,
   return convert_valid_utf16le_to_utf32(
       valid_utf16_input.data(), valid_utf16_input.size(), utf32_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert valid UTF-16BE string into UTF-32 string.
@@ -1831,7 +1831,7 @@ convert_valid_utf16be_to_utf32(std::span<const char16_t> valid_utf16_input,
   return convert_valid_utf16be_to_utf32(
       valid_utf16_input.data(), valid_utf16_input.size(), utf32_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
@@ -1868,7 +1868,7 @@ utf8_length_from_utf16(std::span<const char16_t> valid_utf16_input) noexcept {
   return utf8_length_from_utf16(valid_utf16_input.data(),
                                 valid_utf16_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
@@ -1891,7 +1891,7 @@ utf8_length_from_utf16le(std::span<const char16_t> valid_utf16_input) noexcept {
   return utf8_length_from_utf16le(valid_utf16_input.data(),
                                   valid_utf16_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Compute the number of bytes that this UTF-16BE string would require in UTF-8
@@ -1912,7 +1912,7 @@ utf8_length_from_utf16be(std::span<const char16_t> valid_utf16_input) noexcept {
   return utf8_length_from_utf16be(valid_utf16_input.data(),
                                   valid_utf16_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
@@ -1939,7 +1939,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_utf32_to_utf8(
   return convert_utf32_to_utf8(utf32_input.data(), utf32_input.size(),
                                reinterpret_cast<char *>(utf8_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-32 string into UTF-8 string and stop on error.
@@ -1968,7 +1968,7 @@ convert_utf32_to_utf8_with_errors(
       utf32_input.data(), utf32_input.size(),
       reinterpret_cast<char *>(utf8_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert valid UTF-32 string into UTF-8 string.
@@ -1993,7 +1993,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf32_to_utf8(
       valid_utf32_input.data(), valid_utf32_input.size(),
       reinterpret_cast<char *>(utf8_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
@@ -2020,7 +2020,7 @@ convert_utf32_to_utf16(std::span<const char32_t> utf32_input,
   return convert_utf32_to_utf16(utf32_input.data(), utf32_input.size(),
                                 utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-32 string into UTF-16LE string.
@@ -2044,7 +2044,7 @@ convert_utf32_to_utf16le(std::span<const char32_t> utf32_input,
   return convert_utf32_to_utf16le(utf32_input.data(), utf32_input.size(),
                                   utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
@@ -2072,7 +2072,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_utf32_to_latin1(
       utf32_input.data(), utf32_input.size(),
       reinterpret_cast<char *>(latin1_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-32 string into Latin1 string and stop on error.
@@ -2102,7 +2102,7 @@ convert_utf32_to_latin1_with_errors(
       utf32_input.data(), utf32_input.size(),
       reinterpret_cast<char *>(latin1_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert valid UTF-32 string into Latin1 string.
@@ -2134,7 +2134,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf32_to_latin1(
       valid_utf32_input.data(), valid_utf32_input.size(),
       reinterpret_cast<char *>(latin1_output.data()));
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
@@ -2160,7 +2160,7 @@ convert_utf32_to_utf16be(std::span<const char32_t> utf32_input,
   return convert_utf32_to_utf16be(utf32_input.data(), utf32_input.size(),
                                   utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Using native endianness, convert possibly broken UTF-32 string into UTF-16
@@ -2188,7 +2188,7 @@ convert_utf32_to_utf16_with_errors(std::span<const char32_t> utf32_input,
   return convert_utf32_to_utf16_with_errors(
       utf32_input.data(), utf32_input.size(), utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-32 string into UTF-16LE string and stop on error.
@@ -2216,7 +2216,7 @@ convert_utf32_to_utf16le_with_errors(
   return convert_utf32_to_utf16le_with_errors(
       utf32_input.data(), utf32_input.size(), utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert possibly broken UTF-32 string into UTF-16BE string and stop on error.
@@ -2244,7 +2244,7 @@ convert_utf32_to_utf16be_with_errors(
   return convert_utf32_to_utf16be_with_errors(
       utf32_input.data(), utf32_input.size(), utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Using native endianness, convert valid UTF-32 string into a UTF-16 string.
@@ -2268,7 +2268,7 @@ convert_valid_utf32_to_utf16(std::span<const char32_t> valid_utf32_input,
   return convert_valid_utf32_to_utf16(
       valid_utf32_input.data(), valid_utf32_input.size(), utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert valid UTF-32 string into UTF-16LE string.
@@ -2292,7 +2292,7 @@ convert_valid_utf32_to_utf16le(std::span<const char32_t> valid_utf32_input,
   return convert_valid_utf32_to_utf16le(
       valid_utf32_input.data(), valid_utf32_input.size(), utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert valid UTF-32 string into UTF-16BE string.
@@ -2316,7 +2316,7 @@ convert_valid_utf32_to_utf16be(std::span<const char32_t> valid_utf32_input,
   return convert_valid_utf32_to_utf16be(
       valid_utf32_input.data(), valid_utf32_input.size(), utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF16
@@ -2342,7 +2342,7 @@ change_endianness_utf16(std::span<const char16_t> utf16_input,
   return change_endianness_utf16(utf16_input.data(), utf16_input.size(),
                                  utf16_output.data());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
@@ -2365,7 +2365,7 @@ utf8_length_from_utf32(std::span<const char32_t> valid_utf32_input) noexcept {
   return utf8_length_from_utf32(valid_utf32_input.data(),
                                 valid_utf32_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
@@ -2388,7 +2388,7 @@ utf16_length_from_utf32(std::span<const char32_t> valid_utf32_input) noexcept {
   return utf16_length_from_utf32(valid_utf32_input.data(),
                                  valid_utf32_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Using native endianness; Compute the number of bytes that this UTF-16
@@ -2413,7 +2413,7 @@ utf32_length_from_utf16(std::span<const char16_t> valid_utf16_input) noexcept {
   return utf32_length_from_utf16(valid_utf16_input.data(),
                                  valid_utf16_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Compute the number of bytes that this UTF-16LE string would require in UTF-32
@@ -2438,7 +2438,7 @@ simdutf_really_inline simdutf_warn_unused size_t utf32_length_from_utf16le(
   return utf32_length_from_utf16le(valid_utf16_input.data(),
                                    valid_utf16_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Compute the number of bytes that this UTF-16BE string would require in UTF-32
@@ -2463,7 +2463,7 @@ simdutf_really_inline simdutf_warn_unused size_t utf32_length_from_utf16be(
   return utf32_length_from_utf16be(valid_utf16_input.data(),
                                    valid_utf16_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF16
@@ -2488,7 +2488,7 @@ simdutf_really_inline simdutf_warn_unused size_t
 count_utf16(std::span<const char16_t> valid_utf16_input) noexcept {
   return count_utf16(valid_utf16_input.data(), valid_utf16_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Count the number of code points (characters) in the string assuming that
@@ -2511,7 +2511,7 @@ simdutf_really_inline simdutf_warn_unused size_t
 count_utf16le(std::span<const char16_t> valid_utf16_input) noexcept {
   return count_utf16le(valid_utf16_input.data(), valid_utf16_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Count the number of code points (characters) in the string assuming that
@@ -2534,7 +2534,7 @@ simdutf_really_inline simdutf_warn_unused size_t
 count_utf16be(std::span<const char16_t> valid_utf16_input) noexcept {
   return count_utf16be(valid_utf16_input.data(), valid_utf16_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8
@@ -2558,7 +2558,7 @@ simdutf_really_inline simdutf_warn_unused size_t count_utf8(
   return count_utf8(reinterpret_cast<const char *>(valid_utf8_input.data()),
                     valid_utf8_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Given a valid UTF-8 string having a possibly truncated last character,
@@ -2582,7 +2582,7 @@ simdutf_really_inline simdutf_warn_unused size_t trim_partial_utf8(
       reinterpret_cast<const char *>(valid_utf8_input.data()),
       valid_utf8_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF8
 
 #if SIMDUTF_FEATURE_UTF16
@@ -2608,7 +2608,7 @@ trim_partial_utf16be(std::span<const char16_t> valid_utf16_input) noexcept {
   return trim_partial_utf16be(valid_utf16_input.data(),
                               valid_utf16_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Given a valid UTF-16LE string having a possibly truncated last character,
@@ -2632,7 +2632,7 @@ trim_partial_utf16le(std::span<const char16_t> valid_utf16_input) noexcept {
   return trim_partial_utf16le(valid_utf16_input.data(),
                               valid_utf16_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Given a valid UTF-16 string having a possibly truncated last character,
@@ -2655,7 +2655,7 @@ simdutf_really_inline simdutf_warn_unused size_t
 trim_partial_utf16(std::span<const char16_t> valid_utf16_input) noexcept {
   return trim_partial_utf16(valid_utf16_input.data(), valid_utf16_input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_BASE64
@@ -2707,7 +2707,7 @@ maximal_binary_length_from_base64(
   return maximal_binary_length_from_base64(
       reinterpret_cast<const char *>(input.data()), input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Provide the maximal binary length in bytes given the base64 input.
@@ -2726,7 +2726,7 @@ simdutf_really_inline simdutf_warn_unused size_t
 maximal_binary_length_from_base64(std::span<const char16_t> input) noexcept {
   return maximal_binary_length_from_base64(input.data(), input.size());
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert a base64 input to a binary output.
@@ -2797,7 +2797,7 @@ simdutf_really_inline simdutf_warn_unused result base64_to_binary(
                           reinterpret_cast<char *>(binary_output.data()),
                           options, last_chunk_options);
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Provide the base64 length in bytes given the length of a binary input.
@@ -2840,7 +2840,7 @@ binary_to_base64(const detail::input_span_of_byte_like auto &input,
       reinterpret_cast<const char *>(input.data()), input.size(),
       reinterpret_cast<char *>(binary_output.data()), options);
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert a base64 input to a binary output.
@@ -2913,7 +2913,7 @@ simdutf_really_inline simdutf_warn_unused result base64_to_binary(
                           reinterpret_cast<char *>(binary_output.data()),
                           options, last_chunk_options);
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 /**
  * Convert a base64 input to a binary output.
@@ -2996,7 +2996,7 @@ simdutf_really_inline simdutf_warn_unused result base64_to_binary_safe(
                                reinterpret_cast<char *>(binary_output.data()),
                                outlen, options, last_chunk_options);
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 
 simdutf_warn_unused result
 base64_to_binary_safe(const char16_t *input, size_t length, char *output,
@@ -3017,7 +3017,7 @@ simdutf_really_inline simdutf_warn_unused result base64_to_binary_safe(
                                reinterpret_cast<char *>(binary_output.data()),
                                outlen, options, last_chunk_options);
 }
-  #endif
+  #endif // SIMDUTF_SPAN
 #endif // SIMDUTF_FEATURE_BASE64
 
 /**

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -545,6 +545,7 @@ convert_latin1_to_utf16be(const detail::input_span_of_byte_like auto &input,
  * encode the UTF-16 string as Latin1
  */
 simdutf_warn_unused size_t latin1_length_from_utf16(size_t length) noexcept;
+
 /**
  * Compute the number of code units that this Latin1 string would require in
  * UTF-16 format.

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -144,7 +144,7 @@ detect_encodings(const detail::input_span_of_byte_like auto &input) noexcept {
                           input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_DETECT_ENCODING
+#endif   // SIMDUTF_FEATURE_DETECT_ENCODING
 
 #if SIMDUTF_FEATURE_UTF8 || SIMDUTF_FEATURE_DETECT_ENCODING
 /**
@@ -166,7 +166,7 @@ validate_utf8(const detail::input_span_of_byte_like auto &input) noexcept {
                        input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 || SIMDUTF_FEATURE_DETECT_ENCODING
+#endif   // SIMDUTF_FEATURE_UTF8 || SIMDUTF_FEATURE_DETECT_ENCODING
 
 #if SIMDUTF_FEATURE_UTF8
 /**
@@ -190,7 +190,7 @@ simdutf_really_inline simdutf_warn_unused result validate_utf8_with_errors(
                                    input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8
+#endif   // SIMDUTF_FEATURE_UTF8
 
 #if SIMDUTF_FEATURE_ASCII
 /**
@@ -233,7 +233,7 @@ simdutf_really_inline simdutf_warn_unused result validate_ascii_with_errors(
       reinterpret_cast<const char *>(input.data()), input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_ASCII
+#endif   // SIMDUTF_FEATURE_ASCII
 
 #if SIMDUTF_FEATURE_UTF16
 /**
@@ -258,7 +258,7 @@ validate_utf16(std::span<const char16_t> input) noexcept {
   return validate_utf16(input.data(), input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF16
+#endif   // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
 /**
@@ -283,7 +283,7 @@ validate_utf16le(std::span<const char16_t> input) noexcept {
   return validate_utf16le(input.data(), input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
+#endif   // SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
 
 #if SIMDUTF_FEATURE_UTF16
 /**
@@ -384,7 +384,7 @@ validate_utf16be_with_errors(std::span<const char16_t> input) noexcept {
   return validate_utf16be_with_errors(input.data(), input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF16
+#endif   // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
 /**
@@ -409,7 +409,7 @@ validate_utf32(std::span<const char32_t> input) noexcept {
   return validate_utf32(input.data(), input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
+#endif   // SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
 
 #if SIMDUTF_FEATURE_UTF32
 /**
@@ -436,7 +436,7 @@ validate_utf32_with_errors(std::span<const char32_t> input) noexcept {
   return validate_utf32_with_errors(input.data(), input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF32
+#endif   // SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 /**
@@ -491,7 +491,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_latin1_to_utf8_safe(
       utf8_output.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 /**
@@ -537,17 +537,21 @@ convert_latin1_to_utf16be(const detail::input_span_of_byte_like auto &input,
 }
   #endif // SIMDUTF_SPAN
 /**
- * Compute the number of bytes that this UTF-16 string would require in Latin1 format.
+ * Compute the number of bytes that this UTF-16 string would require in Latin1
+ * format.
  *
  * @param length        the length of the string in Latin1 code units (char)
- * @return the length of the string in Latin1 code units (char) required to encode the UTF-16 string as Latin1
+ * @return the length of the string in Latin1 code units (char) required to
+ * encode the UTF-16 string as Latin1
  */
 simdutf_warn_unused size_t latin1_length_from_utf16(size_t length) noexcept;
 /**
- * Compute the number of code units that this Latin1 string would require in UTF-16 format.
+ * Compute the number of code units that this Latin1 string would require in
+ * UTF-16 format.
  *
  * @param length        the length of the string in Latin1 code units (char)
- * @return the length of the string in 2-byte code units (char16_t) required to encode the Latin1 string as UTF-16
+ * @return the length of the string in 2-byte code units (char16_t) required to
+ * encode the Latin1 string as UTF-16
  */
 simdutf_warn_unused size_t utf16_length_from_latin1(size_t length) noexcept;
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
@@ -574,7 +578,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_latin1_to_utf32(
       utf32_output.data());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
+#endif   // SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 /**
@@ -601,7 +605,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_utf8_to_latin1(
                                 reinterpret_cast<char *>(output.data()));
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 /**
@@ -627,7 +631,7 @@ convert_utf8_to_utf16(const detail::input_span_of_byte_like auto &input,
                                input.size(), output.data());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 /**
@@ -648,7 +652,7 @@ convert_latin1_to_utf16(const detail::input_span_of_byte_like auto &input,
                                  input.size(), output.data());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
+#endif   // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 /**
@@ -698,7 +702,7 @@ convert_utf8_to_utf16be(const detail::input_span_of_byte_like auto &utf8_input,
       utf16_output.data());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 /**
@@ -729,7 +733,7 @@ convert_utf8_to_latin1_with_errors(
       reinterpret_cast<char *>(latin1_output.data()));
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 /**
@@ -813,7 +817,7 @@ convert_utf8_to_utf16be_with_errors(
       utf16_output.data());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 /**
@@ -866,7 +870,7 @@ convert_utf8_to_utf32_with_errors(
       utf32_output.data());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 /**
@@ -899,7 +903,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf8_to_latin1(
       valid_utf8_input.size(), latin1_output.data());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 /**
@@ -967,7 +971,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf8_to_utf16be(
       valid_utf8_input.size(), utf16_output.data());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 /**
@@ -991,7 +995,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf8_to_utf32(
       valid_utf8_input.size(), utf32_output.data());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 /**
@@ -1035,7 +1039,7 @@ simdutf_really_inline simdutf_warn_unused size_t latin1_length_from_utf8(
       valid_utf8_input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 /**
@@ -1062,7 +1066,7 @@ simdutf_really_inline simdutf_warn_unused size_t utf16_length_from_utf8(
       valid_utf8_input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 /**
@@ -1091,7 +1095,7 @@ simdutf_really_inline simdutf_warn_unused size_t utf32_length_from_utf8(
       valid_utf8_input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 /**
@@ -1120,7 +1124,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_utf16_to_utf8(
                                reinterpret_cast<char *>(utf8_output.data()));
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 /**
@@ -1203,7 +1207,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_utf16be_to_latin1(
       reinterpret_cast<char *>(latin1_output.data()));
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
+#endif   // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 /**
@@ -1257,7 +1261,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_utf16be_to_utf8(
                                  reinterpret_cast<char *>(utf8_output.data()));
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 /**
@@ -1346,7 +1350,7 @@ convert_utf16be_to_latin1_with_errors(
       reinterpret_cast<char *>(latin1_output.data()));
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
+#endif   // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 /**
@@ -1461,7 +1465,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf16_to_utf8(
       reinterpret_cast<char *>(utf8_output.data()));
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 /**
@@ -1558,7 +1562,7 @@ convert_valid_utf16be_to_latin1(
       reinterpret_cast<char *>(latin1_output.data()));
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
+#endif   // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 /**
@@ -1611,7 +1615,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf16be_to_utf8(
       reinterpret_cast<char *>(utf8_output.data()));
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 /**
@@ -1846,7 +1850,7 @@ convert_valid_utf16be_to_utf32(std::span<const char16_t> valid_utf16_input,
       valid_utf16_input.data(), valid_utf16_input.size(), utf32_output.data());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
+#endif   // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 /**
@@ -1883,7 +1887,7 @@ utf8_length_from_utf16(std::span<const char16_t> valid_utf16_input) noexcept {
                                 valid_utf16_input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
+#endif   // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 /**
@@ -1927,7 +1931,7 @@ utf8_length_from_utf16be(std::span<const char16_t> valid_utf16_input) noexcept {
                                   valid_utf16_input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 /**
@@ -2008,7 +2012,7 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf32_to_utf8(
       reinterpret_cast<char *>(utf8_output.data()));
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 /**
@@ -2059,7 +2063,7 @@ convert_utf32_to_utf16le(std::span<const char32_t> utf32_input,
                                   utf16_output.data());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
+#endif   // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 /**
@@ -2150,12 +2154,12 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf32_to_latin1(
 }
   #endif // SIMDUTF_SPAN
 
-
 /**
- * Compute the number of bytes that this UTF-32 string would require in Latin1 format.
+ * Compute the number of bytes that this UTF-32 string would require in Latin1
+ * format.
  *
- * This function does not validate the input. It is acceptable to pass invalid UTF-32 strings but in such cases
- * the result is implementation defined.
+ * This function does not validate the input. It is acceptable to pass invalid
+ * UTF-32 strings but in such cases the result is implementation defined.
  *
  * This function is not BOM-aware.
  *
@@ -2165,10 +2169,12 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf32_to_latin1(
 simdutf_warn_unused size_t latin1_length_from_utf32(size_t length) noexcept;
 
 /**
- * Compute the number of bytes that this Latin1 string would require in UTF-32 format.
+ * Compute the number of bytes that this Latin1 string would require in UTF-32
+ * format.
  *
  * @param length        the length of the string in Latin1 code units (char)
- * @return the length of the string in 4-byte code units (char32_t) required to encode the Latin1 string as UTF-32
+ * @return the length of the string in 4-byte code units (char32_t) required to
+ * encode the Latin1 string as UTF-32
  */
 simdutf_warn_unused size_t utf32_length_from_latin1(size_t length) noexcept;
 #endif // SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
@@ -2353,7 +2359,7 @@ convert_valid_utf32_to_utf16be(std::span<const char32_t> valid_utf32_input,
       valid_utf32_input.data(), valid_utf32_input.size(), utf16_output.data());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
+#endif   // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF16
 /**
@@ -2379,7 +2385,7 @@ change_endianness_utf16(std::span<const char16_t> utf16_input,
                                  utf16_output.data());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF16
+#endif   // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 /**
@@ -2402,7 +2408,7 @@ utf8_length_from_utf32(std::span<const char32_t> valid_utf32_input) noexcept {
                                 valid_utf32_input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
+#endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 /**
@@ -2500,7 +2506,7 @@ simdutf_really_inline simdutf_warn_unused size_t utf32_length_from_utf16be(
                                    valid_utf16_input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
+#endif   // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF16
 /**
@@ -2571,7 +2577,7 @@ count_utf16be(std::span<const char16_t> valid_utf16_input) noexcept {
   return count_utf16be(valid_utf16_input.data(), valid_utf16_input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF16
+#endif   // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8
 /**
@@ -2619,7 +2625,7 @@ simdutf_really_inline simdutf_warn_unused size_t trim_partial_utf8(
       valid_utf8_input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF8
+#endif   // SIMDUTF_FEATURE_UTF8
 
 #if SIMDUTF_FEATURE_UTF16
 /**
@@ -2692,7 +2698,7 @@ trim_partial_utf16(std::span<const char16_t> valid_utf16_input) noexcept {
   return trim_partial_utf16(valid_utf16_input.data(), valid_utf16_input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_UTF16
+#endif   // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_BASE64
 // base64_options are used to specify the base64 encoding options.
@@ -3054,7 +3060,7 @@ simdutf_really_inline simdutf_warn_unused result base64_to_binary_safe(
                                outlen, options, last_chunk_options);
 }
   #endif // SIMDUTF_SPAN
-#endif // SIMDUTF_FEATURE_BASE64
+#endif   // SIMDUTF_FEATURE_BASE64
 
 /**
  * An implementation of simdutf for a particular CPU architecture.

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -536,6 +536,20 @@ convert_latin1_to_utf16be(const detail::input_span_of_byte_like auto &input,
                                    input.size(), output.data());
 }
   #endif // SIMDUTF_SPAN
+/**
+ * Compute the number of bytes that this UTF-16 string would require in Latin1 format.
+ *
+ * @param length        the length of the string in Latin1 code units (char)
+ * @return the length of the string in Latin1 code units (char) required to encode the UTF-16 string as Latin1
+ */
+simdutf_warn_unused size_t latin1_length_from_utf16(size_t length) noexcept;
+/**
+ * Compute the number of code units that this Latin1 string would require in UTF-16 format.
+ *
+ * @param length        the length of the string in Latin1 code units (char)
+ * @return the length of the string in 2-byte code units (char16_t) required to encode the Latin1 string as UTF-16
+ */
+simdutf_warn_unused size_t utf16_length_from_latin1(size_t length) noexcept;
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
@@ -2135,6 +2149,28 @@ simdutf_really_inline simdutf_warn_unused size_t convert_valid_utf32_to_latin1(
       reinterpret_cast<char *>(latin1_output.data()));
 }
   #endif // SIMDUTF_SPAN
+
+
+/**
+ * Compute the number of bytes that this UTF-32 string would require in Latin1 format.
+ *
+ * This function does not validate the input. It is acceptable to pass invalid UTF-32 strings but in such cases
+ * the result is implementation defined.
+ *
+ * This function is not BOM-aware.
+ *
+ * @param length        the length of the string in 4-byte code units (char32_t)
+ * @return the number of bytes required to encode the UTF-32 string as Latin1
+ */
+simdutf_warn_unused size_t latin1_length_from_utf32(size_t length) noexcept;
+
+/**
+ * Compute the number of bytes that this Latin1 string would require in UTF-32 format.
+ *
+ * @param length        the length of the string in Latin1 code units (char)
+ * @return the length of the string in 4-byte code units (char32_t) required to encode the Latin1 string as UTF-32
+ */
+simdutf_warn_unused size_t utf32_length_from_latin1(size_t length) noexcept;
 #endif // SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
@@ -4393,7 +4429,6 @@ public:
    * Return the number of bytes that this UTF-32 string would require in Latin1
    * format.
    *
-   * @param input         the UTF-32 string to convert
    * @param length        the length of the string in 4-byte code units
    * (char32_t)
    * @return the number of bytes required to encode the UTF-32 string as Latin1

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1399,6 +1399,12 @@ simdutf_warn_unused size_t convert_latin1_to_utf32(
   return get_default_implementation()->convert_latin1_to_utf32(buf, len,
                                                                latin1_output);
 }
+simdutf_warn_unused size_t latin1_length_from_utf32(size_t length) noexcept {
+  return length;
+}
+simdutf_warn_unused size_t utf32_length_from_latin1(size_t length) noexcept {
+  return length;
+}
 #endif // SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
@@ -1602,6 +1608,12 @@ simdutf_warn_unused result convert_utf16be_to_latin1_with_errors(
     const char16_t *buf, size_t len, char *latin1_buffer) noexcept {
   return get_default_implementation()->convert_utf16be_to_latin1_with_errors(
       buf, len, latin1_buffer);
+}
+simdutf_warn_unused size_t latin1_length_from_utf16(size_t length) noexcept {
+  return length;
+}
+simdutf_warn_unused size_t utf16_length_from_latin1(size_t length) noexcept {
+  return length;
 }
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 


### PR DESCRIPTION
We have some silly (convenience) functions which may have gone missing. This PR puts them back or add them if they weren't there. These functions are truly silly and could have been omitted, but we include them purely for convenience.

I am also adding a terminating comment, moving from

```C++
#endif
```

to

```C++
#endif // SIMDUTF_SPAN
```

in some places as it is more readable to know what the `#endif` is closing.

Fixes https://github.com/simdutf/simdutf/issues/661