### PR TITLE
Implementing to_well_formed_utf16

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,37 @@ simdutf_warn_unused result validate_utf32_with_errors(const char32_t *buf, size_
 
 ```
 
+Given a potentially invalid UTF-16 input, you may want to make it correct, by using
+a replacement character whenever needed. We have fast functions for this purpose.
+
+```cpp
+/**
+ * Copies the UTF-16BE string while replacing mismatched surrogates with the
+ * Unicode replacement character U+FFFD. We allow the input and output to be the
+ * same buffer so that the correction is done in-place.
+ *
+ * @param input the UTF-16BE string to correct.
+ * @param len the length of the string in number of 2-byte code units
+ * (char16_t).
+ * @param output the output buffer.
+ */
+void to_well_formed_utf16be(const char16_t *input, size_t len,
+                            char16_t *output) noexcept;
+
+/**
+ * Copies the UTF-16 string while replacing mismatched surrogates with the
+ * Unicode replacement character U+FFFD. We allow the input and output to be the
+ * same buffer so that the correction is done in-place.
+ *
+ * @param input the UTF-16 string to correct.
+ * @param len the length of the string in number of 2-byte code units
+ * (char16_t).
+ * @param output the output buffer.
+ */
+void to_well_formed_utf16(const char16_t *input, size_t len,
+                          char16_t *output) noexcept;
+```
+
 Given a valid UTF-8 or UTF-16 input, you may count the number Unicode characters using
 fast functions. For UTF-32, there is no need for a function given that each character
 requires a flat 4 bytes. Likewise for Latin1: one byte will always equal one character.

--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -15,16 +15,17 @@ void info_message() {
   std::cout << "Using iconv version " << _LIBICONV_VERSION << std::endl;
 #endif
 #if defined(__clang__)
-  std::cout << "Compiler: Clang " << __clang_major__ << "." 
-          << __clang_minor__ << "." << __clang_patchlevel__ << "\n";
+  std::cout << "Compiler: Clang " << __clang_major__ << "." << __clang_minor__
+            << "." << __clang_patchlevel__ << "\n";
 #elif defined(__GNUC__)
-  std::cout << "Compiler: GCC " << __GNUC__ << "." 
-          << __GNUC_MINOR__ << "." << __GNUC_PATCHLEVEL__ << "\n";
+  std::cout << "Compiler: GCC " << __GNUC__ << "." << __GNUC_MINOR__ << "."
+            << __GNUC_PATCHLEVEL__ << "\n";
 #elif defined(_MSC_VER)
   std::cout << "Compiler: MSVC " << _MSC_VER << "\n";
 #endif
   std::cout << "SIMDUTF version: " << SIMDUTF_VERSION << "\n";
-  std::cout << "System: " << simdutf::get_active_implementation()->name() << "\n";
+  std::cout << "System: " << simdutf::get_active_implementation()->name()
+            << "\n";
   std::cout << "===========================\n";
 }
 

--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -113,7 +113,9 @@ void Benchmark::register_function(std::string name, Fn function,
 
 Benchmark::Benchmark(std::vector<input::Testcase> &&testcases)
     : BenchmarkBase(std::move(testcases)) {
-
+  register_function("run_to_well_formed_utf16",
+                    &Benchmark::run_to_well_formed_utf16,
+                    simdutf::encoding_type::UTF16_LE);
   register_function("validate_utf8", &Benchmark::run_validate_utf8,
                     simdutf::encoding_type::UTF8);
   register_function("validate_utf8_with_errors",
@@ -853,6 +855,20 @@ void Benchmark::run_utf8_length_from_utf32(
   count_events(proc, iterations); // warming up!
   const auto result = count_events(proc, iterations);
   print_summary(result, size, size);
+}
+
+void Benchmark::run_to_well_formed_utf16(
+  const simdutf::implementation &implementation, size_t iterations) {
+    const char16_t *data = reinterpret_cast<const char16_t *>(input_data.data());
+    const size_t size = input_data.size()/2;
+    std::unique_ptr<char16_t[]> output_buffer{new char16_t[size]};
+    auto proc = [&implementation, data, size, &output_buffer]() {
+      implementation.to_well_formed_utf16le(data, size, output_buffer.get());
+    };
+    count_events(proc, iterations); // warming up!
+    const auto result = count_events(proc, iterations);
+    size_t char_count = get_active_implementation()->count_utf16le(data, size);
+    print_summary(result, size, char_count);
 }
 
 void Benchmark::run_utf16_length_from_utf8(

--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -858,17 +858,17 @@ void Benchmark::run_utf8_length_from_utf32(
 }
 
 void Benchmark::run_to_well_formed_utf16(
-  const simdutf::implementation &implementation, size_t iterations) {
-    const char16_t *data = reinterpret_cast<const char16_t *>(input_data.data());
-    const size_t size = input_data.size()/2;
-    std::unique_ptr<char16_t[]> output_buffer{new char16_t[size]};
-    auto proc = [&implementation, data, size, &output_buffer]() {
-      implementation.to_well_formed_utf16le(data, size, output_buffer.get());
-    };
-    count_events(proc, iterations); // warming up!
-    const auto result = count_events(proc, iterations);
-    size_t char_count = get_active_implementation()->count_utf16le(data, size);
-    print_summary(result, size, char_count);
+    const simdutf::implementation &implementation, size_t iterations) {
+  const char16_t *data = reinterpret_cast<const char16_t *>(input_data.data());
+  const size_t size = input_data.size() / 2;
+  std::unique_ptr<char16_t[]> output_buffer{new char16_t[size]};
+  auto proc = [&implementation, data, size, &output_buffer]() {
+    implementation.to_well_formed_utf16le(data, size, output_buffer.get());
+  };
+  count_events(proc, iterations); // warming up!
+  const auto result = count_events(proc, iterations);
+  size_t char_count = get_active_implementation()->count_utf16le(data, size);
+  print_summary(result, size, char_count);
 }
 
 void Benchmark::run_utf16_length_from_utf8(

--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -868,7 +868,7 @@ void Benchmark::run_to_well_formed_utf16(
   count_events(proc, iterations); // warming up!
   const auto result = count_events(proc, iterations);
   size_t char_count = get_active_implementation()->count_utf16le(data, size);
-  print_summary(result, size, char_count);
+  print_summary(result, input_data.size(), char_count);
 }
 
 void Benchmark::run_utf16_length_from_utf8(

--- a/benchmarks/src/benchmark.h
+++ b/benchmarks/src/benchmark.h
@@ -88,6 +88,7 @@ private:
   void
   register_function(std::string name, Fn function, simdutf::encoding_type enc1,
                     simdutf::encoding_type enc2, simdutf::encoding_type enc3);
+
 private:
   void run_validate_utf8(const simdutf::implementation &implementation,
                          size_t iterations);
@@ -102,7 +103,7 @@ private:
   void run_validate_utf32(const simdutf::implementation &implementation,
                           size_t iterations);
   void run_to_well_formed_utf16(const simdutf::implementation &implementation,
-                          size_t iterations);
+                                size_t iterations);
   void
   run_validate_utf32_with_errors(const simdutf::implementation &implementation,
                                  size_t iterations);

--- a/benchmarks/src/benchmark.h
+++ b/benchmarks/src/benchmark.h
@@ -101,6 +101,8 @@ private:
                                  size_t iterations);
   void run_validate_utf32(const simdutf::implementation &implementation,
                           size_t iterations);
+  void run_to_well_formed_utf16(const simdutf::implementation &implementation,
+                          size_t iterations);
   void
   run_validate_utf32_with_errors(const simdutf::implementation &implementation,
                                  size_t iterations);

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -403,7 +403,7 @@ void to_well_formed_utf16le(const char16_t *input, size_t len,
 simdutf_really_inline void
 to_well_formed_utf16le(std::span<const char16_t> input,
                        std::span<char16_t> output) noexcept {
-  return to_well_formed_utf16le(input.data(), input.size(), output.data());
+  to_well_formed_utf16le(input.data(), input.size(), output.data());
 }
   #endif // SIMDUTF_SPAN
 
@@ -425,7 +425,7 @@ void to_well_formed_utf16be(const char16_t *input, size_t len,
 simdutf_really_inline void
 to_well_formed_utf16be(std::span<const char16_t> input,
                        std::span<char16_t> output) noexcept {
-  return to_well_formed_utf16be(input.data(), input.size(), output.data());
+  to_well_formed_utf16be(input.data(), input.size(), output.data());
 }
   #endif // SIMDUTF_SPAN
 
@@ -447,7 +447,7 @@ void to_well_formed_utf16(const char16_t *input, size_t len,
 simdutf_really_inline void
 to_well_formed_utf16(std::span<const char16_t> input,
                      std::span<char16_t> output) noexcept {
-  return to_well_formed_utf16(input.data(), input.size(), output.data());
+  to_well_formed_utf16(input.data(), input.size(), output.data());
 }
   #endif // SIMDUTF_SPAN
 

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -384,7 +384,68 @@ validate_utf16be_with_errors(std::span<const char16_t> input) noexcept {
   return validate_utf16be_with_errors(input.data(), input.size());
 }
   #endif // SIMDUTF_SPAN
-#endif   // SIMDUTF_FEATURE_UTF16
+
+/**
+ * Copies the UTF-16LE string while replacing mismatched surrogates with the
+ * Unicode replacement character U+FFFD. We allow the input and output to be the
+ * same buffer so that the correction is done in-place.
+ *
+ * @param input the UTF-16LE string to correct.
+ * @param len the length of the string in number of 2-byte code units
+ * (char16_t).
+ * @param output the output buffer.
+ */
+void to_well_formed_utf16le(const char16_t *input, size_t len,
+                            char16_t *output) noexcept;
+  #if SIMDUTF_SPAN
+simdutf_really_inline simdutf_warn_unused result
+to_well_formed_utf16le(std::span<const char16_t> input,
+                       std::span<const char16_t> output) noexcept {
+  return to_well_formed_utf16le(input.data(), input.size(), output.data());
+}
+  #endif // SIMDUTF_SPAN
+
+/**
+ * Copies the UTF-16BE string while replacing mismatched surrogates with the
+ * Unicode replacement character U+FFFD. We allow the input and output to be the
+ * same buffer so that the correction is done in-place.
+ *
+ * @param input the UTF-16BE string to correct.
+ * @param len the length of the string in number of 2-byte code units
+ * (char16_t).
+ * @param output the output buffer.
+ */
+void to_well_formed_utf16be(const char16_t *input, size_t len,
+                            char16_t *output) noexcept;
+  #if SIMDUTF_SPAN
+simdutf_really_inline simdutf_warn_unused result
+to_well_formed_utf16be(std::span<const char16_t> input,
+                       std::span<const char16_t> output) noexcept {
+  return to_well_formed_utf16be(input.data(), input.size(), output.data());
+}
+  #endif // SIMDUTF_SPAN
+
+/**
+ * Copies the UTF-16 string while replacing mismatched surrogates with the
+ * Unicode replacement character U+FFFD. We allow the input and output to be the
+ * same buffer so that the correction is done in-place.
+ *
+ * @param input the UTF-16 string to correct.
+ * @param len the length of the string in number of 2-byte code units
+ * (char16_t).
+ * @param output the output buffer.
+ */
+void to_well_formed_utf16(const char16_t *input, size_t len,
+                          char16_t *output) noexcept;
+  #if SIMDUTF_SPAN
+simdutf_really_inline simdutf_warn_unused result
+to_well_formed_utf16(std::span<const char16_t> input,
+                     std::span<const char16_t> output) noexcept {
+  return to_well_formed_utf16(input.data(), input.size(), output.data());
+}
+  #endif // SIMDUTF_SPAN
+
+#endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
 /**
@@ -3326,6 +3387,34 @@ public:
   simdutf_warn_unused virtual result
   validate_utf16be_with_errors(const char16_t *buf,
                                size_t len) const noexcept = 0;
+  /**
+   * Copies the UTF-16LE string while replacing mismatched surrogates with the
+   * Unicode replacement character U+FFFD. We allow the input and output to be
+   * the same buffer so that the correction is done in-place.
+   *
+   * Overridden by each implementation.
+   *
+   * @param input the UTF-16LE string to correct.
+   * @param len the length of the string in number of 2-byte code units
+   * (char16_t).
+   * @param output the output buffer.
+   */
+  virtual void to_well_formed_utf16le(const char16_t *input, size_t len,
+                                      char16_t *output) const noexcept = 0;
+  /**
+   * Copies the UTF-16BE string while replacing mismatched surrogates with the
+   * Unicode replacement character U+FFFD. We allow the input and output to be
+   * the same buffer so that the correction is done in-place.
+   *
+   * Overridden by each implementation.
+   *
+   * @param input the UTF-16BE string to correct.
+   * @param len the length of the string in number of 2-byte code units
+   * (char16_t).
+   * @param output the output buffer.
+   */
+  virtual void to_well_formed_utf16be(const char16_t *input, size_t len,
+                                      char16_t *output) const noexcept = 0;
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -400,7 +400,7 @@ void to_well_formed_utf16le(const char16_t *input, size_t len,
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused result
 to_well_formed_utf16le(std::span<const char16_t> input,
-                       std::span<const char16_t> output) noexcept {
+                       std::span<char16_t> output) noexcept {
   return to_well_formed_utf16le(input.data(), input.size(), output.data());
 }
   #endif // SIMDUTF_SPAN
@@ -420,7 +420,7 @@ void to_well_formed_utf16be(const char16_t *input, size_t len,
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused result
 to_well_formed_utf16be(std::span<const char16_t> input,
-                       std::span<const char16_t> output) noexcept {
+                       std::span<char16_t> output) noexcept {
   return to_well_formed_utf16be(input.data(), input.size(), output.data());
 }
   #endif // SIMDUTF_SPAN
@@ -440,7 +440,7 @@ void to_well_formed_utf16(const char16_t *input, size_t len,
   #if SIMDUTF_SPAN
 simdutf_really_inline simdutf_warn_unused result
 to_well_formed_utf16(std::span<const char16_t> input,
-                     std::span<const char16_t> output) noexcept {
+                     std::span<char16_t> output) noexcept {
   return to_well_formed_utf16(input.data(), input.size(), output.data());
 }
   #endif // SIMDUTF_SPAN

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -398,7 +398,7 @@ validate_utf16be_with_errors(std::span<const char16_t> input) noexcept {
 void to_well_formed_utf16le(const char16_t *input, size_t len,
                             char16_t *output) noexcept;
   #if SIMDUTF_SPAN
-simdutf_really_inline simdutf_warn_unused result
+simdutf_really_inline void
 to_well_formed_utf16le(std::span<const char16_t> input,
                        std::span<char16_t> output) noexcept {
   return to_well_formed_utf16le(input.data(), input.size(), output.data());
@@ -418,7 +418,7 @@ to_well_formed_utf16le(std::span<const char16_t> input,
 void to_well_formed_utf16be(const char16_t *input, size_t len,
                             char16_t *output) noexcept;
   #if SIMDUTF_SPAN
-simdutf_really_inline simdutf_warn_unused result
+simdutf_really_inline void
 to_well_formed_utf16be(std::span<const char16_t> input,
                        std::span<char16_t> output) noexcept {
   return to_well_formed_utf16be(input.data(), input.size(), output.data());
@@ -438,7 +438,7 @@ to_well_formed_utf16be(std::span<const char16_t> input,
 void to_well_formed_utf16(const char16_t *input, size_t len,
                           char16_t *output) noexcept;
   #if SIMDUTF_SPAN
-simdutf_really_inline simdutf_warn_unused result
+simdutf_really_inline void
 to_well_formed_utf16(std::span<const char16_t> input,
                      std::span<char16_t> output) noexcept {
   return to_well_formed_utf16(input.data(), input.size(), output.data());

--- a/src/arm64/arm_utf16fix.cpp
+++ b/src/arm64/arm_utf16fix.cpp
@@ -92,7 +92,7 @@ static inline uint64_t get_mask(uint8x16_t illse0, uint8x16_t illse1,
                                 uint8x16_t illse2, uint8x16_t illse3) {
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
   uint8x16_t bit_mask =
-      simdutf_make_uint16x8_t(0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
+      simdutf_make_uint8x16_t(0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
                               0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80);
 #else
   uint8x16_t bit_mask = {0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
@@ -126,7 +126,8 @@ static inline bool utf16fix_block64(char16_t *out, const char16_t *in,
     return (0xd800 <= c && c <= 0xdbff);
   };
   // this branch could be marked as unlikely:
-  if (veq_non_zero(illse0 | illse1 | illse2 | illse3)) {
+  if (veq_non_zero(
+          vorrq_u8(vorrq_u8(illse0, illse1), vorrq_u8(illse2, illse3)))) {
     uint64_t matches = get_mask(illse0, illse1, illse2, illse3);
     // Given that ARM has a fast bitreverse instruction, we can
     // reverse once and then use clz to find the first bit set.

--- a/src/arm64/arm_utf16fix.cpp
+++ b/src/arm64/arm_utf16fix.cpp
@@ -23,7 +23,6 @@ static inline int veq_non_zero(uint8x16_t v) {
 template <endianness big_endian>
 static inline void utf16fix_block(char16_t *out, const char16_t *in,
                                   bool inplace) {
-
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
   uint8x16x2_t lb, block;

--- a/src/arm64/arm_utf16fix.cpp
+++ b/src/arm64/arm_utf16fix.cpp
@@ -158,11 +158,8 @@ void utf16fix_neon_64bits(const char16_t *in, size_t n, char16_t *out) {
   if (n < 17) {
     return scalar::utf16::to_well_formed_utf16<big_endian>(in, n, out);
   }
-  auto is_low_surrogate = [](char16_t c) -> bool {
-    c = !match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
-    return (0xdc00 <= c && c <= 0xdfff);
-  };
-  out[0] = is_low_surrogate(in[0]) ? replacement : in[0];
+  out[0] =
+      scalar::utf16::is_low_surrogate<big_endian>(in[0]) ? replacement : in[0];
   i = 1;
 
   /* duplicate code to have the compiler specialise utf16fix_block() */
@@ -187,9 +184,7 @@ void utf16fix_neon_64bits(const char16_t *in, size_t n, char16_t *out) {
 
     utf16fix_block<big_endian>(out + n - 16, in + n - 16, false);
   }
-  auto is_high_surrogate = [](char16_t c) -> bool {
-    c = !match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
-    return (0xd800 <= c && c <= 0xdbff);
-  };
-  out[n - 1] = is_high_surrogate(out[n - 1]) ? replacement : out[n - 1];
+  out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])
+                   ? replacement
+                   : out[n - 1];
 }

--- a/src/arm64/arm_utf16fix.cpp
+++ b/src/arm64/arm_utf16fix.cpp
@@ -2,7 +2,7 @@
 /*
  * Returns if a vector of type uint8x16_t is all zero.
  */
- simdutf_really_inline int veq_non_zero(uint8x16_t v) {
+simdutf_really_inline int veq_non_zero(uint8x16_t v) {
   // might compile to two instructions:
   //	umaxv   s0, v0.4s
   //	fmov	w0, s0
@@ -21,8 +21,7 @@
  * If that character is illsequenced, it too is overwritten.
  */
 template <endianness big_endian>
-void utf16fix_block(char16_t *out, const char16_t *in,
-                                  bool inplace) {
+void utf16fix_block(char16_t *out, const char16_t *in, bool inplace) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
   uint8x16x2_t lb, block;
@@ -71,8 +70,7 @@ void utf16fix_block(char16_t *out, const char16_t *in,
 }
 
 template <endianness big_endian>
-uint8x16_t get_mismatch_copy(const char16_t *in, char16_t *out,
-                                           bool inplace) {
+uint8x16_t get_mismatch_copy(const char16_t *in, char16_t *out, bool inplace) {
   const int idx = !match_system(big_endian) ? 0 : 1;
   uint8x16x2_t lb = vld2q_u8((const uint8_t *)(in - 1));
   uint8x16x2_t block = vld2q_u8((const uint8_t *)in);
@@ -88,7 +86,7 @@ uint8x16_t get_mismatch_copy(const char16_t *in, char16_t *out,
 }
 
 simdutf_really_inline uint64_t get_mask(uint8x16_t illse0, uint8x16_t illse1,
-                                uint8x16_t illse2, uint8x16_t illse3) {
+                                        uint8x16_t illse2, uint8x16_t illse3) {
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
   uint8x16_t bit_mask =
       simdutf_make_uint8x16_t(0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
@@ -111,8 +109,7 @@ simdutf_really_inline uint64_t get_mask(uint8x16_t illse0, uint8x16_t illse1,
 // function might be faster than alternative implementations working on small
 // blocks of input.
 template <endianness big_endian>
-bool utf16fix_block64(char16_t *out, const char16_t *in,
-                                    bool inplace) {
+bool utf16fix_block64(char16_t *out, const char16_t *in, bool inplace) {
 
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;

--- a/src/arm64/arm_utf16fix.cpp
+++ b/src/arm64/arm_utf16fix.cpp
@@ -22,7 +22,7 @@ simdutf_really_inline int veq_non_zero(uint8x16_t v) {
  */
 template <endianness big_endian, bool inplace>
 void utf16fix_block(char16_t *out, const char16_t *in) {
-  const char16_t replacement = scalar::utf16::replacement<big_endian>;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
   uint8x16x2_t lb, block;
   uint8x16_t lb_masked, block_masked, lb_is_high, block_is_low;
   uint8x16_t illseq;
@@ -109,7 +109,7 @@ simdutf_really_inline uint64_t get_mask(uint8x16_t illse0, uint8x16_t illse1,
 // blocks of input.
 template <endianness big_endian, bool inplace>
 bool utf16fix_block64(char16_t *out, const char16_t *in) {
-  const char16_t replacement = scalar::utf16::replacement<big_endian>;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
 
   uint8x16_t illse0 = inplace ? get_mismatch_copy<big_endian, true>(in, out)
                               : get_mismatch_copy<big_endian, false>(in, out);
@@ -154,7 +154,7 @@ bool utf16fix_block64(char16_t *out, const char16_t *in) {
 template <endianness big_endian>
 void utf16fix_neon_64bits(const char16_t *in, size_t n, char16_t *out) {
   size_t i;
-  const char16_t replacement = scalar::utf16::replacement<big_endian>;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
   if (n < 17) {
     return scalar::utf16::to_well_formed_utf16<big_endian>(in, n, out);
   }

--- a/src/arm64/arm_utf16fix.cpp
+++ b/src/arm64/arm_utf16fix.cpp
@@ -2,7 +2,7 @@
 /*
  * Returns if a vector of type uint8x16_t is all zero.
  */
-static inline int veq_non_zero(uint8x16_t v) {
+ simdutf_really_inline int veq_non_zero(uint8x16_t v) {
   // might compile to two instructions:
   //	umaxv   s0, v0.4s
   //	fmov	w0, s0
@@ -21,7 +21,7 @@ static inline int veq_non_zero(uint8x16_t v) {
  * If that character is illsequenced, it too is overwritten.
  */
 template <endianness big_endian>
-static inline void utf16fix_block(char16_t *out, const char16_t *in,
+void utf16fix_block(char16_t *out, const char16_t *in,
                                   bool inplace) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
@@ -71,7 +71,7 @@ static inline void utf16fix_block(char16_t *out, const char16_t *in,
 }
 
 template <endianness big_endian>
-static inline uint8x16_t get_mismatch_copy(const char16_t *in, char16_t *out,
+uint8x16_t get_mismatch_copy(const char16_t *in, char16_t *out,
                                            bool inplace) {
   const int idx = !match_system(big_endian) ? 0 : 1;
   uint8x16x2_t lb = vld2q_u8((const uint8_t *)(in - 1));
@@ -87,7 +87,7 @@ static inline uint8x16_t get_mismatch_copy(const char16_t *in, char16_t *out,
   return illseq;
 }
 
-static inline uint64_t get_mask(uint8x16_t illse0, uint8x16_t illse1,
+simdutf_really_inline uint64_t get_mask(uint8x16_t illse0, uint8x16_t illse1,
                                 uint8x16_t illse2, uint8x16_t illse3) {
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
   uint8x16_t bit_mask =
@@ -111,7 +111,7 @@ static inline uint64_t get_mask(uint8x16_t illse0, uint8x16_t illse1,
 // function might be faster than alternative implementations working on small
 // blocks of input.
 template <endianness big_endian>
-static inline bool utf16fix_block64(char16_t *out, const char16_t *in,
+bool utf16fix_block64(char16_t *out, const char16_t *in,
                                     bool inplace) {
 
   const char16_t replacement =

--- a/src/arm64/arm_utf16fix.cpp
+++ b/src/arm64/arm_utf16fix.cpp
@@ -1,0 +1,180 @@
+
+/*
+ * Returns if a vector of type uint8x16_t is all zero.
+ */
+static int veq_non_zero(uint8x16_t v) {
+  // might compile to two instructions:
+  //	umaxv   s0, v0.4s
+  //	fmov	w0, s0
+  // On Apple hardware, they both have a latency of 3 cycles, with a throughput
+  // of four instructions per cycle. So that's 6 cycles of latency (!!!) for the
+  // two instructions. A narrowing shift has the same latency and throughput.
+  return vmaxvq_u32(vreinterpretq_u32_u8(v));
+}
+
+/*
+ * Process one block of 16 characters.  If in_place is false,
+ * copy the block from in to out.  If there is a sequencing
+ * error in the block, overwrite the illsequenced characters
+ * with the replacement character.  This function reads one
+ * character before the beginning of the buffer as a lookback.
+ * If that character is illsequenced, it too is overwritten.
+ */
+template <endianness big_endian>
+static inline void utf16fix_block(char16_t *out, const char16_t *in,
+                                  bool inplace) {
+
+  const char16_t replacement =
+      !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+  uint8x16x2_t lb, block;
+  uint8x16_t lb_masked, block_masked, lb_is_high, block_is_low;
+  uint8x16_t illseq;
+
+  const int idx = !match_system(big_endian) ? 0 : 1;
+
+  /* TODO: compute lookback using shifts */
+  lb = vld2q_u8((const uint8_t *)(in - 1));
+  block = vld2q_u8((const uint8_t *)in);
+  lb_masked = vandq_u8(lb.val[idx], vdupq_n_u8(0xfc));
+  block_masked = vandq_u8(block.val[idx], vdupq_n_u8(0xfc));
+  lb_is_high = vceqq_u8(lb_masked, vdupq_n_u8(0xd8));
+  block_is_low = vceqq_u8(block_masked, vdupq_n_u8(0xdc));
+
+  illseq = veorq_u8(lb_is_high, block_is_low);
+  if (veq_non_zero(illseq)) {
+    uint8x16_t lb_illseq, block_illseq;
+    char16_t lbc;
+    int ill;
+
+    /* compute the cause of the illegal sequencing */
+    lb_illseq = vbicq_u8(lb_is_high, block_is_low);
+    block_illseq = vorrq_u8(vbicq_u8(block_is_low, lb_is_high),
+                            vextq_u8(lb_illseq, vdupq_n_u8(0), 1));
+
+    /* fix illegal sequencing in the lookback */
+    ill = vgetq_lane_u8(lb_illseq, 0);
+    lbc = out[-1];
+    out[-1] = ill ? replacement : lbc;
+
+    /* fix illegal sequencing in the main block */
+    if (!match_system(big_endian)) {
+      block.val[1] = vbslq_u8(block_illseq, vdupq_n_u8(0xfd), block.val[1]);
+      block.val[0] = vorrq_u8(block_illseq, block.val[0]);
+    } else {
+      block.val[0] = vbslq_u8(block_illseq, vdupq_n_u8(0xfd), block.val[0]);
+      block.val[1] = vorrq_u8(block_illseq, block.val[1]);
+    }
+
+    vst2q_u8((uint8_t *)out, block);
+  } else if (!inplace) {
+    vst2q_u8((uint8_t *)out, block);
+  }
+}
+
+template <endianness big_endian>
+static inline uint8x16_t get_mismatch_copy(const char16_t *in, char16_t *out,
+                                           bool inplace) {
+  const int idx = !match_system(big_endian) ? 0 : 1;
+  uint8x16x2_t lb = vld2q_u8((const uint8_t *)(in - 1));
+  uint8x16x2_t block = vld2q_u8((const uint8_t *)in);
+  uint8x16_t lb_masked = vandq_u8(lb.val[idx], vdupq_n_u8(0xfc));
+  uint8x16_t block_masked = vandq_u8(block.val[idx], vdupq_n_u8(0xfc));
+  uint8x16_t lb_is_high = vceqq_u8(lb_masked, vdupq_n_u8(0xd8));
+  uint8x16_t block_is_low = vceqq_u8(block_masked, vdupq_n_u8(0xdc));
+  uint8x16_t illseq = veorq_u8(lb_is_high, block_is_low);
+  if (!inplace) {
+    vst2q_u8((uint8_t *)out, block);
+  }
+  return illseq;
+}
+
+static inline uint64_t get_mask(uint8x16_t illse0, uint8x16_t illse1,
+                                uint8x16_t illse2, uint8x16_t illse3) {
+  uint8x16_t bit_mask = {0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
+                         0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80};
+  uint8x16_t sum0 = vpaddq_u8(illse0 & bit_mask, illse1 & bit_mask);
+  uint8x16_t sum1 = vpaddq_u8(illse2 & bit_mask, illse3 & bit_mask);
+  sum0 = vpaddq_u8(sum0, sum1);
+  sum0 = vpaddq_u8(sum0, sum0);
+  return vgetq_lane_u64(vreinterpretq_u64_u8(sum0), 0);
+}
+
+// The idea is to process 64 characters at a time, and if there is a mismatch
+// we can fix it with a bit of scalar code. When the input is correct, this
+// function might be faster than alternative implementations working on small
+// blocks of input.
+template <endianness big_endian>
+static inline bool utf16fix_block64(char16_t *out, const char16_t *in,
+                                    bool inplace) {
+
+  const char16_t replacement =
+      !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+  uint8x16_t illse0 = get_mismatch_copy<big_endian>(in, out, inplace);
+  uint8x16_t illse1 = get_mismatch_copy<big_endian>(in + 16, out + 16, inplace);
+  uint8x16_t illse2 = get_mismatch_copy<big_endian>(in + 32, out + 32, inplace);
+  uint8x16_t illse3 = get_mismatch_copy<big_endian>(in + 48, out + 48, inplace);
+  auto is_high_surrogate = [](char16_t c) -> bool {
+    return (0xd800 <= c && c <= 0xdbff);
+  };
+  // this branch could be marked as unlikely:
+  if (veq_non_zero(illse0 | illse1 | illse2 | illse3)) {
+    uint64_t matches = get_mask(illse0, illse1, illse2, illse3);
+    // Given that ARM has a fast bitreverse instruction, we can
+    // reverse once and then use clz to find the first bit set.
+    // It is how it is done in simdjson and *might* be beneficial.
+    //
+    // We might also proceed in reverse to reduce the RAW hazard,
+    // but it might require more instructions.
+
+    while (matches != 0) {
+      uint64_t t = matches & (~matches + 1);
+      int r = trailing_zeroes(matches); // generates rbit + clz
+      // Either we have a high surrogate followed by a non-low surrogate
+      // or we have a low surrogate not preceded by a high surrogate.
+      bool is_high = is_high_surrogate(in[r - 1]);
+      out[r - is_high] = replacement;
+      matches ^= t;
+    }
+    return false;
+  }
+  return true;
+}
+
+template <endianness big_endian>
+void utf16fix_neon_64bits(char16_t *out, const char16_t *in, size_t n) {
+  size_t i;
+  const char16_t replacement =
+      !match_system(big_endian) ? u16_swap_bytes(0xfffd) : 0xfffd;
+  if (n < 17) {
+    scalar::utf16::to_well_formed_utf16<big_endian>(out, in, n);
+    return;
+  }
+  auto is_low_surrogate = [](char16_t c) -> bool {
+    return (0xdc00 <= c && c <= 0xdfff);
+  };
+  out[0] = is_low_surrogate(in[0]) ? replacement : in[0];
+  i = 1;
+
+  /* duplicate code to have the compiler specialise utf16fix_block() */
+  if (in == out) {
+    for (i = 1; i + 64 < n; i += 64)
+      utf16fix_block64(out + i, in + i, true);
+
+    for (; i + 16 < n; i += 16)
+      utf16fix_block(out + i, in + i, true);
+
+    /* tbd: find carry */
+    utf16fix_block(out + n - 16, in + n - 16, true);
+  } else {
+    for (i = 1; i + 64 < n; i += 64)
+      utf16fix_block64(out + i, in + i, false);
+    for (; i + 16 < n; i += 16)
+      utf16fix_block(out + i, in + i, false);
+
+    utf16fix_block(out + n - 16, in + n - 16, false);
+  }
+  auto is_high_surrogate = [](char16_t c) -> bool {
+    return (0xd800 <= c && c <= 0xdbff);
+  };
+  out[n - 1] = is_high_surrogate(out[n - 1]) ? replacement : out[n - 1];
+}

--- a/src/arm64/arm_utf16fix.cpp
+++ b/src/arm64/arm_utf16fix.cpp
@@ -22,8 +22,7 @@ simdutf_really_inline int veq_non_zero(uint8x16_t v) {
  */
 template <endianness big_endian, bool inplace>
 void utf16fix_block(char16_t *out, const char16_t *in) {
-  const char16_t replacement =
-      !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>;
   uint8x16x2_t lb, block;
   uint8x16_t lb_masked, block_masked, lb_is_high, block_is_low;
   uint8x16_t illseq;
@@ -110,9 +109,7 @@ simdutf_really_inline uint64_t get_mask(uint8x16_t illse0, uint8x16_t illse1,
 // blocks of input.
 template <endianness big_endian, bool inplace>
 bool utf16fix_block64(char16_t *out, const char16_t *in) {
-
-  const char16_t replacement =
-      !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>;
   uint8x16_t illse0 = get_mismatch_copy<big_endian>(in, out, inplace);
   uint8x16_t illse1 = get_mismatch_copy<big_endian>(in + 16, out + 16, inplace);
   uint8x16_t illse2 = get_mismatch_copy<big_endian>(in + 32, out + 32, inplace);
@@ -149,8 +146,7 @@ bool utf16fix_block64(char16_t *out, const char16_t *in) {
 template <endianness big_endian>
 void utf16fix_neon_64bits(const char16_t *in, size_t n, char16_t *out) {
   size_t i;
-  const char16_t replacement =
-      !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>;
   if (n < 17) {
     return scalar::utf16::to_well_formed_utf16<big_endian>(in, n, out);
   }

--- a/src/arm64/arm_utf16fix.cpp
+++ b/src/arm64/arm_utf16fix.cpp
@@ -90,10 +90,18 @@ static inline uint8x16_t get_mismatch_copy(const char16_t *in, char16_t *out,
 
 static inline uint64_t get_mask(uint8x16_t illse0, uint8x16_t illse1,
                                 uint8x16_t illse2, uint8x16_t illse3) {
+#ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
+  uint8x16_t bit_mask =
+      simdutf_make_uint16x8_t(0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
+                              0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80);
+#else
   uint8x16_t bit_mask = {0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
                          0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80};
-  uint8x16_t sum0 = vpaddq_u8(illse0 & bit_mask, illse1 & bit_mask);
-  uint8x16_t sum1 = vpaddq_u8(illse2 & bit_mask, illse3 & bit_mask);
+#endif
+  uint8x16_t sum0 =
+      vpaddq_u8(vandq_u8(illse0, bit_mask), vandq_u8(illse1, bit_mask));
+  uint8x16_t sum1 =
+      vpaddq_u8(vandq_u8(illse2, bit_mask), vandq_u8(illse3, bit_mask));
   sum0 = vpaddq_u8(sum0, sum1);
   sum0 = vpaddq_u8(sum0, sum0);
   return vgetq_lane_u64(vreinterpretq_u64_u8(sum0), 0);

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -317,6 +317,18 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
     return res;
   }
 }
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
+                                                                 output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
+                                                              output);
+}
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -107,6 +107,9 @@ convert_utf8_1_to_2_byte_to_utf16(uint8x16_t in, size_t shufutf8_idx) {
 #endif // SIMDUTF_FEATURE_UTF8 && (SIMDUTF_FEATURE_UTF16 ||
        // SIMDUTF_FEATURE_UTF32)
 
+#if SIMDUTF_FEATURE_UTF16
+#include "arm64/arm_utf16fix.cpp"
+#endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
   #include "arm64/arm_validate_utf16.cpp"
 #endif // SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -108,7 +108,7 @@ convert_utf8_1_to_2_byte_to_utf16(uint8x16_t in, size_t shufutf8_idx) {
        // SIMDUTF_FEATURE_UTF32)
 
 #if SIMDUTF_FEATURE_UTF16
-#include "arm64/arm_utf16fix.cpp"
+  #include "arm64/arm_utf16fix.cpp"
 #endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
   #include "arm64/arm_validate_utf16.cpp"
@@ -323,14 +323,12 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
 
 void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
                                             char16_t *output) const noexcept {
-  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
-                                                                 output);
+  return utf16fix_neon_64bits<endianness::LITTLE>(input, len, output);
 }
 
 void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
                                             char16_t *output) const noexcept {
-  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
-                                                              output);
+  return utf16fix_neon_64bits<endianness::BIG>(input, len, output);
 }
 #endif // SIMDUTF_FEATURE_UTF16
 

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -82,6 +82,18 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
     const char16_t *buf, size_t len) const noexcept {
   return scalar::utf16::validate_with_errors<endianness::BIG>(buf, len);
 }
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
+                                                                 output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
+                                                              output);
+}
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING

--- a/src/haswell/avx2_utf16fix.cpp
+++ b/src/haswell/avx2_utf16fix.cpp
@@ -55,8 +55,7 @@ void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
 }
 
 template <endianness big_endian>
-void utf16fix_block_sse(char16_t *out, const char16_t *in,
-                               bool in_place) {
+void utf16fix_block_sse(char16_t *out, const char16_t *in, bool in_place) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
   auto swap_if_needed = [](uint16_t c) -> uint16_t {

--- a/src/haswell/avx2_utf16fix.cpp
+++ b/src/haswell/avx2_utf16fix.cpp
@@ -28,10 +28,10 @@ static void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
     lookback = swap_endianness(lookback);
     block = swap_endianness(block);
   }
-  lb_masked = _mm256_and_si256(lookback, _mm256_set1_epi16(0xfc00));
-  block_masked = _mm256_and_si256(block, _mm256_set1_epi16(0xfc00));
-  lb_is_high = _mm256_cmpeq_epi16(lb_masked, _mm256_set1_epi16(0xd800));
-  block_is_low = _mm256_cmpeq_epi16(block_masked, _mm256_set1_epi16(0xdc00));
+  lb_masked = _mm256_and_si256(lookback, _mm256_set1_epi16(0xfc00u));
+  block_masked = _mm256_and_si256(block, _mm256_set1_epi16(0xfc00u));
+  lb_is_high = _mm256_cmpeq_epi16(lb_masked, _mm256_set1_epi16(0xd800u));
+  block_is_low = _mm256_cmpeq_epi16(block_masked, _mm256_set1_epi16(0xdc00u));
 
   illseq = _mm256_xor_si256(lb_is_high, block_is_low);
   if (!_mm256_testz_si256(illseq, illseq)) {
@@ -163,7 +163,7 @@ void utf16fix_avx(const char16_t *in, size_t n, char16_t *out) {
   size_t i;
 
   if (n < 17) {
-    utf16fix_sse<big_endian>(out, in, n);
+    utf16fix_sse<big_endian>(in, n, out);
     return;
   }
 

--- a/src/haswell/avx2_utf16fix.cpp
+++ b/src/haswell/avx2_utf16fix.cpp
@@ -74,15 +74,12 @@ void utf16fix_block_sse(char16_t *out, const char16_t *in) {
 
   illseq = _mm_xor_si128(lb_is_high, block_is_low);
   if (_mm_movemask_epi8(illseq) != 0) {
-    int lb;
-
     /* compute the cause of the illegal sequencing */
     lb_illseq = _mm_andnot_si128(block_is_low, lb_is_high);
     block_illseq = _mm_or_si128(_mm_andnot_si128(lb_is_high, block_is_low),
                                 _mm_bsrli_si128(lb_illseq, 2));
-
     /* fix illegal sequencing in the lookback */
-    lb = _mm_cvtsi128_si32(lb_illseq);
+    int lb = _mm_cvtsi128_si32(lb_illseq);
     lb = (lb & replacement) | (~lb & out[-1]);
     out[-1] = char16_t(lb);
     /* fix illegal sequencing in the main block */

--- a/src/haswell/avx2_utf16fix.cpp
+++ b/src/haswell/avx2_utf16fix.cpp
@@ -1,0 +1,104 @@
+
+/*
+ * Process one block of 16 characters.  If in_place is false,
+ * copy the block from in to out.  If there is a sequencing
+ * error in the block, overwrite the illsequenced characters
+ * with the replacement character.  This function reads one
+ * character before the beginning of the buffer as a lookback.
+ * If that character is illsequenced, it too is overwritten.
+ */
+template <endianness big_endian>
+static void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
+  __m256i lookback, block, lb_masked, block_masked, lb_is_high, block_is_low;
+  __m256i illseq, lb_illseq, block_illseq, lb_illseq_shifted;
+
+  lookback = _mm256_loadu_si256((const __m256i *)(in - 1));
+  block = _mm256_loadu_si256((const __m256i *)in);
+
+  lb_masked = _mm256_and_si256(lookback, _mm256_set1_epi16(0xfc00));
+  block_masked = _mm256_and_si256(block, _mm256_set1_epi16(0xfc00));
+  lb_is_high = _mm256_cmpeq_epi16(lb_masked, _mm256_set1_epi16(0xd800));
+  block_is_low = _mm256_cmpeq_epi16(block_masked, _mm256_set1_epi16(0xdc00));
+
+  illseq = _mm256_xor_si256(lb_is_high, block_is_low);
+  if (!_mm256_testz_si256(illseq, illseq)) {
+    int lb;
+
+    /* compute the cause of the illegal sequencing */
+    lb_illseq = _mm256_andnot_si256(block_is_low, lb_is_high);
+    lb_illseq_shifted =
+        _mm256_or_si256(_mm256_bsrli_epi128(lb_illseq, 2),
+                        _mm256_zextsi128_si256(_mm_bslli_si128(
+                            _mm256_extracti128_si256(lb_illseq, 1), 14)));
+    block_illseq = _mm256_or_si256(
+        _mm256_andnot_si256(lb_is_high, block_is_low), lb_illseq_shifted);
+
+    /* fix illegal sequencing in the lookback */
+    lb = _mm256_cvtsi256_si32(lb_illseq);
+    lb = lb & 0xfffd | ~lb & out[-1];
+    out[-1] = lb & 0xffff;
+
+    /* fix illegal sequencing in the main block */
+    block = _mm256_blendv_epi8(block, _mm256_set1_epi16(0xfffd), block_illseq);
+    _mm256_storeu_si256((__m256i *)out, block);
+  } else if (!in_place)
+    _mm256_storeu_si256((__m256i *)out, block);
+}
+
+template <endianness big_endian>
+void utf16fix_sse(char16_t *out, const char16_t *in, size_t n) {
+  size_t i;
+
+  if (n < 9) {
+    scalar::utf16::to_well_formed_utf16<big_endian>(out, in, n);
+    return;
+  }
+
+  out[0] = scalar::utf16::is_low_surrogate<big_endian>(in[0]) ? 0xfffd : in[0];
+
+  /* duplicate code to have the compiler specialise utf16fix_block() */
+  if (in == out) {
+    for (i = 1; i + 8 < n; i += 8)
+      utf16fix_block<big_endian>(out + i, in + i, true);
+
+    utf16fix_block<big_endian>(out + n - 8, in + n - 8, true);
+  } else {
+    for (i = 1; i + 8 < n; i += 8)
+      utf16fix_block<big_endian>(out + i, in + i, false);
+
+    utf16fix_block<big_endian>(out + n - 8, in + n - 8, false);
+  }
+
+  out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])
+                   ? 0xfffd
+                   : out[n - 1];
+}
+
+template <endianness big_endian>
+void utf16fix_avx(char16_t *out, const char16_t *in, size_t n) {
+  size_t i;
+
+  if (n < 17) {
+    utf16fix_sse<big_endian>(out, in, n);
+    return;
+  }
+
+  out[0] = scalar::utf16::is_low_surrogate<big_endian>(in[0]) ? 0xfffd : in[0];
+
+  /* duplicate code to have the compiler specialise utf16fix_block() */
+  if (in == out) {
+    for (i = 1; i + 16 < n; i += 16)
+      utf16fix_block<big_endian>(out + i, in + i, true);
+
+    utf16fix_block<big_endian>(out + n - 16, in + n - 16, true);
+  } else {
+    for (i = 1; i + 16 < n; i += 16)
+      utf16fix_block<big_endian>(out + i, in + i, false);
+
+    utf16fix_block<big_endian>(out + n - 16, in + n - 16, false);
+  }
+
+  out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])
+                   ? 0xfffd
+                   : out[n - 1];
+}

--- a/src/haswell/avx2_utf16fix.cpp
+++ b/src/haswell/avx2_utf16fix.cpp
@@ -8,8 +8,7 @@
  */
 template <endianness big_endian, bool in_place>
 void utf16fix_block(char16_t *out, const char16_t *in) {
-  const char16_t replacement =
-      !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>;
   auto swap_if_needed = [](uint16_t c) -> uint16_t {
     return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
   };
@@ -56,8 +55,7 @@ void utf16fix_block(char16_t *out, const char16_t *in) {
 
 template <endianness big_endian, bool in_place>
 void utf16fix_block_sse(char16_t *out, const char16_t *in) {
-  const char16_t replacement =
-      !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>;
   auto swap_if_needed = [](uint16_t c) -> uint16_t {
     return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
   };
@@ -99,8 +97,7 @@ void utf16fix_block_sse(char16_t *out, const char16_t *in) {
 
 template <endianness big_endian>
 void utf16fix_sse(const char16_t *in, size_t n, char16_t *out) {
-  const char16_t replacement =
-      !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>;
   size_t i;
 
   if (n < 9) {
@@ -133,8 +130,7 @@ void utf16fix_sse(const char16_t *in, size_t n, char16_t *out) {
 
 template <endianness big_endian>
 void utf16fix_avx(const char16_t *in, size_t n, char16_t *out) {
-  const char16_t replacement =
-      !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>;
   size_t i;
 
   if (n < 17) {

--- a/src/haswell/avx2_utf16fix.cpp
+++ b/src/haswell/avx2_utf16fix.cpp
@@ -41,8 +41,9 @@ static void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
     /* fix illegal sequencing in the main block */
     block = _mm256_blendv_epi8(block, _mm256_set1_epi16(0xfffd), block_illseq);
     _mm256_storeu_si256((__m256i *)out, block);
-  } else if (!in_place)
+  } else if (!in_place) {
     _mm256_storeu_si256((__m256i *)out, block);
+  }
 }
 
 template <endianness big_endian>
@@ -58,13 +59,15 @@ void utf16fix_sse(char16_t *out, const char16_t *in, size_t n) {
 
   /* duplicate code to have the compiler specialise utf16fix_block() */
   if (in == out) {
-    for (i = 1; i + 8 < n; i += 8)
+    for (i = 1; i + 8 < n; i += 8) {
       utf16fix_block<big_endian>(out + i, in + i, true);
+    }
 
     utf16fix_block<big_endian>(out + n - 8, in + n - 8, true);
   } else {
-    for (i = 1; i + 8 < n; i += 8)
+    for (i = 1; i + 8 < n; i += 8) {
       utf16fix_block<big_endian>(out + i, in + i, false);
+    }
 
     utf16fix_block<big_endian>(out + n - 8, in + n - 8, false);
   }
@@ -87,13 +90,15 @@ void utf16fix_avx(char16_t *out, const char16_t *in, size_t n) {
 
   /* duplicate code to have the compiler specialise utf16fix_block() */
   if (in == out) {
-    for (i = 1; i + 16 < n; i += 16)
+    for (i = 1; i + 16 < n; i += 16) {
       utf16fix_block<big_endian>(out + i, in + i, true);
+    }
 
     utf16fix_block<big_endian>(out + n - 16, in + n - 16, true);
   } else {
-    for (i = 1; i + 16 < n; i += 16)
+    for (i = 1; i + 16 < n; i += 16) {
       utf16fix_block<big_endian>(out + i, in + i, false);
+    }
 
     utf16fix_block<big_endian>(out + n - 16, in + n - 16, false);
   }

--- a/src/haswell/avx2_utf16fix.cpp
+++ b/src/haswell/avx2_utf16fix.cpp
@@ -8,7 +8,7 @@
  */
 template <endianness big_endian, bool in_place>
 void utf16fix_block(char16_t *out, const char16_t *in) {
-  const char16_t replacement = scalar::utf16::replacement<big_endian>;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
   auto swap_if_needed = [](uint16_t c) -> uint16_t {
     return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
   };
@@ -55,7 +55,7 @@ void utf16fix_block(char16_t *out, const char16_t *in) {
 
 template <endianness big_endian, bool in_place>
 void utf16fix_block_sse(char16_t *out, const char16_t *in) {
-  const char16_t replacement = scalar::utf16::replacement<big_endian>;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
   auto swap_if_needed = [](uint16_t c) -> uint16_t {
     return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
   };
@@ -97,7 +97,7 @@ void utf16fix_block_sse(char16_t *out, const char16_t *in) {
 
 template <endianness big_endian>
 void utf16fix_sse(const char16_t *in, size_t n, char16_t *out) {
-  const char16_t replacement = scalar::utf16::replacement<big_endian>;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
   size_t i;
 
   if (n < 9) {
@@ -130,7 +130,7 @@ void utf16fix_sse(const char16_t *in, size_t n, char16_t *out) {
 
 template <endianness big_endian>
 void utf16fix_avx(const char16_t *in, size_t n, char16_t *out) {
-  const char16_t replacement = scalar::utf16::replacement<big_endian>;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
   size_t i;
 
   if (n < 17) {

--- a/src/haswell/avx2_utf16fix.cpp
+++ b/src/haswell/avx2_utf16fix.cpp
@@ -7,7 +7,7 @@
  * If that character is illsequenced, it too is overwritten.
  */
 template <endianness big_endian>
-static void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
+void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
   auto swap_if_needed = [](uint16_t c) -> uint16_t {
@@ -55,7 +55,7 @@ static void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
 }
 
 template <endianness big_endian>
-static void utf16fix_block_sse(char16_t *out, const char16_t *in,
+void utf16fix_block_sse(char16_t *out, const char16_t *in,
                                bool in_place) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;

--- a/src/haswell/avx2_utf16fix.cpp
+++ b/src/haswell/avx2_utf16fix.cpp
@@ -46,7 +46,8 @@ static void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
     out[-1] = char16_t(lb);
 
     /* fix illegal sequencing in the main block */
-    block = _mm256_blendv_epi8(block, _mm256_set1_epi16(replacement), block_illseq);
+    block =
+        _mm256_blendv_epi8(block, _mm256_set1_epi16(replacement), block_illseq);
     _mm256_storeu_si256((__m256i *)out, block);
   } else if (!in_place) {
     _mm256_storeu_si256((__m256i *)out, block);

--- a/src/haswell/avx2_utf16fix.cpp
+++ b/src/haswell/avx2_utf16fix.cpp
@@ -1,4 +1,12 @@
 
+__m256i swap_endianness(__m256i x) {
+  const __m256i swap = _mm256_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10,
+                                        13, 12, 15, 14, 17, 16, 19, 18, 21, 20,
+                                        23, 22, 25, 24, 27, 26, 29, 28, 31, 30);
+
+  return _mm256_shuffle_epi8(x, swap);
+}
+
 /*
  * Process one block of 16 characters.  If in_place is false,
  * copy the block from in to out.  If there is a sequencing
@@ -16,7 +24,10 @@ static void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
 
   lookback = _mm256_loadu_si256((const __m256i *)(in - 1));
   block = _mm256_loadu_si256((const __m256i *)in);
-
+  if (big_endian) {
+    lookback = swap_endianness(lookback);
+    block = swap_endianness(block);
+  }
   lb_masked = _mm256_and_si256(lookback, _mm256_set1_epi16(0xfc00));
   block_masked = _mm256_and_si256(block, _mm256_set1_epi16(0xfc00));
   lb_is_high = _mm256_cmpeq_epi16(lb_masked, _mm256_set1_epi16(0xd800));
@@ -37,26 +48,88 @@ static void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
 
     /* fix illegal sequencing in the lookback */
     lb = _mm256_cvtsi256_si32(lb_illseq);
-    lb = lb & replacement | ~lb & out[-1];
-    out[-1] = lb & 0xffff;
+    lb = (lb & replacement) | (~lb & out[-1]);
+    out[-1] = char16_t(lb);
 
     /* fix illegal sequencing in the main block */
     block =
-        _mm256_blendv_epi8(block, _mm256_set1_epi16(replacement), block_illseq);
+        _mm256_blendv_epi8(block, _mm256_set1_epi16(0xfffdu), block_illseq);
+    if (big_endian) {
+      block = swap_endianness(block);
+    }
     _mm256_storeu_si256((__m256i *)out, block);
   } else if (!in_place) {
+    if (big_endian) {
+      block = swap_endianness(block);
+    }
     _mm256_storeu_si256((__m256i *)out, block);
   }
 }
 
+__m128i swap_endianness(__m128i x) {
+  const __m128i swap =
+      _mm_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
+  return _mm_shuffle_epi8(x, swap);
+}
+
 template <endianness big_endian>
-void utf16fix_sse(char16_t *out, const char16_t *in, size_t n) {
+static void utf16fix_block_sse(char16_t *out, const char16_t *in,
+                               bool in_place) {
+  const char16_t replacement =
+      !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+
+  __m128i lookback, block, lb_masked, block_masked, lb_is_high, block_is_low;
+  __m128i illseq, lb_illseq, block_illseq;
+
+  lookback = _mm_loadu_si128((const __m128i *)(in - 1));
+  block = _mm_loadu_si128((const __m128i *)in);
+  if (!simdutf::match_system(big_endian)) {
+    lookback = swap_endianness(lookback);
+    block = swap_endianness(block);
+  }
+
+  lb_masked = _mm_and_si128(lookback, _mm_set1_epi16(0xfc00U));
+  block_masked = _mm_and_si128(block, _mm_set1_epi16(0xfc00U));
+  lb_is_high = _mm_cmpeq_epi16(lb_masked, _mm_set1_epi16(0xd800U));
+  block_is_low = _mm_cmpeq_epi16(block_masked, _mm_set1_epi16(0xdc00U));
+
+  illseq = _mm_xor_si128(lb_is_high, block_is_low);
+  if (_mm_movemask_epi8(illseq) != 0) {
+    int lb;
+
+    /* compute the cause of the illegal sequencing */
+    lb_illseq = _mm_andnot_si128(block_is_low, lb_is_high);
+    block_illseq = _mm_or_si128(_mm_andnot_si128(lb_is_high, block_is_low),
+                                _mm_bsrli_si128(lb_illseq, 2));
+
+    /* fix illegal sequencing in the lookback */
+    lb = _mm_cvtsi128_si32(lb_illseq);
+    lb = (lb & replacement) | (~lb & out[-1]);
+    out[-1] = char16_t(lb);
+    /* fix illegal sequencing in the main block */
+    block =
+        _mm_or_si128(_mm_andnot_si128(block_illseq, block),
+                     _mm_and_si128(block_illseq, _mm_set1_epi16(0xfffdu)));
+    if (!simdutf::match_system(big_endian)) {
+      block = swap_endianness(block);
+    }
+    _mm_storeu_si128((__m128i *)out, block);
+  } else if (!in_place) {
+    if (!simdutf::match_system(big_endian)) {
+      block = swap_endianness(block);
+    }
+    _mm_storeu_si128((__m128i *)out, block);
+  }
+}
+
+template <endianness big_endian>
+void utf16fix_sse(const char16_t *in, size_t n, char16_t *out) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
   size_t i;
 
   if (n < 9) {
-    scalar::utf16::to_well_formed_utf16<big_endian>(out, in, n);
+    scalar::utf16::to_well_formed_utf16<big_endian>(in, n, out);
     return;
   }
 
@@ -66,16 +139,16 @@ void utf16fix_sse(char16_t *out, const char16_t *in, size_t n) {
   /* duplicate code to have the compiler specialise utf16fix_block() */
   if (in == out) {
     for (i = 1; i + 8 < n; i += 8) {
-      utf16fix_block<big_endian>(out + i, in + i, true);
+      utf16fix_block_sse<big_endian>(out + i, in + i, true);
     }
 
-    utf16fix_block<big_endian>(out + n - 8, in + n - 8, true);
+    utf16fix_block_sse<big_endian>(out + n - 8, in + n - 8, true);
   } else {
     for (i = 1; i + 8 < n; i += 8) {
-      utf16fix_block<big_endian>(out + i, in + i, false);
+      utf16fix_block_sse<big_endian>(out + i, in + i, false);
     }
 
-    utf16fix_block<big_endian>(out + n - 8, in + n - 8, false);
+    utf16fix_block_sse<big_endian>(out + n - 8, in + n - 8, false);
   }
 
   out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])
@@ -84,7 +157,7 @@ void utf16fix_sse(char16_t *out, const char16_t *in, size_t n) {
 }
 
 template <endianness big_endian>
-void utf16fix_avx(char16_t *out, const char16_t *in, size_t n) {
+void utf16fix_avx(const char16_t *in, size_t n, char16_t *out) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
   size_t i;

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -34,6 +34,9 @@ namespace utf16 {
 }
 #endif // SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
 
+#if SIMDUTF_FEATURE_UTF16
+  #include "haswell/avx2_utf16fix.cpp"
+#endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
   #include "haswell/avx2_convert_latin1_to_utf8.cpp"
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -356,6 +356,18 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
     return res;
   }
 }
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
+                                                                 output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
+                                                              output);
+}
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -361,15 +361,13 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
 }
 
 void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
-                                            char16_t *output) const noexcept {
-  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
-                                                                 output);
+  char16_t *output) const noexcept {
+return utf16fix_avx<endianness::LITTLE>(input, len, output);
 }
 
 void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
-                                            char16_t *output) const noexcept {
-  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
-                                                              output);
+  char16_t *output) const noexcept {
+return utf16fix_avx<endianness::BIG>(input, len, output);
 }
 #endif // SIMDUTF_FEATURE_UTF16
 

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -361,13 +361,13 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
 }
 
 void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
-  char16_t *output) const noexcept {
-return utf16fix_avx<endianness::LITTLE>(input, len, output);
+                                            char16_t *output) const noexcept {
+  return utf16fix_avx<endianness::LITTLE>(input, len, output);
 }
 
 void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
-  char16_t *output) const noexcept {
-return utf16fix_avx<endianness::BIG>(input, len, output);
+                                            char16_t *output) const noexcept {
+  return utf16fix_avx<endianness::BIG>(input, len, output);
 }
 #endif // SIMDUTF_FEATURE_UTF16
 

--- a/src/icelake/icelake_utf16fix.cpp
+++ b/src/icelake/icelake_utf16fix.cpp
@@ -1,0 +1,112 @@
+
+/*
+ * Process one block of 32 characters.  If in_place is false,
+ * copy the block from in to out.  If there is a sequencing
+ * error in the block, overwrite the illsequenced characters
+ * with the replacement character.  This function reads one
+ * character before the beginning of the buffer as a lookback.
+ * If that character is illsequenced, it too is overwritten.
+ */
+static void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
+  __m512i lookback, block, lb_masked, block_masked;
+  __mmask32 lb_is_high, block_is_low, illseq;
+
+  lookback = _mm512_loadu_si512((const void *)(in - 1));
+  block = _mm512_loadu_si512((const void *)in);
+  lb_masked = _mm512_and_epi32(lookback, _mm512_set1_epi16(0xfc00U));
+  block_masked = _mm512_and_epi32(block, _mm512_set1_epi16(0xfc00U));
+
+  lb_is_high = _mm512_cmpeq_epi16_mask(lb_masked, _mm512_set1_epi16(0xd800U));
+  block_is_low =
+      _mm512_cmpeq_epi16_mask(block_masked, _mm512_set1_epi16(0xdc00U));
+  illseq = _kxor_mask32(lb_is_high, block_is_low);
+  if (!_ktestz_mask32_u8(illseq, illseq)) {
+    __mmask32 lb_illseq, block_illseq;
+
+    /* compute the cause of the illegal sequencing */
+    lb_illseq = _kandn_mask32(block_is_low, lb_is_high);
+    block_illseq = _kor_mask32(_kandn_mask32(lb_is_high, block_is_low),
+                               _kshiftri_mask32(lb_illseq, 1));
+
+    /* fix illegal sequencing in the lookback */
+    lb_illseq = _kand_mask32(lb_illseq, _cvtu32_mask32(1));
+    _mm512_mask_storeu_epi16(out - 1, lb_illseq, _mm512_set1_epi16(0xfffdU));
+
+    /* fix illegal sequencing in the main block */
+    if (in_place)
+      _mm512_mask_storeu_epi16(out, block_illseq, _mm512_set1_epi16(0xfffdU));
+    else
+      _mm512_storeu_epi32(out,
+                          _mm512_mask_blend_epi16(block_illseq, block,
+                                                  _mm512_set1_epi16(0xfffdU)));
+  } else if (!in_place)
+    _mm512_storeu_si512((void *)out, block);
+}
+
+/*
+ * Special case for inputs of 0--32 bytes.  Works for both in-place and
+ * out-of-place operation.
+ */
+template <endianness big_endian>
+void utf16fix_runt(char16_t *out, const char16_t *in, size_t n) {
+  __m512i lookback, block, lb_masked, block_masked;
+  __mmask32 lb_is_high, block_is_low, illseq;
+  unsigned long long mask;
+
+  mask = (1ULL << n) - 1;
+  lookback = _mm512_maskz_loadu_epi16(_cvtmask32_u32(mask << 1),
+                                      (const void *)(in - 1));
+  block = _mm512_maskz_loadu_epi16(_cvtmask32_u32(mask), (const void *)in);
+  lb_masked = _mm512_and_epi32(lookback, _mm512_set1_epi16(0xfc00));
+  block_masked = _mm512_and_epi32(block, _mm512_set1_epi16(0xfc00));
+
+  lb_is_high = _mm512_cmpeq_epi16_mask(lb_masked, _mm512_set1_epi16(0xd800));
+  block_is_low =
+      _mm512_cmpeq_epi16_mask(block_masked, _mm512_set1_epi16(0xdc00));
+  illseq = _kxor_mask32(lb_is_high, block_is_low);
+  if (!_ktestz_mask32_u8(illseq, illseq)) {
+    __mmask32 lb_illseq, block_illseq;
+
+    /* compute the cause of the illegal sequencing */
+    lb_illseq = _kandn_mask32(block_is_low, lb_is_high);
+    block_illseq = _kor_mask32(_kandn_mask32(lb_is_high, block_is_low),
+                               _kshiftri_mask32(lb_illseq, 1));
+
+    /* fix illegal sequencing in the main block */
+    _mm512_mask_storeu_epi16(
+        (void *)out, _cvtmask32_u32(mask),
+        _mm512_mask_blend_epi16(block_illseq, block,
+                                _mm512_set1_epi16(0xfffd)));
+  } else {
+    _mm512_mask_storeu_epi16((void *)out, _cvtmask32_u32(mask), block);
+  }
+  out[n - 1] = is_high_surrogate<big_endian>(out[n - 1]) ? 0xfffd : out[n - 1];
+}
+
+template <endianness big_endian>
+void utf16fix_avx512(char16_t *out, const char16_t *in, size_t n) {
+  size_t i;
+
+  if (n == 0)
+    return;
+  else if (n < 33) {
+    utf16fix_runt<big_endian>(out, in, n);
+    return;
+  }
+  out[0] = is_low_surrogate<big_endian>(in[0]) ? 0xfffd : in[0];
+
+  /* duplicate code to have the compiler specialise utf16fix_block() */
+  if (in == out) {
+    for (i = 1; i + 32 < n; i += 32)
+      utf16fix_block(out + i, in + i, true);
+
+    utf16fix_block(out + n - 32, in + n - 32, true);
+  } else {
+    for (i = 1; i + 32 < n; i += 32)
+      utf16fix_block(out + i, in + i, false);
+
+    utf16fix_block(out + n - 32, in + n - 32, false);
+  }
+
+  out[n - 1] = is_high_surrogate<big_endian>(out[n - 1]) ? 0xfffd : out[n - 1];
+}

--- a/src/icelake/icelake_utf16fix.cpp
+++ b/src/icelake/icelake_utf16fix.cpp
@@ -115,7 +115,7 @@ void utf16fix_avx512(const char16_t *in, size_t n, char16_t *out) {
   if (n == 0)
     return;
   else if (n < 33) {
-    utf16fix_runt<big_endian>(out, in, n);
+    utf16fix_runt<big_endian>(in, n, out);
     return;
   }
   out[0] = is_low_surrogate<big_endian>(in[0]) ? replacement : in[0];

--- a/src/icelake/icelake_utf16fix.cpp
+++ b/src/icelake/icelake_utf16fix.cpp
@@ -7,7 +7,7 @@
  * If that character is illsequenced, it too is overwritten.
  */
 template <endianness big_endian>
-static void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
+simdutf_really_inline void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
   auto swap_if_needed = [](uint16_t c) -> uint16_t {

--- a/src/icelake/icelake_utf16fix.cpp
+++ b/src/icelake/icelake_utf16fix.cpp
@@ -8,7 +8,7 @@
  */
 template <endianness big_endian, bool in_place>
 simdutf_really_inline void utf16fix_block(char16_t *out, const char16_t *in) {
-  const char16_t replacement = scalar::utf16::replacement<big_endian>;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
   auto swap_if_needed = [](uint16_t c) -> uint16_t {
     return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
   };
@@ -61,7 +61,7 @@ simdutf_really_inline void utf16fix_block(char16_t *out, const char16_t *in) {
  */
 template <endianness big_endian>
 void utf16fix_runt(const char16_t *in, size_t n, char16_t *out) {
-  const char16_t replacement = scalar::utf16::replacement<big_endian>;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
   auto swap_if_needed = [](uint16_t c) -> uint16_t {
     return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
   };
@@ -104,7 +104,7 @@ void utf16fix_runt(const char16_t *in, size_t n, char16_t *out) {
 
 template <endianness big_endian>
 void utf16fix_avx512(const char16_t *in, size_t n, char16_t *out) {
-  const char16_t replacement = scalar::utf16::replacement<big_endian>;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
   size_t i;
 
   if (n == 0)

--- a/src/icelake/icelake_utf16fix.cpp
+++ b/src/icelake/icelake_utf16fix.cpp
@@ -6,9 +6,8 @@
  * character before the beginning of the buffer as a lookback.
  * If that character is illsequenced, it too is overwritten.
  */
-template <endianness big_endian>
-simdutf_really_inline void utf16fix_block(char16_t *out, const char16_t *in,
-                                          bool in_place) {
+template <endianness big_endian, bool in_place>
+simdutf_really_inline void utf16fix_block(char16_t *out, const char16_t *in) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
   auto swap_if_needed = [](uint16_t c) -> uint16_t {
@@ -123,16 +122,16 @@ void utf16fix_avx512(const char16_t *in, size_t n, char16_t *out) {
   /* duplicate code to have the compiler specialise utf16fix_block() */
   if (in == out) {
     for (i = 1; i + 32 < n; i += 32) {
-      utf16fix_block<big_endian>(out + i, in + i, true);
+      utf16fix_block<big_endian, true>(out + i, in + i);
     }
 
-    utf16fix_block<big_endian>(out + n - 32, in + n - 32, true);
+    utf16fix_block<big_endian, true>(out + n - 32, in + n - 32);
   } else {
     for (i = 1; i + 32 < n; i += 32) {
-      utf16fix_block<big_endian>(out + i, in + i, false);
+      utf16fix_block<big_endian, false>(out + i, in + i);
     }
 
-    utf16fix_block<big_endian>(out + n - 32, in + n - 32, false);
+    utf16fix_block<big_endian, false>(out + n - 32, in + n - 32);
   }
 
   out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])

--- a/src/icelake/icelake_utf16fix.cpp
+++ b/src/icelake/icelake_utf16fix.cpp
@@ -8,8 +8,7 @@
  */
 template <endianness big_endian, bool in_place>
 simdutf_really_inline void utf16fix_block(char16_t *out, const char16_t *in) {
-  const char16_t replacement =
-      !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>;
   auto swap_if_needed = [](uint16_t c) -> uint16_t {
     return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
   };
@@ -62,8 +61,7 @@ simdutf_really_inline void utf16fix_block(char16_t *out, const char16_t *in) {
  */
 template <endianness big_endian>
 void utf16fix_runt(const char16_t *in, size_t n, char16_t *out) {
-  const char16_t replacement =
-      !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>;
   auto swap_if_needed = [](uint16_t c) -> uint16_t {
     return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
   };
@@ -106,8 +104,7 @@ void utf16fix_runt(const char16_t *in, size_t n, char16_t *out) {
 
 template <endianness big_endian>
 void utf16fix_avx512(const char16_t *in, size_t n, char16_t *out) {
-  const char16_t replacement =
-      !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>;
   size_t i;
 
   if (n == 0)

--- a/src/icelake/icelake_utf16fix.cpp
+++ b/src/icelake/icelake_utf16fix.cpp
@@ -7,7 +7,8 @@
  * If that character is illsequenced, it too is overwritten.
  */
 template <endianness big_endian>
-simdutf_really_inline void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
+simdutf_really_inline void utf16fix_block(char16_t *out, const char16_t *in,
+                                          bool in_place) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
   auto swap_if_needed = [](uint16_t c) -> uint16_t {

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -495,6 +495,18 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
   }
   return result(error_code::SUCCESS, len);
 }
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
+                                                                 output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
+                                                              output);
+}
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -28,6 +28,9 @@ using namespace simd;
 #endif // SIMDUTF_FEATURE_UTF8 && (SIMDUTF_FEATURE_UTF16 ||
        // SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_LATIN1)
 
+#if SIMDUTF_FEATURE_UTF16
+  #include "icelake/icelake_utf16fix.cpp"
+#endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
   #include "icelake/icelake_convert_utf8_to_latin1.inl.cpp"
   #include "icelake/icelake_convert_valid_utf8_to_latin1.inl.cpp"

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -501,14 +501,12 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
 
 void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
                                             char16_t *output) const noexcept {
-  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
-                                                                 output);
+  return utf16fix_avx512<endianness::LITTLE>(input, len, output);
 }
 
 void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
                                             char16_t *output) const noexcept {
-  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
-                                                              output);
+  return utf16fix_avx512<endianness::BIG>(input, len, output);
 }
 #endif // SIMDUTF_FEATURE_UTF16
 

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1495,7 +1495,7 @@ void to_well_formed_utf16le(const char16_t *input, size_t len,
                                                               output);
 }
 void to_well_formed_utf16(const char16_t *input, size_t len,
-                                        char16_t *output) noexcept {
+                          char16_t *output) noexcept {
   #if SIMDUTF_IS_BIG_ENDIAN
   to_well_formed_utf16be(input, len, output);
   #else

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1494,7 +1494,7 @@ void to_well_formed_utf16le(const char16_t *input, size_t len,
   return get_default_implementation()->to_well_formed_utf16le(input, len,
                                                               output);
 }
-simdutf_warn_unused bool validate_utf16(const char16_t *input, size_t len,
+void to_well_formed_utf16(const char16_t *input, size_t len,
                                         char16_t *output) noexcept {
   #if SIMDUTF_IS_BIG_ENDIAN
   to_well_formed_utf16be(input, len, output);

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1494,6 +1494,14 @@ void to_well_formed_utf16le(const char16_t *input, size_t len,
   return get_default_implementation()->to_well_formed_utf16le(input, len,
                                                               output);
 }
+simdutf_warn_unused bool validate_utf16(const char16_t *input, size_t len,
+                                        char16_t *output) noexcept {
+  #if SIMDUTF_IS_BIG_ENDIAN
+  return to_well_formed_utf16be(input, len, output);
+  #else
+  return to_well_formed_utf16le(input, len, output);
+  #endif
+}
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1497,9 +1497,9 @@ void to_well_formed_utf16le(const char16_t *input, size_t len,
 simdutf_warn_unused bool validate_utf16(const char16_t *input, size_t len,
                                         char16_t *output) noexcept {
   #if SIMDUTF_IS_BIG_ENDIAN
-  return to_well_formed_utf16be(input, len, output);
+  to_well_formed_utf16be(input, len, output);
   #else
-  return to_well_formed_utf16le(input, len, output);
+  to_well_formed_utf16le(input, len, output);
   #endif
 }
 #endif // SIMDUTF_FEATURE_UTF16

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1484,14 +1484,6 @@ simdutf_warn_unused bool validate_utf16(const char16_t *buf,
   return validate_utf16le(buf, len);
   #endif
 }
-void validate_utf16(const char16_t *input, size_t len,
-                    char16_t *output) noexcept {
-  #if SIMDUTF_IS_BIG_ENDIAN
-  return to_well_formed_utf16be(input, len, output);
-  #else
-  return to_well_formed_utf16le(input, len, output);
-  #endif
-}
 void to_well_formed_utf16be(const char16_t *input, size_t len,
                             char16_t *output) noexcept {
   return get_default_implementation()->to_well_formed_utf16be(input, len,

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -267,6 +267,14 @@ public:
       const char16_t *buf, size_t len) const noexcept final override {
     return set_best()->validate_utf16be_with_errors(buf, len);
   }
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final override {
+    return set_best()->to_well_formed_utf16be(input, len, output);
+  }
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final override {
+    return set_best()->to_well_formed_utf16le(input, len, output);
+  }
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
@@ -845,6 +853,10 @@ public:
       const char16_t *, size_t) const noexcept final override {
     return result(error_code::OTHER, 0);
   }
+  void to_well_formed_utf16be(const char16_t *, size_t,
+                              char16_t *) const noexcept final override {}
+  void to_well_formed_utf16le(const char16_t *, size_t,
+                              char16_t *) const noexcept final override {}
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
@@ -1471,6 +1483,24 @@ simdutf_warn_unused bool validate_utf16(const char16_t *buf,
   #else
   return validate_utf16le(buf, len);
   #endif
+}
+void validate_utf16(const char16_t *input, size_t len,
+                    char16_t *output) noexcept {
+  #if SIMDUTF_IS_BIG_ENDIAN
+  return to_well_formed_utf16be(input, len, output);
+  #else
+  return to_well_formed_utf16le(input, len, output);
+  #endif
+}
+void to_well_formed_utf16be(const char16_t *input, size_t len,
+                            char16_t *output) noexcept {
+  return get_default_implementation()->to_well_formed_utf16be(input, len,
+                                                              output);
+}
+void to_well_formed_utf16le(const char16_t *input, size_t len,
+                            char16_t *output) noexcept {
+  return get_default_implementation()->to_well_formed_utf16le(input, len,
+                                                              output);
 }
 #endif // SIMDUTF_FEATURE_UTF16
 

--- a/src/lasx/implementation.cpp
+++ b/src/lasx/implementation.cpp
@@ -355,6 +355,18 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
     return res;
   }
 }
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
+                                                                 output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
+                                                              output);
+}
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING

--- a/src/lsx/implementation.cpp
+++ b/src/lsx/implementation.cpp
@@ -355,6 +355,18 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
     return res;
   }
 }
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
+                                                                 output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
+                                                              output);
+}
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -238,6 +238,18 @@ implementation::validate_utf16be(const char16_t *buf,
   return validate_utf16be_with_errors(buf, len).is_ok();
 }
 
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
+                                                                 output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
+                                                              output);
+}
+
 simdutf_warn_unused result implementation::validate_utf16le_with_errors(
     const char16_t *buf, size_t len) const noexcept {
   const auto res =

--- a/src/rvv/implementation.cpp
+++ b/src/rvv/implementation.cpp
@@ -52,6 +52,19 @@ implementation::detect_encodings(const char *input,
 #endif // SIMDUTF_FEATURE_DETECT_ENCODING
 
 #if SIMDUTF_FEATURE_UTF16
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
+                                                                 output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
+                                                              output);
+}
+
 template <simdutf_ByteFlip bflip>
 simdutf_really_inline static void
 rvv_change_endianness_utf16(const char16_t *src, size_t len, char16_t *dst) {

--- a/src/scalar/utf16.h
+++ b/src/scalar/utf16.h
@@ -162,9 +162,11 @@ void to_well_formed_utf16(const char16_t *input, size_t len, char16_t *output) {
   }
 }
 
+// variable templates are a C++14 extension
 template <endianness big_endian>
-const char16_t replacement = !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
-
+char16_t replacement() { 
+  return !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+}
 } // namespace utf16
 } // unnamed namespace
 } // namespace scalar

--- a/src/scalar/utf16.h
+++ b/src/scalar/utf16.h
@@ -163,8 +163,7 @@ void to_well_formed_utf16(const char16_t *input, size_t len, char16_t *output) {
 }
 
 // variable templates are a C++14 extension
-template <endianness big_endian>
-char16_t replacement() { 
+template <endianness big_endian> char16_t replacement() {
   return !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
 }
 } // namespace utf16

--- a/src/scalar/utf16.h
+++ b/src/scalar/utf16.h
@@ -141,8 +141,6 @@ void to_well_formed_utf16(const char16_t *input, size_t len, char16_t *output) {
     c = !match_system(big_endian) ? u16_swap_bytes(c) : c;
     high_surrogate = is_high_surrogate(c);
     low_surrogate = is_low_surrogate(c);
-    // printf("c: %x, high_surrogate: %d, low_surrogate: %d\n", c,
-    // high_surrogate, low_surrogate);
 
     if (high_surrogate_prev && !low_surrogate) {
       output[i - 1] = replacement;

--- a/src/scalar/utf16.h
+++ b/src/scalar/utf16.h
@@ -123,6 +123,45 @@ simdutf_warn_unused inline size_t trim_partial_utf16(const char16_t *input,
   return length;
 }
 
+template <endianness big_endian>
+void to_well_formed_utf16(const char16_t *input, size_t len, char16_t *output) {
+  auto is_high_surrogate = [](char16_t c) -> bool {
+    return (0xd800 <= c && c <= 0xdbff);
+  };
+
+  auto is_low_surrogate = [](char16_t c) -> bool {
+    return (0xdc00 <= c && c <= 0xdfff);
+  };
+  const char16_t replacement =
+      !match_system(big_endian) ? u16_swap_bytes(0xfffd) : 0xfffd;
+  bool high_surrogate_prev = false, high_surrogate, low_surrogate;
+  size_t i = 0;
+  for (; i < len; i++) {
+    char16_t c = input[i];
+    c = !match_system(big_endian) ? u16_swap_bytes(c) : c;
+    high_surrogate = is_high_surrogate(c);
+    low_surrogate = is_low_surrogate(c);
+    // printf("c: %x, high_surrogate: %d, low_surrogate: %d\n", c,
+    // high_surrogate, low_surrogate);
+
+    if (high_surrogate_prev && !low_surrogate) {
+      output[i - 1] = replacement;
+    }
+
+    if (!high_surrogate_prev && low_surrogate) {
+      output[i] = replacement;
+    } else {
+      output[i] = input[i];
+    }
+    high_surrogate_prev = high_surrogate;
+  }
+
+  /* string may not end with high surrogate */
+  if (high_surrogate_prev) {
+    output[i - 1] = replacement;
+  }
+}
+
 } // namespace utf16
 } // unnamed namespace
 } // namespace scalar

--- a/src/scalar/utf16.h
+++ b/src/scalar/utf16.h
@@ -126,24 +126,27 @@ simdutf_warn_unused inline size_t trim_partial_utf16(const char16_t *input,
 template <endianness big_endian> bool is_high_surrogate(char16_t c) {
   c = !match_system(big_endian) ? u16_swap_bytes(c) : c;
   return (0xd800 <= c && c <= 0xdbff);
-};
+}
 
 template <endianness big_endian> bool is_low_surrogate(char16_t c) {
   c = !match_system(big_endian) ? u16_swap_bytes(c) : c;
   return (0xdc00 <= c && c <= 0xdfff);
-};
+}
+
+// variable templates are a C++14 extension
+template <endianness big_endian> char16_t replacement() {
+  return !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+}
 
 template <endianness big_endian>
 void to_well_formed_utf16(const char16_t *input, size_t len, char16_t *output) {
-  const char16_t replacement =
-      !match_system(big_endian) ? u16_swap_bytes(0xfffd) : 0xfffd;
+  const char16_t replacement = utf16::replacement<big_endian>();
   bool high_surrogate_prev = false, high_surrogate, low_surrogate;
   size_t i = 0;
   for (; i < len; i++) {
     char16_t c = input[i];
     high_surrogate = is_high_surrogate<big_endian>(c);
     low_surrogate = is_low_surrogate<big_endian>(c);
-
     if (high_surrogate_prev && !low_surrogate) {
       output[i - 1] = replacement;
     }
@@ -162,10 +165,6 @@ void to_well_formed_utf16(const char16_t *input, size_t len, char16_t *output) {
   }
 }
 
-// variable templates are a C++14 extension
-template <endianness big_endian> char16_t replacement() {
-  return !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
-}
 } // namespace utf16
 } // unnamed namespace
 } // namespace scalar

--- a/src/scalar/utf16.h
+++ b/src/scalar/utf16.h
@@ -162,6 +162,9 @@ void to_well_formed_utf16(const char16_t *input, size_t len, char16_t *output) {
   }
 }
 
+template <endianness big_endian>
+const char16_t replacement = !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+
 } // namespace utf16
 } // unnamed namespace
 } // namespace scalar

--- a/src/simdutf/arm64/bitmanipulation.h
+++ b/src/simdutf/arm64/bitmanipulation.h
@@ -23,6 +23,9 @@ simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
   #endif // SIMDUTF_REGULAR_VISUAL_STUDIO
 }
 #endif
+template <typename T> T clear_least_significant_bit(T x) {
+  return (x & (x - 1));
+}
 
 } // unnamed namespace
 } // namespace SIMDUTF_IMPLEMENTATION

--- a/src/simdutf/arm64/implementation.h
+++ b/src/simdutf/arm64/implementation.h
@@ -46,6 +46,10 @@ public:
       const char16_t *buf, size_t len) const noexcept final;
   simdutf_warn_unused result validate_utf16be_with_errors(
       const char16_t *buf, size_t len) const noexcept final;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
   simdutf_warn_unused bool validate_utf32(const char32_t *buf,

--- a/src/simdutf/fallback/implementation.h
+++ b/src/simdutf/fallback/implementation.h
@@ -50,6 +50,10 @@ public:
       const char16_t *buf, size_t len) const noexcept final;
   simdutf_warn_unused result validate_utf16be_with_errors(
       const char16_t *buf, size_t len) const noexcept final;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING

--- a/src/simdutf/haswell/implementation.h
+++ b/src/simdutf/haswell/implementation.h
@@ -217,6 +217,10 @@ public:
                                            size_t length) const noexcept;
   simdutf_warn_unused size_t count_utf16be(const char16_t *buf,
                                            size_t length) const noexcept;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8

--- a/src/simdutf/icelake/implementation.h
+++ b/src/simdutf/icelake/implementation.h
@@ -59,6 +59,10 @@ public:
       const char16_t *buf, size_t len) const noexcept final;
   simdutf_warn_unused result validate_utf16be_with_errors(
       const char16_t *buf, size_t len) const noexcept final;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING

--- a/src/simdutf/lasx/implementation.h
+++ b/src/simdutf/lasx/implementation.h
@@ -47,6 +47,10 @@ public:
       const char16_t *buf, size_t len) const noexcept final;
   simdutf_warn_unused result validate_utf16be_with_errors(
       const char16_t *buf, size_t len) const noexcept final;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
   simdutf_warn_unused bool validate_utf32(const char32_t *buf,

--- a/src/simdutf/lsx/implementation.h
+++ b/src/simdutf/lsx/implementation.h
@@ -46,6 +46,10 @@ public:
       const char16_t *buf, size_t len) const noexcept final;
   simdutf_warn_unused result validate_utf16be_with_errors(
       const char16_t *buf, size_t len) const noexcept final;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING
   simdutf_warn_unused bool validate_utf32(const char32_t *buf,

--- a/src/simdutf/ppc64/implementation.h
+++ b/src/simdutf/ppc64/implementation.h
@@ -299,6 +299,10 @@ public:
 #ifdef SIMDUTF_INTERNAL_TESTS
   virtual std::vector<TestProcedure> internal_tests() const override;
 #endif
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 };
 
 } // namespace ppc64

--- a/src/simdutf/rvv/implementation.h
+++ b/src/simdutf/rvv/implementation.h
@@ -44,6 +44,10 @@ public:
 #if SIMDUTF_FEATURE_UTF16
   simdutf_warn_unused bool validate_utf16be(const char16_t *buf,
                                             size_t len) const noexcept final;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF16
   simdutf_warn_unused result validate_utf16le_with_errors(

--- a/src/simdutf/westmere/implementation.h
+++ b/src/simdutf/westmere/implementation.h
@@ -217,6 +217,10 @@ public:
                                            size_t length) const noexcept;
   simdutf_warn_unused size_t count_utf16be(const char16_t *buf,
                                            size_t length) const noexcept;
+  void to_well_formed_utf16be(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
+  void to_well_formed_utf16le(const char16_t *input, size_t len,
+                              char16_t *output) const noexcept final;
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -32,6 +32,9 @@ must_be_2_3_continuation(const simd8<uint8_t> prev2,
   #include "westmere/internal/loader.cpp"
 #endif // SIMDUTF_FEATURE_UTF8
 
+#if SIMDUTF_FEATURE_UTF16
+  #include "westmere/sse_utf16fix.cpp"
+#endif // SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
   #include "westmere/sse_validate_utf16.cpp"
 #endif // SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -386,6 +386,18 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
     return res;
   }
 }
+
+void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
+                                                                 output);
+}
+
+void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
+                                            char16_t *output) const noexcept {
+  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
+                                                              output);
+}
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF32 || SIMDUTF_FEATURE_DETECT_ENCODING

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -392,14 +392,12 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
 
 void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
                                             char16_t *output) const noexcept {
-  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
-                                                                 output);
+  return utf16fix_sse<endianness::LITTLE>(input, len, output);
 }
 
 void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
                                             char16_t *output) const noexcept {
-  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
-                                                              output);
+  return utf16fix_sse<endianness::BIG>(input, len, output);
 }
 #endif // SIMDUTF_FEATURE_UTF16
 

--- a/src/westmere/sse_utf16fix.cpp
+++ b/src/westmere/sse_utf16fix.cpp
@@ -1,0 +1,72 @@
+/*
+ * Process one block of 8 characters.  If in_place is false,
+ * copy the block from in to out.  If there is a sequencing
+ * error in the block, overwrite the illsequenced characters
+ * with the replacement character.  This function reads one
+ * character before the beginning of the buffer as a lookback.
+ * If that character is illsequenced, it too is overwritten.
+ */
+template <endianness big_endian>
+static void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
+  __m128i lookback, block, lb_masked, block_masked, lb_is_high, block_is_low;
+  __m128i illseq, lb_illseq, block_illseq;
+
+  lookback = _mm_loadu_si128((const void *)(in - 1));
+  block = _mm_loadu_si128((const void *)in);
+
+  lb_masked = _mm_and_si128(lookback, _mm_set1_epi16(0xfc00));
+  block_masked = _mm_and_si128(block, _mm_set1_epi16(0xfc00));
+  lb_is_high = _mm_cmpeq_epi16(lb_masked, _mm_set1_epi16(0xd800));
+  block_is_low = _mm_cmpeq_epi16(block_masked, _mm_set1_epi16(0xdc00));
+
+  illseq = _mm_xor_si128(lb_is_high, block_is_low);
+  if (_mm_movemask_epi8(illseq) != 0) {
+    int lb;
+
+    /* compute the cause of the illegal sequencing */
+    lb_illseq = _mm_andnot_si128(block_is_low, lb_is_high);
+    block_illseq = _mm_or_si128(_mm_andnot_si128(lb_is_high, block_is_low),
+                                _mm_bsrli_si128(lb_illseq, 2));
+
+    /* fix illegal sequencing in the lookback */
+    lb = _mm_cvtsi128_si32(lb_illseq);
+    lb = lb & 0xfffd | ~lb & out[-1];
+    out[-1] = lb & 0xffff;
+
+    /* fix illegal sequencing in the main block */
+    block = _mm_or_si128(_mm_andnot_si128(block_illseq, block),
+                         _mm_and_si128(block_illseq, _mm_set1_epi16(0xfffd)));
+
+    _mm_storeu_si128((void *)out, block);
+  } else if (!in_place)
+    _mm_storeu_si128((void *)out, block);
+}
+
+template <endianness big_endian>
+void utf16fix_sse(char16_t *out, const char16_t *in, size_t n) {
+  size_t i;
+
+  if (n < 9) {
+    scalar::utf16::to_well_formed_utf16<big_endian>(out, in, n);
+    return;
+  }
+
+  out[0] = scalar::utf16::is_low_surrogate<big_endian>(in[0]) ? 0xfffd : in[0];
+
+  /* duplicate code to have the compiler specialise utf16fix_block() */
+  if (in == out) {
+    for (i = 1; i + 8 < n; i += 8)
+      utf16fix_block<big_endian>(out + i, in + i, true);
+
+    utf16fix_block<big_endian>(out + n - 8, in + n - 8, true);
+  } else {
+    for (i = 1; i + 8 < n; i += 8)
+      utf16fix_block<big_endian>(out + i, in + i, false);
+
+    utf16fix_block<big_endian>(out + n - 8, in + n - 8, false);
+  }
+
+  out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])
+                   ? 0xfffd
+                   : out[n - 1];
+}

--- a/src/westmere/sse_utf16fix.cpp
+++ b/src/westmere/sse_utf16fix.cpp
@@ -7,7 +7,7 @@
  * If that character is illsequenced, it too is overwritten.
  */
 template <endianness big_endian>
-static void utf16fix_block_sse(char16_t *out, const char16_t *in,
+simdutf_really_inline void utf16fix_block_sse(char16_t *out, const char16_t *in,
                                bool in_place) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;

--- a/src/westmere/sse_utf16fix.cpp
+++ b/src/westmere/sse_utf16fix.cpp
@@ -6,9 +6,8 @@
  * character before the beginning of the buffer as a lookback.
  * If that character is illsequenced, it too is overwritten.
  */
-template <endianness big_endian>
-simdutf_really_inline void utf16fix_block_sse(char16_t *out, const char16_t *in,
-                                              bool in_place) {
+template <endianness big_endian, bool in_place>
+simdutf_really_inline void utf16fix_block_sse(char16_t *out, const char16_t *in) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
   auto swap_if_needed = [](uint16_t c) -> uint16_t {
@@ -66,16 +65,16 @@ void utf16fix_sse(const char16_t *in, size_t n, char16_t *out) {
   /* duplicate code to have the compiler specialise utf16fix_block() */
   if (in == out) {
     for (i = 1; i + 8 < n; i += 8) {
-      utf16fix_block_sse<big_endian>(out + i, in + i, true);
+      utf16fix_block_sse<big_endian, true>(out + i, in + i);
     }
 
-    utf16fix_block_sse<big_endian>(out + n - 8, in + n - 8, true);
+    utf16fix_block_sse<big_endian, true>(out + n - 8, in + n - 8);
   } else {
     for (i = 1; i + 8 < n; i += 8) {
-      utf16fix_block_sse<big_endian>(out + i, in + i, false);
+      utf16fix_block_sse<big_endian, false>(out + i, in + i);
     }
 
-    utf16fix_block_sse<big_endian>(out + n - 8, in + n - 8, false);
+    utf16fix_block_sse<big_endian, false>(out + n - 8, in + n - 8);
   }
 
   out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])

--- a/src/westmere/sse_utf16fix.cpp
+++ b/src/westmere/sse_utf16fix.cpp
@@ -8,7 +8,7 @@
  */
 template <endianness big_endian>
 simdutf_really_inline void utf16fix_block_sse(char16_t *out, const char16_t *in,
-                               bool in_place) {
+                                              bool in_place) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
   auto swap_if_needed = [](uint16_t c) -> uint16_t {

--- a/src/westmere/sse_utf16fix.cpp
+++ b/src/westmere/sse_utf16fix.cpp
@@ -1,8 +1,3 @@
-__m128i swap_endianness(__m128i x) {
-  const __m128i swap =
-      _mm_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-  return _mm_shuffle_epi8(x, swap);
-}
 /*
  * Process one block of 8 characters.  If in_place is false,
  * copy the block from in to out.  If there is a sequencing
@@ -16,21 +11,21 @@ static void utf16fix_block_sse(char16_t *out, const char16_t *in,
                                bool in_place) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+  auto swap_if_needed = [](uint16_t c) -> uint16_t {
+    return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
+  };
 
   __m128i lookback, block, lb_masked, block_masked, lb_is_high, block_is_low;
   __m128i illseq, lb_illseq, block_illseq;
 
   lookback = _mm_loadu_si128((const __m128i *)(in - 1));
   block = _mm_loadu_si128((const __m128i *)in);
-  if (!simdutf::match_system(big_endian)) {
-    lookback = swap_endianness(lookback);
-    block = swap_endianness(block);
-  }
-
-  lb_masked = _mm_and_si128(lookback, _mm_set1_epi16(0xfc00U));
-  block_masked = _mm_and_si128(block, _mm_set1_epi16(0xfc00U));
-  lb_is_high = _mm_cmpeq_epi16(lb_masked, _mm_set1_epi16(0xd800U));
-  block_is_low = _mm_cmpeq_epi16(block_masked, _mm_set1_epi16(0xdc00U));
+  lb_masked = _mm_and_si128(lookback, _mm_set1_epi16(swap_if_needed(0xfc00U)));
+  block_masked = _mm_and_si128(block, _mm_set1_epi16(swap_if_needed(0xfc00U)));
+  lb_is_high =
+      _mm_cmpeq_epi16(lb_masked, _mm_set1_epi16(swap_if_needed(0xd800U)));
+  block_is_low =
+      _mm_cmpeq_epi16(block_masked, _mm_set1_epi16(swap_if_needed(0xdc00U)));
 
   illseq = _mm_xor_si128(lb_is_high, block_is_low);
   if (_mm_movemask_epi8(illseq) != 0) {
@@ -48,15 +43,9 @@ static void utf16fix_block_sse(char16_t *out, const char16_t *in,
     /* fix illegal sequencing in the main block */
     block =
         _mm_or_si128(_mm_andnot_si128(block_illseq, block),
-                     _mm_and_si128(block_illseq, _mm_set1_epi16(0xfffdu)));
-    if (!simdutf::match_system(big_endian)) {
-      block = swap_endianness(block);
-    }
+                     _mm_and_si128(block_illseq, _mm_set1_epi16(replacement)));
     _mm_storeu_si128((__m128i *)out, block);
   } else if (!in_place) {
-    if (!simdutf::match_system(big_endian)) {
-      block = swap_endianness(block);
-    }
     _mm_storeu_si128((__m128i *)out, block);
   }
 }

--- a/src/westmere/sse_utf16fix.cpp
+++ b/src/westmere/sse_utf16fix.cpp
@@ -8,8 +8,7 @@
  */
 template <endianness big_endian, bool in_place>
 simdutf_really_inline void utf16fix_block_sse(char16_t *out, const char16_t *in) {
-  const char16_t replacement =
-      !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>;
   auto swap_if_needed = [](uint16_t c) -> uint16_t {
     return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
   };
@@ -51,8 +50,7 @@ simdutf_really_inline void utf16fix_block_sse(char16_t *out, const char16_t *in)
 
 template <endianness big_endian>
 void utf16fix_sse(const char16_t *in, size_t n, char16_t *out) {
-  const char16_t replacement =
-      !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>;
   size_t i;
   if (n < 9) {
     scalar::utf16::to_well_formed_utf16<big_endian>(in, n, out);

--- a/src/westmere/sse_utf16fix.cpp
+++ b/src/westmere/sse_utf16fix.cpp
@@ -9,7 +9,7 @@
 template <endianness big_endian, bool in_place>
 simdutf_really_inline void utf16fix_block_sse(char16_t *out,
                                               const char16_t *in) {
-  const char16_t replacement = scalar::utf16::replacement<big_endian>;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
   auto swap_if_needed = [](uint16_t c) -> uint16_t {
     return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
   };
@@ -51,7 +51,7 @@ simdutf_really_inline void utf16fix_block_sse(char16_t *out,
 
 template <endianness big_endian>
 void utf16fix_sse(const char16_t *in, size_t n, char16_t *out) {
-  const char16_t replacement = scalar::utf16::replacement<big_endian>;
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
   size_t i;
   if (n < 9) {
     scalar::utf16::to_well_formed_utf16<big_endian>(in, n, out);

--- a/src/westmere/sse_utf16fix.cpp
+++ b/src/westmere/sse_utf16fix.cpp
@@ -37,9 +37,10 @@ static void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
     block = _mm_or_si128(_mm_andnot_si128(block_illseq, block),
                          _mm_and_si128(block_illseq, _mm_set1_epi16(0xfffd)));
 
-    _mm_storeu_si128((void *)out, block);
-  } else if (!in_place)
-    _mm_storeu_si128((void *)out, block);
+    _mm_storeu_si128((__m128i *)out, block);
+  } else if (!in_place) {
+    _mm_storeu_si128((__m128i *)out, block);
+  }
 }
 
 template <endianness big_endian>
@@ -55,13 +56,15 @@ void utf16fix_sse(char16_t *out, const char16_t *in, size_t n) {
 
   /* duplicate code to have the compiler specialise utf16fix_block() */
   if (in == out) {
-    for (i = 1; i + 8 < n; i += 8)
+    for (i = 1; i + 8 < n; i += 8) {
       utf16fix_block<big_endian>(out + i, in + i, true);
+    }
 
     utf16fix_block<big_endian>(out + n - 8, in + n - 8, true);
   } else {
-    for (i = 1; i + 8 < n; i += 8)
+    for (i = 1; i + 8 < n; i += 8) {
       utf16fix_block<big_endian>(out + i, in + i, false);
+    }
 
     utf16fix_block<big_endian>(out + n - 8, in + n - 8, false);
   }

--- a/src/westmere/sse_utf16fix.cpp
+++ b/src/westmere/sse_utf16fix.cpp
@@ -1,3 +1,8 @@
+__m128i swap_endianness(__m128i x) {
+  const __m128i swap =
+      _mm_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
+  return _mm_shuffle_epi8(x, swap);
+}
 /*
  * Process one block of 8 characters.  If in_place is false,
  * copy the block from in to out.  If there is a sequencing
@@ -7,19 +12,25 @@
  * If that character is illsequenced, it too is overwritten.
  */
 template <endianness big_endian>
-static void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
+static void utf16fix_block_sse(char16_t *out, const char16_t *in,
+                               bool in_place) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
+
   __m128i lookback, block, lb_masked, block_masked, lb_is_high, block_is_low;
   __m128i illseq, lb_illseq, block_illseq;
 
-  lookback = _mm_loadu_si128((const void *)(in - 1));
-  block = _mm_loadu_si128((const void *)in);
+  lookback = _mm_loadu_si128((const __m128i *)(in - 1));
+  block = _mm_loadu_si128((const __m128i *)in);
+  if (!simdutf::match_system(big_endian)) {
+    lookback = swap_endianness(lookback);
+    block = swap_endianness(block);
+  }
 
-  lb_masked = _mm_and_si128(lookback, _mm_set1_epi16(0xfc00));
-  block_masked = _mm_and_si128(block, _mm_set1_epi16(0xfc00));
-  lb_is_high = _mm_cmpeq_epi16(lb_masked, _mm_set1_epi16(0xd800));
-  block_is_low = _mm_cmpeq_epi16(block_masked, _mm_set1_epi16(0xdc00));
+  lb_masked = _mm_and_si128(lookback, _mm_set1_epi16(0xfc00U));
+  block_masked = _mm_and_si128(block, _mm_set1_epi16(0xfc00U));
+  lb_is_high = _mm_cmpeq_epi16(lb_masked, _mm_set1_epi16(0xd800U));
+  block_is_low = _mm_cmpeq_epi16(block_masked, _mm_set1_epi16(0xdc00U));
 
   illseq = _mm_xor_si128(lb_is_high, block_is_low);
   if (_mm_movemask_epi8(illseq) != 0) {
@@ -32,28 +43,31 @@ static void utf16fix_block(char16_t *out, const char16_t *in, bool in_place) {
 
     /* fix illegal sequencing in the lookback */
     lb = _mm_cvtsi128_si32(lb_illseq);
-    lb = lb & replacement | ~lb & out[-1];
-    out[-1] = lb & 0xffff;
-
+    lb = (lb & replacement) | (~lb & out[-1]);
+    out[-1] = char16_t(lb);
     /* fix illegal sequencing in the main block */
     block =
         _mm_or_si128(_mm_andnot_si128(block_illseq, block),
-                     _mm_and_si128(block_illseq, _mm_set1_epi16(replacement)));
-
+                     _mm_and_si128(block_illseq, _mm_set1_epi16(0xfffdu)));
+    if (!simdutf::match_system(big_endian)) {
+      block = swap_endianness(block);
+    }
     _mm_storeu_si128((__m128i *)out, block);
   } else if (!in_place) {
+    if (!simdutf::match_system(big_endian)) {
+      block = swap_endianness(block);
+    }
     _mm_storeu_si128((__m128i *)out, block);
   }
 }
 
 template <endianness big_endian>
-void utf16fix_sse(char16_t *out, const char16_t *in, size_t n) {
+void utf16fix_sse(const char16_t *in, size_t n, char16_t *out) {
   const char16_t replacement =
       !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;
   size_t i;
-
   if (n < 9) {
-    scalar::utf16::to_well_formed_utf16<big_endian>(out, in, n);
+    scalar::utf16::to_well_formed_utf16<big_endian>(in, n, out);
     return;
   }
 
@@ -63,16 +77,16 @@ void utf16fix_sse(char16_t *out, const char16_t *in, size_t n) {
   /* duplicate code to have the compiler specialise utf16fix_block() */
   if (in == out) {
     for (i = 1; i + 8 < n; i += 8) {
-      utf16fix_block<big_endian>(out + i, in + i, true);
+      utf16fix_block_sse<big_endian>(out + i, in + i, true);
     }
 
-    utf16fix_block<big_endian>(out + n - 8, in + n - 8, true);
+    utf16fix_block_sse<big_endian>(out + n - 8, in + n - 8, true);
   } else {
     for (i = 1; i + 8 < n; i += 8) {
-      utf16fix_block<big_endian>(out + i, in + i, false);
+      utf16fix_block_sse<big_endian>(out + i, in + i, false);
     }
 
-    utf16fix_block<big_endian>(out + n - 8, in + n - 8, false);
+    utf16fix_block_sse<big_endian>(out + n - 8, in + n - 8, false);
   }
 
   out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -396,3 +396,8 @@ target_link_libraries(internal_tests
 add_cpp_test(utf8_length_from_utf16_tests)
 target_link_libraries(utf8_length_from_utf16_tests
     PUBLIC simdutf::tests::helpers)
+
+add_cpp_test(to_well_formed_utf16)
+target_link_libraries(to_well_formed_utf16
+  PUBLIC simdutf::tests::helpers
+         simdutf::tests::reference)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -397,7 +397,7 @@ add_cpp_test(utf8_length_from_utf16_tests)
 target_link_libraries(utf8_length_from_utf16_tests
     PUBLIC simdutf::tests::helpers)
 
-add_cpp_test(to_well_formed_utf16)
-target_link_libraries(to_well_formed_utf16
+add_cpp_test(to_well_formed_utf16_tests)
+target_link_libraries(to_well_formed_utf16_tests
   PUBLIC simdutf::tests::helpers
          simdutf::tests::reference)

--- a/tests/helpers/test.h
+++ b/tests/helpers/test.h
@@ -79,6 +79,30 @@ void dump_diff_hex(const T &lhs, const U &rhs) {
   putchar('\n');
 }
 
+inline std::ostream &operator<<(std::ostream &os, char8_t c) {
+  return os << uint8_t(c);
+}
+inline std::ostream &operator<<(std::ostream &os, char16_t c) {
+  return os << uint16_t(c);
+}
+inline std::ostream &operator<<(std::ostream &os, char32_t c) {
+  return os << uint32_t(c);
+}
+template <typename T>
+std::ostream &operator<<(std::ostream &os, const std::vector<T> &vec) {
+  os << "["; // Start with opening bracket
+  if (!vec.empty()) {
+    // Print first element without leading comma
+    os << static_cast<uint16_t>(vec[0]);
+    // Print remaining elements with commas
+    for (size_t i = 1; i < vec.size(); ++i) {
+      os << ", " << static_cast<uint16_t>(vec[i]);
+    }
+  }
+  os << "]"; // End with closing bracket
+  return os;
+}
+
 #define TEST(name)                                                             \
   void test_impl_##name(const simdutf::implementation &impl);                  \
   void name(const simdutf::implementation &impl) {                             \

--- a/tests/to_well_formed_utf16.cpp
+++ b/tests/to_well_formed_utf16.cpp
@@ -18,26 +18,33 @@ constexpr char16_t replacement_be = 0xFDFF;
 #endif
 
 TEST_LOOP(trials, to_well_formed_utf16le_single_surrogate) {
-  for (size_t j = 0; j < 40; j++) {
-    std::vector<uint16_t> utf16(40);
-    utf16[j] = 0xD800;
-    const auto len = utf16.size();
-    std::vector<char16_t> output(len);
-    implementation.to_well_formed_utf16le((const char16_t *)utf16.data(), len,
-                                          output.data());
-    ASSERT_TRUE(output[j] == replacement_le);
+  const size_t length = 128;
+  std::vector<uint16_t> utf16(length);
+  std::vector<char16_t> surrogates = {0xD800, 0xDC00, 0xDFFF, 0xD800, 0xDC00};
+  for (size_t j = 0; j < length; j++) {
+    for(char16_t surrogate : surrogates) {
+      utf16[j] = surrogate;
+      const auto len = utf16.size();
+      std::vector<char16_t> output(len);
+      implementation.to_well_formed_utf16le((const char16_t *)utf16.data(), len,
+                                            output.data());
+      ASSERT_TRUE(output[j] == replacement_le);
+      utf16[j] = 0x0000; // Reset to a valid character
+    }
   }
 }
 
 TEST_LOOP(trials, to_well_formed_utf16be_single_surrogate) {
-  for (size_t j = 0; j < 40; j++) {
-    std::vector<uint16_t> utf16(40);
+  const size_t length = 128;
+  std::vector<uint16_t> utf16(length);
+  for (size_t j = 0; j < length; j++) {
     utf16[j] = 0x00D8;
     const auto len = utf16.size();
     std::vector<char16_t> output(len);
     implementation.to_well_formed_utf16be((const char16_t *)utf16.data(), len,
                                           output.data());
     ASSERT_TRUE(output[j] == replacement_be);
+    utf16[j] = 0x0000; // Reset to a valid character
   }
 }
 // Should be the identity on valid input

--- a/tests/to_well_formed_utf16.cpp
+++ b/tests/to_well_formed_utf16.cpp
@@ -35,7 +35,7 @@ TEST_LOOP(trials, to_well_formed_utf16be_single_surrogate) {
 TEST_LOOP(trials,
           to_well_formed_utf16le_for_valid_input_surrogate_pairs_short) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
-  const auto utf16{generator.generate(8)};
+  const auto utf16{generator.generate_le(8)};
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
   implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
@@ -45,19 +45,16 @@ TEST_LOOP(trials,
 TEST_LOOP(trials,
           to_well_formed_utf16be_for_valid_input_surrogate_pairs_short) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
-  const auto utf16{generator.generate(8)};
+  const auto utf16{generator.generate_be(8)};
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
-  std::vector<char16_t> flipped(utf16.size());
-  implementation.change_endianness_utf16(utf16.data(), utf16.size(),
-                                         flipped.data());
-  implementation.to_well_formed_utf16be(flipped.data(), len, output.data());
-  ASSERT_TRUE(output == flipped);
+  implementation.to_well_formed_utf16be(utf16.data(), len, output.data());
+  ASSERT_TRUE(output == utf16);
 }
 
 TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_surrogate_pairs_long) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
-  const auto utf16{generator.generate(512)};
+  const auto utf16{generator.generate_le(512)};
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
   implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
@@ -66,19 +63,16 @@ TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_surrogate_pairs_long) {
 
 TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_surrogate_pairs_long) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
-  const auto utf16{generator.generate(512)};
+  const auto utf16{generator.generate_be(512)};
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
-  std::vector<char16_t> flipped(utf16.size());
-  implementation.change_endianness_utf16(utf16.data(), utf16.size(),
-                                         flipped.data());
-  implementation.to_well_formed_utf16be(flipped.data(), len, output.data());
-  ASSERT_TRUE(output == flipped);
+  implementation.to_well_formed_utf16be(utf16.data(), len, output.data());
+  ASSERT_TRUE(output == utf16);
 }
 
 TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_mixed_long) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 1};
-  const auto utf16{generator.generate(512)};
+  const auto utf16{generator.generate_le(512)};
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
   implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
@@ -87,19 +81,16 @@ TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_mixed_long) {
 
 TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_mixed_long) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 1};
-  const auto utf16{generator.generate(512)};
+  const auto utf16{generator.generate_be(512)};
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
-  std::vector<char16_t> flipped(utf16.size());
-  implementation.change_endianness_utf16(utf16.data(), utf16.size(),
-                                         flipped.data());
-  implementation.to_well_formed_utf16be(flipped.data(), len, output.data());
-  ASSERT_TRUE(output == flipped);
+  implementation.to_well_formed_utf16be(utf16.data(), len, output.data());
+  ASSERT_TRUE(output == utf16);
 }
 
 TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_mixed_long_self) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 1};
-  const auto utf16{generator.generate(512)};
+  const auto utf16{generator.generate_le(512)};
   const auto len = utf16.size();
   std::vector<char16_t> output = utf16;
   implementation.to_well_formed_utf16le(output.data(), len, output.data());
@@ -108,14 +99,11 @@ TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_mixed_long_self) {
 
 TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_mixed_long_self) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 1};
-  const auto utf16{generator.generate(512)};
+  const auto utf16{generator.generate_be(512)};
   const auto len = utf16.size();
-  std::vector<char16_t> flipped(utf16.size());
-  implementation.change_endianness_utf16(utf16.data(), utf16.size(),
-                                         flipped.data());
-  std::vector<char16_t> output = flipped;
+  std::vector<char16_t> output = utf16;
   implementation.to_well_formed_utf16be(output.data(), len, output.data());
-  ASSERT_TRUE(output == flipped);
+  ASSERT_TRUE(output == utf16);
 }
 
 std::vector<char16_t> random_testcase(size_t n, std::mt19937 &rng) {
@@ -163,13 +151,10 @@ TEST(to_well_formed_utf16be_bad_input) {
   for (size_t i = 0; i < 1000; i++) {
     auto utf16 = random_testcase(512, gen);
     auto len = utf16.size();
-    std::vector<char16_t> flipped(utf16.size());
-    implementation.change_endianness_utf16(utf16.data(), utf16.size(),
-                                           flipped.data());
     std::vector<char16_t> output(len);
-    implementation.to_well_formed_utf16be(flipped.data(), len, output.data());
+    implementation.to_well_formed_utf16be(utf16.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
-      if (flipped[j] != output[j]) {
+      if (utf16[j] != output[j]) {
 #if SIMDUTF_IS_BIG_ENDIAN
         ASSERT_TRUE(output[j] == 0xFFFD);
 #else
@@ -206,13 +191,10 @@ TEST(to_well_formed_utf16be_bad_input_self) {
   for (size_t i = 0; i < 1000; i++) {
     auto utf16 = random_testcase(512, gen);
     auto len = utf16.size();
-    std::vector<char16_t> flipped(utf16.size());
-    implementation.change_endianness_utf16(utf16.data(), utf16.size(),
-                                           flipped.data());
-    std::vector<char16_t> output = flipped;
+    std::vector<char16_t> output = utf16;
     implementation.to_well_formed_utf16be(output.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
-      if (flipped[j] != output[j]) {
+      if (utf16[j] != output[j]) {
 #if SIMDUTF_IS_BIG_ENDIAN
         ASSERT_TRUE(output[j] == 0xFFFD);
 #else

--- a/tests/to_well_formed_utf16.cpp
+++ b/tests/to_well_formed_utf16.cpp
@@ -97,12 +97,12 @@ TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_mixed_long_self) {
 }
 
 std::vector<char16_t> random_testcase(size_t n, std::mt19937 &rng) {
-  std::uniform_int_distribution<uint16_t> dist(0, 0xFFFF);
-  std::uniform_int_distribution<uint8_t> disthl(0, 3);
+  std::uniform_int_distribution<int> dist(0, 0xFFFF);
+  std::uniform_int_distribution<int> disthl(0, 3);
   std::vector<char16_t> buf(n);
   for (size_t i = 0; i < n; ++i) {
-    uint16_t random_value = dist(rng);
-    uint8_t random_hl = disthl(rng);
+    uint16_t random_value(dist(rng));
+    uint8_t random_hl(disthl(rng));
     if (random_hl == 0) { // 25% for low surrogate
       buf[i] = 0xD800 | (random_value & 0x07FF);
     } else if (random_hl == 1) { // Another 25% for high surrogate

--- a/tests/to_well_formed_utf16.cpp
+++ b/tests/to_well_formed_utf16.cpp
@@ -1,0 +1,205 @@
+#include "simdutf.h"
+
+#include <random>
+#include <thread>
+#include <vector>
+
+#include <tests/helpers/random_utf16.h>
+#include <tests/helpers/test.h>
+
+constexpr size_t trials = 1000;
+
+// Should be the identity on valid input
+TEST_LOOP(trials,
+          to_well_formed_utf16le_for_valid_input_surrogate_pairs_short) {
+  simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
+  const auto utf16{generator.generate(8)};
+  const auto len = utf16.size();
+  std::vector<char16_t> output(len);
+  implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
+  ASSERT_TRUE(output == utf16);
+}
+
+TEST_LOOP(trials,
+          to_well_formed_utf16be_for_valid_input_surrogate_pairs_short) {
+  simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
+  const auto utf16{generator.generate(8)};
+  const auto len = utf16.size();
+  std::vector<char16_t> output(len);
+  std::vector<char16_t> flipped(utf16.size());
+  implementation.change_endianness_utf16(utf16.data(), utf16.size(),
+                                         flipped.data());
+  implementation.to_well_formed_utf16be(flipped.data(), len, output.data());
+  ASSERT_TRUE(output == flipped);
+}
+
+TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_surrogate_pairs_long) {
+  simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
+  const auto utf16{generator.generate(512)};
+  const auto len = utf16.size();
+  std::vector<char16_t> output(len);
+  implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
+  ASSERT_TRUE(output == utf16);
+}
+
+TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_surrogate_pairs_long) {
+  simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
+  const auto utf16{generator.generate(512)};
+  const auto len = utf16.size();
+  std::vector<char16_t> output(len);
+  std::vector<char16_t> flipped(utf16.size());
+  implementation.change_endianness_utf16(utf16.data(), utf16.size(),
+                                         flipped.data());
+  implementation.to_well_formed_utf16be(flipped.data(), len, output.data());
+  ASSERT_TRUE(output == flipped);
+}
+
+TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_mixed_long) {
+  simdutf::tests::helpers::random_utf16 generator{seed, 1, 1};
+  const auto utf16{generator.generate(512)};
+  const auto len = utf16.size();
+  std::vector<char16_t> output(len);
+  implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
+  ASSERT_TRUE(output == utf16);
+}
+
+TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_mixed_long) {
+  simdutf::tests::helpers::random_utf16 generator{seed, 1, 1};
+  const auto utf16{generator.generate(512)};
+  const auto len = utf16.size();
+  std::vector<char16_t> output(len);
+  std::vector<char16_t> flipped(utf16.size());
+  implementation.change_endianness_utf16(utf16.data(), utf16.size(),
+                                         flipped.data());
+  implementation.to_well_formed_utf16be(flipped.data(), len, output.data());
+  ASSERT_TRUE(output == flipped);
+}
+
+TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_mixed_long_self) {
+  simdutf::tests::helpers::random_utf16 generator{seed, 1, 1};
+  const auto utf16{generator.generate(512)};
+  const auto len = utf16.size();
+  std::vector<char16_t> output = utf16;
+  implementation.to_well_formed_utf16le(output.data(), len, output.data());
+  ASSERT_TRUE(output == utf16);
+}
+
+TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_mixed_long_self) {
+  simdutf::tests::helpers::random_utf16 generator{seed, 1, 1};
+  const auto utf16{generator.generate(512)};
+  const auto len = utf16.size();
+  std::vector<char16_t> flipped(utf16.size());
+  implementation.change_endianness_utf16(utf16.data(), utf16.size(),
+                                         flipped.data());
+  std::vector<char16_t> output = flipped;
+  implementation.to_well_formed_utf16be(output.data(), len, output.data());
+  ASSERT_TRUE(output == flipped);
+}
+
+std::vector<char16_t> random_testcase(size_t n, std::mt19937 &rng) {
+  std::uniform_int_distribution<uint16_t> dist(0, 0xFFFF);
+  std::uniform_int_distribution<uint8_t> disthl(0, 3);
+  std::vector<char16_t> buf(n);
+  for (size_t i = 0; i < n; ++i) {
+    uint16_t random_value = dist(rng);
+    uint8_t random_hl = disthl(rng);
+    if (random_hl == 0) { // 25% for low surrogate
+      buf[i] = 0xD800 | (random_value & 0x07FF);
+    } else if (random_hl == 1) { // Another 25% for high surrogate
+      buf[i] = 0xDC00 | (random_value & 0x07FF);
+    } else {
+      // Generate any other character in the char16_t range
+      // could be a surrogate pair...
+      buf[i] = random_value;
+    }
+  }
+  return buf;
+}
+
+TEST(to_well_formed_utf16le_bad_input) {
+  std::mt19937 gen((std::mt19937::result_type)(42));
+  for (size_t i = 0; i < 1000; i++) {
+    auto utf16 = random_testcase(512, gen);
+    auto len = utf16.size();
+    std::vector<char16_t> output(len);
+    implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
+    for (size_t j = 0; j < len; j++) {
+      if (utf16[j] != output[j]) {
+#if SIMDUTF_IS_BIG_ENDIAN
+        ASSERT_TRUE(output[j] == 0xFDFF);
+#else
+        ASSERT_TRUE(output[j] == 0xFFFD);
+#endif
+      }
+    }
+    ASSERT_TRUE(implementation.validate_utf16le(output.data(), len));
+  }
+}
+
+TEST(to_well_formed_utf16be_bad_input) {
+  std::mt19937 gen((std::mt19937::result_type)(42));
+  for (size_t i = 0; i < 1000; i++) {
+    auto utf16 = random_testcase(512, gen);
+    auto len = utf16.size();
+    std::vector<char16_t> flipped(utf16.size());
+    implementation.change_endianness_utf16(utf16.data(), utf16.size(),
+                                           flipped.data());
+    std::vector<char16_t> output(len);
+    implementation.to_well_formed_utf16be(flipped.data(), len, output.data());
+    for (size_t j = 0; j < len; j++) {
+      if (flipped[j] != output[j]) {
+#if SIMDUTF_IS_BIG_ENDIAN
+        ASSERT_TRUE(output[j] == 0xFFFD);
+#else
+        ASSERT_TRUE(output[j] == 0xFDFF);
+#endif
+      }
+    }
+    ASSERT_TRUE(implementation.validate_utf16be(output.data(), len));
+  }
+}
+
+TEST(to_well_formed_utf16le_bad_input_self) {
+  std::mt19937 gen((std::mt19937::result_type)(42));
+  for (size_t i = 0; i < 1000; i++) {
+    auto utf16 = random_testcase(512, gen);
+    auto len = utf16.size();
+    std::vector<char16_t> output = utf16;
+    implementation.to_well_formed_utf16le(output.data(), len, output.data());
+    for (size_t j = 0; j < len; j++) {
+      if (utf16[j] != output[j]) {
+#if SIMDUTF_IS_BIG_ENDIAN
+        ASSERT_TRUE(output[j] == 0xFDFF);
+#else
+        ASSERT_TRUE(output[j] == 0xFFFD);
+#endif
+      }
+    }
+    ASSERT_TRUE(implementation.validate_utf16le(output.data(), len));
+  }
+}
+
+TEST(to_well_formed_utf16be_bad_input_self) {
+  std::mt19937 gen((std::mt19937::result_type)(42));
+  for (size_t i = 0; i < 1000; i++) {
+    auto utf16 = random_testcase(512, gen);
+    auto len = utf16.size();
+    std::vector<char16_t> flipped(utf16.size());
+    implementation.change_endianness_utf16(utf16.data(), utf16.size(),
+                                           flipped.data());
+    std::vector<char16_t> output = flipped;
+    implementation.to_well_formed_utf16be(output.data(), len, output.data());
+    for (size_t j = 0; j < len; j++) {
+      if (flipped[j] != output[j]) {
+#if SIMDUTF_IS_BIG_ENDIAN
+        ASSERT_TRUE(output[j] == 0xFFFD);
+#else
+        ASSERT_TRUE(output[j] == 0xFDFF);
+#endif
+      }
+    }
+    ASSERT_TRUE(implementation.validate_utf16be(output.data(), len));
+  }
+}
+
+TEST_MAIN

--- a/tests/to_well_formed_utf16.cpp
+++ b/tests/to_well_formed_utf16.cpp
@@ -9,6 +9,28 @@
 
 constexpr size_t trials = 1000;
 
+TEST_LOOP(trials, to_well_formed_utf16le_single_surrogate) {
+  for (size_t j = 0; j < 40; j++) {
+    std::vector<uint16_t> utf16(40);
+    utf16[j] = 0xD800;
+    const auto len = utf16.size();
+    std::vector<char16_t> output(len);
+    implementation.to_well_formed_utf16le((const char16_t *)utf16.data(), len,
+                                          output.data());
+    ASSERT_TRUE(output[j] == 0xFFFD);
+  }
+}
+TEST_LOOP(trials, to_well_formed_utf16be_single_surrogate) {
+  for (size_t j = 0; j < 40; j++) {
+    std::vector<uint16_t> utf16(40);
+    utf16[j] = 0x00D8;
+    const auto len = utf16.size();
+    std::vector<char16_t> output(len);
+    implementation.to_well_formed_utf16be((const char16_t *)utf16.data(), len,
+                                          output.data());
+    ASSERT_TRUE(output[j] == 0xFDFF);
+  }
+}
 // Should be the identity on valid input
 TEST_LOOP(trials,
           to_well_formed_utf16le_for_valid_input_surrogate_pairs_short) {

--- a/tests/to_well_formed_utf16.cpp
+++ b/tests/to_well_formed_utf16.cpp
@@ -135,11 +135,7 @@ TEST(to_well_formed_utf16le_bad_input) {
     implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
-#if SIMDUTF_IS_BIG_ENDIAN
-        ASSERT_TRUE(output[j] == 0xFDFF);
-#else
         ASSERT_TRUE(output[j] == 0xFFFD);
-#endif
       }
     }
     ASSERT_TRUE(implementation.validate_utf16le(output.data(), len));
@@ -155,11 +151,7 @@ TEST(to_well_formed_utf16be_bad_input) {
     implementation.to_well_formed_utf16be(utf16.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
-#if SIMDUTF_IS_BIG_ENDIAN
-        ASSERT_TRUE(output[j] == 0xFFFD);
-#else
         ASSERT_TRUE(output[j] == 0xFDFF);
-#endif
       }
     }
     ASSERT_TRUE(implementation.validate_utf16be(output.data(), len));
@@ -175,11 +167,7 @@ TEST(to_well_formed_utf16le_bad_input_self) {
     implementation.to_well_formed_utf16le(output.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
-#if SIMDUTF_IS_BIG_ENDIAN
-        ASSERT_TRUE(output[j] == 0xFDFF);
-#else
         ASSERT_TRUE(output[j] == 0xFFFD);
-#endif
       }
     }
     ASSERT_TRUE(implementation.validate_utf16le(output.data(), len));
@@ -195,11 +183,7 @@ TEST(to_well_formed_utf16be_bad_input_self) {
     implementation.to_well_formed_utf16be(output.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
-#if SIMDUTF_IS_BIG_ENDIAN
-        ASSERT_TRUE(output[j] == 0xFFFD);
-#else
         ASSERT_TRUE(output[j] == 0xFDFF);
-#endif
       }
     }
     ASSERT_TRUE(implementation.validate_utf16be(output.data(), len));

--- a/tests/to_well_formed_utf16.cpp
+++ b/tests/to_well_formed_utf16.cpp
@@ -20,6 +20,7 @@ TEST_LOOP(trials, to_well_formed_utf16le_single_surrogate) {
     ASSERT_TRUE(output[j] == 0xFFFD);
   }
 }
+
 TEST_LOOP(trials, to_well_formed_utf16be_single_surrogate) {
   for (size_t j = 0; j < 40; j++) {
     std::vector<uint16_t> utf16(40);

--- a/tests/to_well_formed_utf16.cpp
+++ b/tests/to_well_formed_utf16.cpp
@@ -9,6 +9,14 @@
 
 constexpr size_t trials = 1000;
 
+#if SIMDUTF_BIG_ENDIAN
+constexpr char16_t replacement_le = 0xFDFF;
+constexpr char16_t replacement_be = 0xFFFD;
+#else
+constexpr char16_t replacement_le = 0xFFFD;
+constexpr char16_t replacement_be = 0xFDFF;
+#endif
+
 TEST_LOOP(trials, to_well_formed_utf16le_single_surrogate) {
   for (size_t j = 0; j < 40; j++) {
     std::vector<uint16_t> utf16(40);
@@ -17,7 +25,7 @@ TEST_LOOP(trials, to_well_formed_utf16le_single_surrogate) {
     std::vector<char16_t> output(len);
     implementation.to_well_formed_utf16le((const char16_t *)utf16.data(), len,
                                           output.data());
-    ASSERT_TRUE(output[j] == 0xFFFD);
+    ASSERT_TRUE(output[j] == replacement_le);
   }
 }
 
@@ -29,7 +37,7 @@ TEST_LOOP(trials, to_well_formed_utf16be_single_surrogate) {
     std::vector<char16_t> output(len);
     implementation.to_well_formed_utf16be((const char16_t *)utf16.data(), len,
                                           output.data());
-    ASSERT_TRUE(output[j] == 0xFDFF);
+    ASSERT_TRUE(output[j] == replacement_be);
   }
 }
 // Should be the identity on valid input
@@ -136,7 +144,7 @@ TEST(to_well_formed_utf16le_bad_input) {
     implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
-        ASSERT_TRUE(output[j] == 0xFFFD);
+        ASSERT_TRUE(output[j] == replacement_le);
       }
     }
     ASSERT_TRUE(implementation.validate_utf16le(output.data(), len));
@@ -152,7 +160,7 @@ TEST(to_well_formed_utf16be_bad_input) {
     implementation.to_well_formed_utf16be(utf16.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
-        ASSERT_TRUE(output[j] == 0xFDFF);
+        ASSERT_TRUE(output[j] == replacement_be);
       }
     }
     ASSERT_TRUE(implementation.validate_utf16be(output.data(), len));
@@ -168,7 +176,7 @@ TEST(to_well_formed_utf16le_bad_input_self) {
     implementation.to_well_formed_utf16le(output.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
-        ASSERT_TRUE(output[j] == 0xFFFD);
+        ASSERT_TRUE(output[j] == replacement_le);
       }
     }
     ASSERT_TRUE(implementation.validate_utf16le(output.data(), len));
@@ -184,7 +192,7 @@ TEST(to_well_formed_utf16be_bad_input_self) {
     implementation.to_well_formed_utf16be(output.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
-        ASSERT_TRUE(output[j] == 0xFDFF);
+        ASSERT_TRUE(output[j] == replacement_be);
       }
     }
     ASSERT_TRUE(implementation.validate_utf16be(output.data(), len));

--- a/tests/to_well_formed_utf16.cpp
+++ b/tests/to_well_formed_utf16.cpp
@@ -22,13 +22,13 @@ TEST_LOOP(trials, to_well_formed_utf16le_single_surrogate) {
   std::vector<uint16_t> utf16(length);
   std::vector<char16_t> surrogates = {0xD800, 0xDC00, 0xDFFF, 0xD800, 0xDC00};
   for (size_t j = 0; j < length; j++) {
-    for(char16_t surrogate : surrogates) {
+    for (char16_t surrogate : surrogates) {
       utf16[j] = surrogate;
       const auto len = utf16.size();
       std::vector<char16_t> output(len);
       implementation.to_well_formed_utf16le((const char16_t *)utf16.data(), len,
                                             output.data());
-      ASSERT_TRUE(output[j] == replacement_le);
+      ASSERT_EQUAL(output[j], replacement_le);
       utf16[j] = 0x0000; // Reset to a valid character
     }
   }
@@ -43,7 +43,7 @@ TEST_LOOP(trials, to_well_formed_utf16be_single_surrogate) {
     std::vector<char16_t> output(len);
     implementation.to_well_formed_utf16be((const char16_t *)utf16.data(), len,
                                           output.data());
-    ASSERT_TRUE(output[j] == replacement_be);
+    ASSERT_EQUAL(output[j], replacement_be);
     utf16[j] = 0x0000; // Reset to a valid character
   }
 }
@@ -55,7 +55,7 @@ TEST_LOOP(trials,
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
   implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
-  ASSERT_TRUE(output == utf16);
+  ASSERT_EQUAL(output, utf16);
 }
 
 TEST_LOOP(trials,
@@ -65,7 +65,7 @@ TEST_LOOP(trials,
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
   implementation.to_well_formed_utf16be(utf16.data(), len, output.data());
-  ASSERT_TRUE(output == utf16);
+  ASSERT_EQUAL(output, utf16);
 }
 
 TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_surrogate_pairs_long) {
@@ -74,7 +74,7 @@ TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_surrogate_pairs_long) {
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
   implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
-  ASSERT_TRUE(output == utf16);
+  ASSERT_EQUAL(output, utf16);
 }
 
 TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_surrogate_pairs_long) {
@@ -83,7 +83,7 @@ TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_surrogate_pairs_long) {
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
   implementation.to_well_formed_utf16be(utf16.data(), len, output.data());
-  ASSERT_TRUE(output == utf16);
+  ASSERT_EQUAL(output, utf16);
 }
 
 TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_mixed_long) {
@@ -92,7 +92,7 @@ TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_mixed_long) {
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
   implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
-  ASSERT_TRUE(output == utf16);
+  ASSERT_EQUAL(output, utf16);
 }
 
 TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_mixed_long) {
@@ -101,7 +101,7 @@ TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_mixed_long) {
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
   implementation.to_well_formed_utf16be(utf16.data(), len, output.data());
-  ASSERT_TRUE(output == utf16);
+  ASSERT_EQUAL(output, utf16);
 }
 
 TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_mixed_long_self) {
@@ -110,7 +110,7 @@ TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_mixed_long_self) {
   const auto len = utf16.size();
   std::vector<char16_t> output = utf16;
   implementation.to_well_formed_utf16le(output.data(), len, output.data());
-  ASSERT_TRUE(output == utf16);
+  ASSERT_EQUAL(output, utf16);
 }
 
 TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_mixed_long_self) {
@@ -119,7 +119,7 @@ TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_mixed_long_self) {
   const auto len = utf16.size();
   std::vector<char16_t> output = utf16;
   implementation.to_well_formed_utf16be(output.data(), len, output.data());
-  ASSERT_TRUE(output == utf16);
+  ASSERT_EQUAL(output, utf16);
 }
 
 std::vector<char16_t> random_testcase(size_t n, std::mt19937 &rng) {
@@ -151,7 +151,7 @@ TEST(to_well_formed_utf16le_bad_input) {
     implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
-        ASSERT_TRUE(output[j] == replacement_le);
+        ASSERT_EQUAL(output[j], replacement_le);
       }
     }
     ASSERT_TRUE(implementation.validate_utf16le(output.data(), len));
@@ -167,7 +167,7 @@ TEST(to_well_formed_utf16be_bad_input) {
     implementation.to_well_formed_utf16be(utf16.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
-        ASSERT_TRUE(output[j] == replacement_be);
+        ASSERT_EQUAL(output[j], replacement_be);
       }
     }
     ASSERT_TRUE(implementation.validate_utf16be(output.data(), len));
@@ -183,7 +183,7 @@ TEST(to_well_formed_utf16le_bad_input_self) {
     implementation.to_well_formed_utf16le(output.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
-        ASSERT_TRUE(output[j] == replacement_le);
+        ASSERT_EQUAL(output[j], replacement_le);
       }
     }
     ASSERT_TRUE(implementation.validate_utf16le(output.data(), len));
@@ -199,7 +199,7 @@ TEST(to_well_formed_utf16be_bad_input_self) {
     implementation.to_well_formed_utf16be(output.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
-        ASSERT_TRUE(output[j] == replacement_be);
+        ASSERT_EQUAL(output[j], replacement_be);
       }
     }
     ASSERT_TRUE(implementation.validate_utf16be(output.data(), len));

--- a/tests/to_well_formed_utf16_tests.cpp
+++ b/tests/to_well_formed_utf16_tests.cpp
@@ -9,7 +9,7 @@
 
 constexpr size_t trials = 1000;
 
-#if SIMDUTF_BIG_ENDIAN
+#if SIMDUTF_IS_BIG_ENDIAN
 constexpr char16_t replacement_le = 0xFDFF;
 constexpr char16_t replacement_be = 0xFFFD;
 #else
@@ -20,18 +20,18 @@ constexpr char16_t replacement_be = 0xFDFF;
 TEST_LOOP(trials, to_well_formed_utf16le_single_surrogate) {
   const size_t length = 128;
   std::vector<uint16_t> utf16(length);
-#if SIMDUTF_BIG_ENDIAN
+#if SIMDUTF_IS_BIG_ENDIAN
   std::vector<char16_t> surrogates = {0x00D8, 0x00DC, 0xFFDF, 0x00D8, 0x00DC};
 #else
   std::vector<char16_t> surrogates = {0xD800, 0xDC00, 0xDFFF, 0xD800, 0xDC00};
 #endif
+  std::vector<char16_t> output(length);
   for (size_t j = 0; j < length; j++) {
     for (char16_t surrogate : surrogates) {
       utf16[j] = surrogate;
-      const auto len = utf16.size();
-      std::vector<char16_t> output(len);
-      implementation.to_well_formed_utf16le((const char16_t *)utf16.data(), len,
-                                            output.data());
+      std::fill(output.begin(), output.end(), 0);
+      implementation.to_well_formed_utf16le((const char16_t *)utf16.data(),
+                                            utf16.size(), output.data());
       ASSERT_EQUAL(output[j], replacement_le);
       utf16[j] = 0x0000; // Reset to a valid character
     }
@@ -41,18 +41,18 @@ TEST_LOOP(trials, to_well_formed_utf16le_single_surrogate) {
 TEST_LOOP(trials, to_well_formed_utf16be_single_surrogate) {
   const size_t length = 128;
   std::vector<uint16_t> utf16(length);
-#if SIMDUTF_BIG_ENDIAN
+#if SIMDUTF_IS_BIG_ENDIAN
   std::vector<char16_t> surrogates = {0xD800, 0xDC00, 0xDFFF, 0xD800, 0xDC00};
 #else
   std::vector<char16_t> surrogates = {0x00D8, 0x00DC, 0xFFDF, 0x00D8, 0x00DC};
 #endif
+  std::vector<char16_t> output(length);
   for (size_t j = 0; j < length; j++) {
     for (char16_t surrogate : surrogates) {
       utf16[j] = surrogate;
-      const auto len = utf16.size();
-      std::vector<char16_t> output(len);
-      implementation.to_well_formed_utf16be((const char16_t *)utf16.data(), len,
-                                            output.data());
+      std::fill(output.begin(), output.end(), 0);
+      implementation.to_well_formed_utf16be((const char16_t *)utf16.data(),
+                                            utf16.size(), output.data());
       ASSERT_EQUAL(output[j], replacement_be);
       utf16[j] = 0x0000; // Reset to a valid character
     }


### PR DESCRIPTION
fixes: https://github.com/simdutf/simdutf/issues/599

Effectively, we seek to provide JavaScript's toWellFormed.

I am using `wikipedia_mars/arabic.utf16.txt` (see https://github.com/lemire/unicode_lipsum#) as a reference. It is a *correct* file so we are basically benchmarking a copy (with checks).

Tests on an Apple  M2 with LLVM 15:

```
$  sudo ./build/benchmarks/benchmark -P run_to_well_formed_utf16 -F ../unicode_lipsum/wikipedia_mars/arabic.utf16.txt
Password:
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
Using ICU version 76.1
Using iconv version 267
Compiler: Clang 15.0.0
SIMDUTF version: 6.4.2
System: arm64
===========================
testcases: 1
input detected as UTF16 little-endian
===========================
run_to_well_formed_utf16+arm64, input size: 849690, iterations: 30000, dataset: ../unicode_lipsum/wikipedia_mars/arabic.utf16.txt
   0.446 ins/byte,    0.131 cycle/byte,   27.783 GB/s (3.2 %),     3.637 GHz,    3.410 ins/cycle 
   0.893 ins/char,    0.262 cycle/char,   13.892 Gc/s (3.2 %)     2.00 byte/char  30583.0 ns
run_to_well_formed_utf16+fallback, input size: 849690, iterations: 30000, dataset: ../unicode_lipsum/wikipedia_mars/arabic.utf16.txt
   8.017 ins/byte,    1.172 cycle/byte,    3.001 GB/s (7.1 %),     3.518 GHz,    6.838 ins/cycle 
  16.033 ins/char,    2.345 cycle/char,    1.501 Gc/s (7.1 %)     2.00 byte/char 283125.0 ns
```


Tests on an Intel Ice Lake with GCC 12:

```
$ ./buildrelease/benchmarks/benchmark -P run_to_well_formed_utf16 -F unicode_lipsum/wikipedia_mars/arabic.utf16.txt 
We define the number of bytes to be the number of *input* bytes.
We define a 'char' to be a code point (between 1 and 4 bytes).
Using ICU version 67.1
Compiler: GCC 12.2.1
SIMDUTF version: 6.4.2
System: icelake
===========================
testcases: 1
input detected as UTF16 little-endian
===========================
run_to_well_formed_utf16+fallback, input size: 849690, iterations: 3000, dataset: unicode_lipsum/wikipedia_mars/arabic.utf16.txt
   8.000 ins/byte,    1.502 cycle/byte,    2.126 GB/s (16.9 %),     3.193 GHz,    5.326 ins/cycle 
  16.001 ins/char,    3.004 cycle/char,    1.063 Gc/s (16.9 %)     2.00 byte/char 399723.0 ns
WARNING: Measurements are noisy, try increasing iteration count (-I).
run_to_well_formed_utf16+haswell, input size: 849690, iterations: 3000, dataset: unicode_lipsum/wikipedia_mars/arabic.utf16.txt
   0.375 ins/byte,    0.173 cycle/byte,   18.444 GB/s (1.2 %),     3.199 GHz,    2.164 ins/cycle 
   0.751 ins/char,    0.347 cycle/char,    9.222 Gc/s (1.2 %)     2.00 byte/char  46069.0 ns
run_to_well_formed_utf16+icelake, input size: 849690, iterations: 3000, dataset: unicode_lipsum/wikipedia_mars/arabic.utf16.txt
   0.203 ins/byte,    0.185 cycle/byte,   16.750 GB/s (1.2 %),     3.099 GHz,    1.100 ins/cycle 
   0.407 ins/char,    0.370 cycle/char,    8.375 Gc/s (1.2 %)     2.00 byte/char  50727.0 ns
run_to_well_formed_utf16+westmere, input size: 849690, iterations: 3000, dataset: unicode_lipsum/wikipedia_mars/arabic.utf16.txt
   1.000 ins/byte,    0.226 cycle/byte,   14.177 GB/s (1.1 %),     3.198 GHz,    4.435 ins/cycle 
   2.001 ins/char,    0.451 cycle/char,    7.088 Gc/s (1.1 %)     2.00 byte/char  59935.0 ns
```

Interestingly, the icelake function comes up slightly under the haswell one. The result is robust (switching to clang does not change this observation). But the difference is small so I am tempted to ignore the issue for now.

Joint work with @clausecker 