### PR TITLE
AVX2: better Latin1 <=> UTF-16 conversion

### DIFF
--- a/src/haswell/avx2_convert_latin1_to_utf16.cpp
+++ b/src/haswell/avx2_convert_latin1_to_utf16.cpp
@@ -2,35 +2,26 @@ template <endianness big_endian>
 std::pair<const char *, char16_t *>
 avx2_convert_latin1_to_utf16(const char *latin1_input, size_t len,
                              char16_t *utf16_output) {
-  size_t rounded_len = len & ~0xF; // Round down to nearest multiple of 32
+  size_t rounded_len = len & ~0xF; // Round down to nearest multiple of 16
 
   size_t i = 0;
   for (; i < rounded_len; i += 16) {
     // Load 16 bytes from the address (input + i) into a xmm register
-    __m128i xmm0 =
+    const __m128i latin1 =
         _mm_loadu_si128(reinterpret_cast<const __m128i *>(latin1_input + i));
 
-    // Zero extend each byte in xmm0 to word and put it in another xmm register
-    __m128i xmm1 = _mm_cvtepu8_epi16(xmm0);
-
-    // Shift xmm0 to the right by 8 bytes
-    xmm0 = _mm_srli_si128(xmm0, 8);
-
-    // Zero extend each byte in the shifted xmm0 to word in xmm0
-    xmm0 = _mm_cvtepu8_epi16(xmm0);
+    // Zero extend each byte in `in` to word
+    __m256i utf16 = _mm256_cvtepu8_epi16(latin1);
 
     if (big_endian) {
-      const __m128i swap =
+      const __m128i swap128 =
           _mm_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-      xmm0 = _mm_shuffle_epi8(xmm0, swap);
-      xmm1 = _mm_shuffle_epi8(xmm1, swap);
+      const __m256i swap = _mm256_set_m128i(swap128, swap128);
+      utf16 = _mm256_shuffle_epi8(utf16, swap);
     }
 
     // Store the contents of xmm1 into the address pointed by (output + i)
-    _mm_storeu_si128(reinterpret_cast<__m128i *>(utf16_output + i), xmm1);
-
-    // Store the contents of xmm0 into the address pointed by (output + i + 8)
-    _mm_storeu_si128(reinterpret_cast<__m128i *>(utf16_output + i + 8), xmm0);
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(utf16_output + i), utf16);
   }
 
   return std::make_pair(latin1_input + rounded_len, utf16_output + rounded_len);

--- a/src/haswell/avx2_convert_utf32_to_latin1.cpp
+++ b/src/haswell/avx2_convert_utf32_to_latin1.cpp
@@ -4,63 +4,81 @@ avx2_convert_utf32_to_latin1(const char32_t *buf, size_t len,
   const size_t rounded_len =
       len & ~0x1F; // Round down to nearest multiple of 32
 
-  __m256i high_bytes_mask = _mm256_set1_epi32(0xFFFFFF00);
+  const __m256i high_bytes_mask = _mm256_set1_epi32(0xFFFFFF00);
 
-  __m256i shufmask = _mm256_set_epi8(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                                     -1, 12, 8, 4, 0, -1, -1, -1, -1, -1, -1,
-                                     -1, -1, -1, -1, -1, -1, 12, 8, 4, 0);
+  for (size_t i = 0; i < rounded_len; i += 4 * 8) {
+    __m256i a = _mm256_loadu_si256((__m256i *)(buf + 0 * 8));
+    __m256i b = _mm256_loadu_si256((__m256i *)(buf + 1 * 8));
+    __m256i c = _mm256_loadu_si256((__m256i *)(buf + 2 * 8));
+    __m256i d = _mm256_loadu_si256((__m256i *)(buf + 3 * 8));
 
-  for (size_t i = 0; i < rounded_len; i += 16) {
-    __m256i in1 = _mm256_loadu_si256((__m256i *)buf);
-    __m256i in2 = _mm256_loadu_si256((__m256i *)(buf + 8));
-
-    __m256i check_combined = _mm256_or_si256(in1, in2);
+    const __m256i check_combined =
+        _mm256_or_si256(_mm256_or_si256(a, b), _mm256_or_si256(c, d));
 
     if (!_mm256_testz_si256(check_combined, high_bytes_mask)) {
       return std::make_pair(nullptr, latin1_output);
     }
 
-    // Turn UTF32 bytes into latin 1 bytes
-    __m256i shuffled1 = _mm256_shuffle_epi8(in1, shufmask);
-    __m256i shuffled2 = _mm256_shuffle_epi8(in2, shufmask);
+    b = _mm256_slli_epi32(b, 1 * 8);
+    c = _mm256_slli_epi32(c, 2 * 8);
+    d = _mm256_slli_epi32(d, 3 * 8);
 
-    // move Latin1 bytes to their correct spot
-    __m256i idx1 = _mm256_set_epi32(-1, -1, -1, -1, -1, -1, 4, 0);
-    __m256i idx2 = _mm256_set_epi32(-1, -1, -1, -1, 4, 0, -1, -1);
-    __m256i reshuffled1 = _mm256_permutevar8x32_epi32(shuffled1, idx1);
-    __m256i reshuffled2 = _mm256_permutevar8x32_epi32(shuffled2, idx2);
+    // clang-format off
 
-    __m256i result = _mm256_or_si256(reshuffled1, reshuffled2);
-    _mm_storeu_si128((__m128i *)latin1_output, _mm256_castsi256_si128(result));
+    // a  = [.. .. .. a7|.. .. .. a6|.. .. .. a5|.. .. .. a4||.. .. .. a3|.. .. .. a2|.. .. .. a1|.. .. .. a0]
+    // b  = [.. .. b7 ..|.. .. b6 ..|.. .. b5 ..|.. .. b4 ..||.. .. b3 ..|.. .. b2 ..|.. .. b1 ..|.. .. b0 ..]
+    // c  = [.. c7 .. ..|.. c6 .. ..|.. c5 .. ..|.. c4 .. ..||.. c3 .. ..|.. c2 .. ..|.. c1 .. ..|.. c0 .. ..]
+    // d  = [d7 .. .. ..|d6 .. .. ..|d5 .. .. ..|d4 .. .. ..||d3 .. .. ..|d2 .. .. ..|d1 .. .. ..|d0 .. .. ..]
 
-    latin1_output += 16;
-    buf += 16;
+    // t0 = [d7 c7 b7 a7|d6 c6 b6 a6|d5 c5 b5 a5|d4 c4 b4 a4||d3 c3 b3 a3|d2 c2 b2 a2|d1 c1 b1 a1|d0 c0 b0 a0]
+    const __m256i t0 =
+        _mm256_or_si256(_mm256_or_si256(a, b), _mm256_or_si256(c, d));
+
+    // shuffle bytes within 128-bit lanes
+    // t1 = [d7 d6 d5 d4|c7 c6 c5 c4|b7 b6 b5 b4|a7 a6 a5 a4||d3 d2 d1 d0|c3 c2 c1 c0|b3 b2 b1 b0|a3 a2 a1 a0]
+    const __m256i shuffle_bytes =
+        _mm256_setr_epi8(0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15,
+                         0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15);
+
+    const __m256i t1 = _mm256_shuffle_epi8(t0, shuffle_bytes);
+
+    // reshuffle dwords
+    // t2 = [d7 d6 d5 d4|d3 d2 d1 d0|c7 c6 c5 c4|c3 c2 c1 c0||b7 b6 b5 b4|b3 b2 b1 b0|a7 a6 a5 a4|a3 a2 a1 a0]
+    const __m256i shuffle_dwords = _mm256_setr_epi32(0, 4, 1, 5, 2, 6, 3, 7);
+    const __m256i t2 = _mm256_permutevar8x32_epi32(t1, shuffle_dwords);
+// clang format on
+
+    _mm256_storeu_si256((__m256i *)latin1_output, t2);
+
+    latin1_output += 32;
+    buf += 32;
   }
 
   return std::make_pair(buf, latin1_output);
 }
+
 std::pair<result, char *>
 avx2_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
                                          char *latin1_output) {
   const size_t rounded_len =
       len & ~0x1F; // Round down to nearest multiple of 32
 
-  __m256i high_bytes_mask = _mm256_set1_epi32(0xFFFFFF00);
-  __m256i shufmask = _mm256_set_epi8(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                                     -1, 12, 8, 4, 0, -1, -1, -1, -1, -1, -1,
-                                     -1, -1, -1, -1, -1, -1, 12, 8, 4, 0);
-
   const char32_t *start = buf;
 
-  for (size_t i = 0; i < rounded_len; i += 16) {
-    __m256i in1 = _mm256_loadu_si256((__m256i *)buf);
-    __m256i in2 = _mm256_loadu_si256((__m256i *)(buf + 8));
+  const __m256i high_bytes_mask = _mm256_set1_epi32(0xFFFFFF00);
 
-    __m256i check_combined = _mm256_or_si256(in1, in2);
+  for (size_t i = 0; i < rounded_len; i += 4 * 8) {
+    __m256i a = _mm256_loadu_si256((__m256i *)(buf + 0 * 8));
+    __m256i b = _mm256_loadu_si256((__m256i *)(buf + 1 * 8));
+    __m256i c = _mm256_loadu_si256((__m256i *)(buf + 2 * 8));
+    __m256i d = _mm256_loadu_si256((__m256i *)(buf + 3 * 8));
+
+    const __m256i check_combined =
+        _mm256_or_si256(_mm256_or_si256(a, b), _mm256_or_si256(c, d));
 
     if (!_mm256_testz_si256(check_combined, high_bytes_mask)) {
       // Fallback to scalar code for handling errors
-      for (int k = 0; k < 8; k++) {
+      for (int k = 0; k < 4 * 8; k++) {
         char32_t codepoint = buf[k];
         if (codepoint <= 0xFF) {
           *latin1_output++ = static_cast<char>(codepoint);
@@ -69,23 +87,28 @@ avx2_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
                                 latin1_output);
         }
       }
-      buf += 8;
-    } else {
-      __m256i shuffled1 = _mm256_shuffle_epi8(in1, shufmask);
-      __m256i shuffled2 = _mm256_shuffle_epi8(in2, shufmask);
-
-      __m256i idx1 = _mm256_set_epi32(-1, -1, -1, -1, -1, -1, 4, 0);
-      __m256i idx2 = _mm256_set_epi32(-1, -1, -1, -1, 4, 0, -1, -1);
-      __m256i reshuffled1 = _mm256_permutevar8x32_epi32(shuffled1, idx1);
-      __m256i reshuffled2 = _mm256_permutevar8x32_epi32(shuffled2, idx2);
-
-      __m256i result = _mm256_or_si256(reshuffled1, reshuffled2);
-      _mm_storeu_si128((__m128i *)latin1_output,
-                       _mm256_castsi256_si128(result));
-
-      latin1_output += 16;
-      buf += 16;
     }
+
+    b = _mm256_slli_epi32(b, 1 * 8);
+    c = _mm256_slli_epi32(c, 2 * 8);
+    d = _mm256_slli_epi32(d, 3 * 8);
+
+    const __m256i t0 =
+        _mm256_or_si256(_mm256_or_si256(a, b), _mm256_or_si256(c, d));
+
+    const __m256i shuffle_bytes =
+        _mm256_setr_epi8(0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15,
+                         0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15);
+
+    const __m256i t1 = _mm256_shuffle_epi8(t0, shuffle_bytes);
+
+    const __m256i shuffle_dwords = _mm256_setr_epi32(0, 4, 1, 5, 2, 6, 3, 7);
+    const __m256i t2 = _mm256_permutevar8x32_epi32(t1, shuffle_dwords);
+
+    _mm256_storeu_si256((__m256i *)latin1_output, t2);
+
+    latin1_output += 32;
+    buf += 32;
   }
 
   return std::make_pair(result(error_code::SUCCESS, buf - start),


### PR DESCRIPTION
Early draft, it's faster on my Zen3, need more benchmarking on Skylake and Icelake.

Commands to test:

```
#!/bin/sh

./benchmark -P convert_latin1_to_utf16+haswell -F unicode_lipsum/wikipedia_mars/*.latin1.*
./benchmark -P convert_utf16_to_latin1+haswell -F unicode_lipsum/wikipedia_mars/*.utflatin16.*
./benchmark -P convert_utf16_to_latin1_with_errors+haswell -F unicode_lipsum/wikipedia_mars/*.utflatin16.*
./benchmark -P convert_valid_utf16_to_latin1+haswell -F unicode_lipsum/wikipedia_mars/*.utflatin16.*
./benchmark -P convert_utf32_to_latin1+haswell -F unicode_lipsum/wikipedia_mars/*.utflatin32.*
./benchmark -P convert_valid_utf32_to_latin1+haswell -F unicode_lipsum/wikipedia_mars/*.utflatin32.*
./benchmark -P convert_utf32_to_latin1_with_errors+haswell -F unicode_lipsum/wikipedia_mars/*.utflatin32.*
```

### Ryzen 7

```
+-----------------------+----------+------------+----------+----------+---------+
|        dataset        | size [B] | iterations | old GB/s | new GB/s | speedup |
+=======================+==========+============+==========+==========+=========+
| convert_latin1_to_utf16+haswell                                               |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.latin1      |    82168 |      30000 |    35.65 |    42.03 | 1.18x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.latin1         |   432305 |      30000 |    33.10 |    32.92 | 0.99x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.latin1         |   199331 |      30000 |    29.42 |    35.24 | 1.20x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.latin1     |   271743 |      30000 |    33.54 |    35.70 | 1.06x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_utf16_to_latin1+haswell                                               |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin16  |   164336 |      30000 |    57.38 |    87.14 | 1.52x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin16     |   864610 |      30000 |    52.24 |    70.34 | 1.35x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin16     |   398662 |      30000 |    53.35 |    74.13 | 1.39x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin16 |   543486 |      30000 |    53.30 |    57.22 | 1.07x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_utf16_to_latin1_with_errors+haswell                                   |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin16  |   164336 |      30000 |    49.03 |    44.40 | 0.91x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin16     |   864610 |      30000 |    45.68 |    46.54 | 1.02x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin16     |   398662 |      30000 |    46.79 |    46.79 | 1.00x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin16 |   543486 |      30000 |    46.32 |    46.05 | 0.99x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_valid_utf16_to_latin1+haswell                                         |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin16  |   164336 |      30000 |    57.38 |    78.44 | 1.37x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin16     |   864610 |      30000 |    52.90 |    70.74 | 1.34x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin16     |   398662 |      30000 |    53.35 |    70.47 | 1.32x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin16 |   543486 |      30000 |    47.16 |    62.76 | 1.33x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_utf32_to_latin1+haswell                                               |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin32  |   328672 |      30000 |    85.57 |    87.16 | 1.02x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin32     |  1729220 |      30000 |    75.72 |    84.79 | 1.12x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin32     |   797324 |      30000 |    60.73 |    83.32 | 1.37x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin32 |  1086972 |      30000 |    68.56 |    80.64 | 1.18x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_valid_utf32_to_latin1+haswell                                         |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin32  |   328672 |      30000 |    74.70 |    85.57 | 1.15x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin32     |  1729220 |      30000 |    75.48 |    83.08 | 1.10x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin32     |   797324 |      30000 |    73.18 |    64.50 | 0.88x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin32 |  1086972 |      30000 |    75.92 |    82.34 | 1.08x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_utf32_to_latin1_with_errors+haswell                                   |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin32  |   328672 |      30000 |    75.91 |    78.44 | 1.03x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin32     |  1729220 |      30000 |    75.72 |    80.91 | 1.07x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin32     |   797324 |      30000 |    74.13 |    58.54 | 0.79x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin32 |  1086972 |      30000 |    64.85 |    73.76 | 1.14x   |
+-----------------------+----------+------------+----------+----------+---------+
```

### Skylake-X

```
+-----------------------+----------+------------+----------+----------+---------+
|        dataset        | size [B] | iterations | old GB/s | new GB/s | speedup |
+=======================+==========+============+==========+==========+=========+
| convert_latin1_to_utf16+haswell                                               |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.latin1      |    82168 |      30000 |    14.77 |    16.94 | 1.15x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.latin1         |   432305 |      30000 |     9.37 |     9.32 | 0.99x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.latin1         |   199331 |      30000 |    15.64 |    21.35 | 1.36x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.latin1     |   271743 |      30000 |    14.13 |    19.21 | 1.36x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_utf16_to_latin1+haswell                                               |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin16  |   164336 |      30000 |    20.17 |    36.70 | 1.82x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin16     |   864610 |      30000 |    15.22 |    19.77 | 1.30x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin16     |   398662 |      30000 |    21.03 |    39.29 | 1.87x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin16 |   543486 |      30000 |    20.75 |    36.68 | 1.77x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_utf16_to_latin1_with_errors+haswell                                   |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin16  |   164336 |      30000 |    19.35 |    18.86 | 0.97x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin16     |   864610 |      30000 |    15.90 |    16.07 | 1.01x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin16     |   398662 |      30000 |    20.09 |    19.67 | 0.98x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin16 |   543486 |      30000 |    19.77 |    19.36 | 0.98x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_valid_utf16_to_latin1+haswell                                         |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin16  |   164336 |      30000 |    20.19 |    36.72 | 1.82x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin16     |   864610 |      30000 |    14.95 |    18.40 | 1.23x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin16     |   398662 |      30000 |    21.00 |    38.37 | 1.83x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin16 |   543486 |      30000 |    20.12 |    33.33 | 1.66x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_utf32_to_latin1+haswell                                               |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin32  |   328672 |      30000 |    32.02 |    42.31 | 1.32x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin32     |  1729220 |      30000 |    16.42 |    22.31 | 1.36x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin32     |   797324 |      30000 |    24.23 |    34.68 | 1.43x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin32 |  1086972 |      30000 |    18.44 |    22.06 | 1.20x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_valid_utf32_to_latin1+haswell                                         |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin32  |   328672 |      30000 |    32.05 |    42.22 | 1.32x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin32     |  1729220 |      30000 |    21.28 |    17.78 | 0.84x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin32     |   797324 |      30000 |    27.56 |    34.19 | 1.24x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin32 |  1086972 |      30000 |    21.25 |    21.87 | 1.03x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_utf32_to_latin1_with_errors+haswell                                   |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin32  |   328672 |      30000 |    32.58 |    42.38 | 1.30x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin32     |  1729220 |      30000 |    17.93 |    16.47 | 0.92x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin32     |   797324 |      30000 |    28.75 |    30.95 | 1.08x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin32 |  1086972 |      30000 |    20.24 |    20.33 | 1.00x   |
+-----------------------+----------+------------+----------+----------+---------+
```

### Icelake

```
+-----------------------+----------+------------+----------+----------+---------+
|        dataset        | size [B] | iterations | old GB/s | new GB/s | speedup |
+=======================+==========+============+==========+==========+=========+
| convert_latin1_to_utf16+haswell                                               |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.latin1      |    82168 |      30000 |    26.11 |    11.49 | 0.44x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.latin1         |   432305 |      30000 |    18.28 |    13.44 | 0.74x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.latin1         |   199331 |      30000 |    26.18 |    25.39 | 0.97x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.latin1     |   271743 |      30000 |    25.43 |    25.41 | 1.00x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_utf16_to_latin1+haswell                                               |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin16  |   164336 |      30000 |    25.16 |    52.84 | 2.10x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin16     |   864610 |      30000 |    24.07 |    35.98 | 1.49x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin16     |   398662 |      30000 |    25.22 |    53.41 | 2.12x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin16 |   543486 |      30000 |    25.16 |    53.28 | 2.12x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_utf16_to_latin1_with_errors+haswell                                   |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin16  |   164336 |      30000 |    25.11 |    25.07 | 1.00x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin16     |   864610 |      30000 |    24.19 |    24.15 | 1.00x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin16     |   398662 |      30000 |    25.22 |    25.23 | 1.00x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin16 |   543486 |      30000 |    25.11 |    25.21 | 1.00x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_valid_utf16_to_latin1+haswell                                         |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin16  |   164336 |      30000 |    25.15 |    33.21 | 1.32x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin16     |   864610 |      30000 |    23.91 |    35.91 | 1.50x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin16     |   398662 |      30000 |    25.23 |    53.29 | 2.11x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin16 |   543486 |      30000 |    25.24 |    53.35 | 2.11x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_utf32_to_latin1+haswell                                               |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin32  |   328672 |      30000 |    40.12 |    58.22 | 1.45x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin32     |  1729220 |      30000 |    25.63 |    26.34 | 1.03x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin32     |   797324 |      30000 |    39.00 |    58.35 | 1.50x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin32 |  1086972 |      30000 |    32.57 |    44.90 | 1.38x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_valid_utf32_to_latin1+haswell                                         |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin32  |   328672 |      30000 |    40.04 |    58.30 | 1.46x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin32     |  1729220 |      30000 |    25.01 |    26.33 | 1.05x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin32     |   797324 |      30000 |    40.00 |    58.50 | 1.46x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin32 |  1086972 |      30000 |    34.57 |    44.00 | 1.27x   |
+-----------------------+----------+------------+----------+----------+---------+
| convert_utf32_to_latin1_with_errors+haswell                                   |
+-----------------------+----------+------------+----------+----------+---------+
| esperanto.utflatin32  |   328672 |      30000 |    40.03 |    57.70 | 1.44x   |
+-----------------------+----------+------------+----------+----------+---------+
| french.utflatin32     |  1729220 |      30000 |    25.85 |    26.68 | 1.03x   |
+-----------------------+----------+------------+----------+----------+---------+
| german.utflatin32     |   797324 |      30000 |    40.00 |    55.14 | 1.38x   |
+-----------------------+----------+------------+----------+----------+---------+
| portuguese.utflatin32 |  1086972 |      30000 |    34.94 |    41.37 | 1.18x   |
+-----------------------+----------+------------+----------+----------+---------+
```