### PR TITLE
Fixing AVX-512 performance bug

### DIFF
--- a/src/icelake/icelake_convert_utf32_to_utf16.inl.cpp
+++ b/src/icelake/icelake_convert_utf32_to_utf16.inl.cpp
@@ -70,8 +70,13 @@ avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
             2, 3, 0, 1);
         in = _mm512_shuffle_epi8(in, swap_512);
       }
-      _mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
-      utf16_output += _mm_popcnt_u32(output_mask);
+      // we deliberately avoid _mm512_mask_compressstoreu_epi16 for portability
+      // (AMD Zen4 has terrible performance with it, it is effectively broken)
+      __m512i compressed = _mm512_maskz_compress_epi16(output_mask, in);
+      auto written_out = _mm_popcnt_u32(output_mask);
+      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u64(0xFFFFFFFFFFFFFFFFULL, written_out), compressed);
+      //_mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
+      utf16_output += written_out;
       buf += 16;
     }
   }
@@ -125,8 +130,13 @@ avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
             2, 3, 0, 1);
         in = _mm512_shuffle_epi8(in, swap_512);
       }
-      _mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
-      utf16_output += _mm_popcnt_u32(output_mask);
+      // we deliberately avoid _mm512_mask_compressstoreu_epi16 for portability
+      // (AMD Zen4 has terrible performance with it, it is effectively broken)
+      __m512i compressed = _mm512_maskz_compress_epi16(output_mask, in);
+      auto written_out = _mm_popcnt_u32(output_mask);
+      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u64(0xFFFFFFFFFFFFFFFFULL, written_out), compressed);
+      //_mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
+      utf16_output += written_out;
       buf += remaining_len;
     }
   }
@@ -224,8 +234,13 @@ avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
             2, 3, 0, 1);
         in = _mm512_shuffle_epi8(in, swap_512);
       }
-      _mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
-      utf16_output += _mm_popcnt_u32(output_mask);
+      // we deliberately avoid _mm512_mask_compressstoreu_epi16 for portability
+      // (AMD Zen4 has terrible performance with it, it is effectively broken)
+      __m512i compressed = _mm512_maskz_compress_epi16(output_mask, in);
+      auto written_out = _mm_popcnt_u32(output_mask);
+      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u64(0xFFFFFFFFFFFFFFFFULL, written_out), compressed);
+      //_mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
+      utf16_output +=written_out;
       if (simdutf_unlikely(err)) {
         return std::make_pair(result(code, buf - start + error_idx),
                               utf16_output);
@@ -300,8 +315,13 @@ avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
             2, 3, 0, 1);
         in = _mm512_shuffle_epi8(in, swap_512);
       }
-      _mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
-      utf16_output += _mm_popcnt_u32(output_mask);
+      // we deliberately avoid _mm512_mask_compressstoreu_epi16 for portability
+      // (AMD Zen4 has terrible performance with it, it is effectively broken)
+      __m512i compressed = _mm512_maskz_compress_epi16(output_mask, in);
+      auto written_out = _mm_popcnt_u32(output_mask);
+      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u64(0xFFFFFFFFFFFFFFFFULL, written_out), compressed);
+      //_mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
+      utf16_output += written_out;
       if (simdutf_unlikely(err)) {
         return std::make_pair(result(code, buf - start + error_idx),
                               utf16_output);

--- a/src/icelake/icelake_convert_utf32_to_utf16.inl.cpp
+++ b/src/icelake/icelake_convert_utf32_to_utf16.inl.cpp
@@ -74,7 +74,7 @@ avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
       // (AMD Zen4 has terrible performance with it, it is effectively broken)
       __m512i compressed = _mm512_maskz_compress_epi16(output_mask, in);
       auto written_out = _mm_popcnt_u32(output_mask);
-      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u64(0xFFFFFFFFFFFFFFFFULL, written_out), compressed);
+      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u32(0xFFFFFFFF, written_out), compressed);
       //_mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
       utf16_output += written_out;
       buf += 16;
@@ -134,7 +134,7 @@ avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
       // (AMD Zen4 has terrible performance with it, it is effectively broken)
       __m512i compressed = _mm512_maskz_compress_epi16(output_mask, in);
       auto written_out = _mm_popcnt_u32(output_mask);
-      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u64(0xFFFFFFFFFFFFFFFFULL, written_out), compressed);
+      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u32(0xFFFFFFFF, written_out), compressed);
       //_mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
       utf16_output += written_out;
       buf += remaining_len;
@@ -238,7 +238,7 @@ avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
       // (AMD Zen4 has terrible performance with it, it is effectively broken)
       __m512i compressed = _mm512_maskz_compress_epi16(output_mask, in);
       auto written_out = _mm_popcnt_u32(output_mask);
-      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u64(0xFFFFFFFFFFFFFFFFULL, written_out), compressed);
+      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u32(0xFFFFFFFF, written_out), compressed);
       //_mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
       utf16_output +=written_out;
       if (simdutf_unlikely(err)) {
@@ -319,7 +319,7 @@ avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
       // (AMD Zen4 has terrible performance with it, it is effectively broken)
       __m512i compressed = _mm512_maskz_compress_epi16(output_mask, in);
       auto written_out = _mm_popcnt_u32(output_mask);
-      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u64(0xFFFFFFFFFFFFFFFFULL, written_out), compressed);
+      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u32(0xFFFFFFFF, written_out), compressed);
       //_mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
       utf16_output += written_out;
       if (simdutf_unlikely(err)) {

--- a/src/icelake/icelake_convert_utf32_to_utf16.inl.cpp
+++ b/src/icelake/icelake_convert_utf32_to_utf16.inl.cpp
@@ -74,7 +74,8 @@ avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
       // (AMD Zen4 has terrible performance with it, it is effectively broken)
       __m512i compressed = _mm512_maskz_compress_epi16(output_mask, in);
       auto written_out = _mm_popcnt_u32(output_mask);
-      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u32(0xFFFFFFFF, written_out), compressed);
+      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u32(0xFFFFFFFF, written_out),
+                               compressed);
       //_mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
       utf16_output += written_out;
       buf += 16;
@@ -134,7 +135,8 @@ avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
       // (AMD Zen4 has terrible performance with it, it is effectively broken)
       __m512i compressed = _mm512_maskz_compress_epi16(output_mask, in);
       auto written_out = _mm_popcnt_u32(output_mask);
-      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u32(0xFFFFFFFF, written_out), compressed);
+      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u32(0xFFFFFFFF, written_out),
+                               compressed);
       //_mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
       utf16_output += written_out;
       buf += remaining_len;
@@ -238,9 +240,10 @@ avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
       // (AMD Zen4 has terrible performance with it, it is effectively broken)
       __m512i compressed = _mm512_maskz_compress_epi16(output_mask, in);
       auto written_out = _mm_popcnt_u32(output_mask);
-      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u32(0xFFFFFFFF, written_out), compressed);
+      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u32(0xFFFFFFFF, written_out),
+                               compressed);
       //_mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
-      utf16_output +=written_out;
+      utf16_output += written_out;
       if (simdutf_unlikely(err)) {
         return std::make_pair(result(code, buf - start + error_idx),
                               utf16_output);
@@ -319,7 +322,8 @@ avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
       // (AMD Zen4 has terrible performance with it, it is effectively broken)
       __m512i compressed = _mm512_maskz_compress_epi16(output_mask, in);
       auto written_out = _mm_popcnt_u32(output_mask);
-      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u32(0xFFFFFFFF, written_out), compressed);
+      _mm512_mask_storeu_epi16(utf16_output, _bzhi_u32(0xFFFFFFFF, written_out),
+                               compressed);
       //_mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
       utf16_output += written_out;
       if (simdutf_unlikely(err)) {

--- a/src/icelake/icelake_utf8_common.inl.cpp
+++ b/src/icelake/icelake_utf8_common.inl.cpp
@@ -515,7 +515,8 @@ simdutf_really_inline size_t utf32_to_utf16_masked(const __m512i byteflip,
     // (AMD Zen4 has terrible performance with it, it is effectively broken)
     __m512i compressed = _mm512_maskz_compress_epi16(nonzero_masked, t5);
     _mm512_mask_storeu_epi16(
-        output, _bzhi_u32(0xFFFFFFFF, count + _mm_popcnt_u32(sp_mask)), compressed);
+        output, _bzhi_u32(0xFFFFFFFF, count + _mm_popcnt_u32(sp_mask)),
+        compressed);
     //_mm512_mask_compressstoreu_epi16(output, nonzero_masked, t5);
   }
 

--- a/src/icelake/icelake_utf8_common.inl.cpp
+++ b/src/icelake/icelake_utf8_common.inl.cpp
@@ -515,9 +515,7 @@ simdutf_really_inline size_t utf32_to_utf16_masked(const __m512i byteflip,
     // (AMD Zen4 has terrible performance with it, it is effectively broken)
     __m512i compressed = _mm512_maskz_compress_epi16(nonzero_masked, t5);
     _mm512_mask_storeu_epi16(
-        output,
-        (1 << (count + static_cast<unsigned int>(count_ones(sp_mask)))) - 1,
-        compressed);
+        output, _bzhi_u32(0xFFFFFFFF, count + _mm_popcnt_u32(sp_mask)), compressed);
     //_mm512_mask_compressstoreu_epi16(output, nonzero_masked, t5);
   }
 

--- a/src/icelake/icelake_utf8_common.inl.cpp
+++ b/src/icelake/icelake_utf8_common.inl.cpp
@@ -512,7 +512,7 @@ simdutf_really_inline size_t utf32_to_utf16_masked(const __m512i byteflip,
       t5 = _mm512_shuffle_epi8(t5, byteflip);
     }
     // we deliberately avoid _mm512_mask_compressstoreu_epi16 for portability
-    // (zen4)
+    // (AMD Zen4 has terrible performance with it, it is effectively broken)
     __m512i compressed = _mm512_maskz_compress_epi16(nonzero_masked, t5);
     _mm512_mask_storeu_epi16(
         output,


### PR DESCRIPTION
[We recently upgraded the UTF-32 to UTF-16 conversion functions in the icelake kernel](https://github.com/simdutf/simdutf/commit/123ddb7344886a35ab33d13c5643e98ad99d3267). Specifically, [Shreesh Adiga](https://github.com/tantei3) did (@tantei3). The code is fine for Intel processors... and if you just read it out, it great work. Unfortunately, we used `_mm512_mask_compressstoreu_epi16` which is a big issue. Under AMD processors, this can compile down to code that it is very slow. Effectively, AMD Zen 4 does not support it and they microcoded some hack.

If I knew how, I'd make it impossible to use this intrinsic in the future.