### PR TITLE
x86 targets: simplify UTF-32 to UTF-8

### DIFF
--- a/src/haswell/avx2_convert_utf32_to_utf8.cpp
+++ b/src/haswell/avx2_convert_utf32_to_utf8.cpp
@@ -7,7 +7,6 @@ avx2_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
   const __m256i v_f800 = _mm256_set1_epi16((uint16_t)0xf800);
   const __m256i v_c080 = _mm256_set1_epi16((uint16_t)0xc080);
   const __m256i v_7fffffff = _mm256_set1_epi32((uint32_t)0x7fffffff);
-  __m256i running_max = _mm256_setzero_si256();
   __m256i forbidden_bytemask = _mm256_setzero_si256();
 
   const size_t safety_margin =
@@ -17,7 +16,6 @@ avx2_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
   while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
     __m256i in = _mm256_loadu_si256((__m256i *)buf);
     __m256i nextin = _mm256_loadu_si256((__m256i *)buf + 1);
-    running_max = _mm256_max_epu32(_mm256_max_epu32(in, running_max), nextin);
 
     // Pack 32-bit UTF-32 code units to 16-bit UTF-16 code units with unsigned
     // saturation
@@ -267,12 +265,6 @@ avx2_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
   } // while
 
   // check for invalid input
-  const __m256i v_10ffff = _mm256_set1_epi32((uint32_t)0x10ffff);
-  if (static_cast<uint32_t>(_mm256_movemask_epi8(_mm256_cmpeq_epi32(
-          _mm256_max_epu32(running_max, v_10ffff), v_10ffff))) != 0xffffffff) {
-    return std::make_pair(nullptr, utf8_output);
-  }
-
   if (static_cast<uint32_t>(_mm256_movemask_epi8(forbidden_bytemask)) != 0) {
     return std::make_pair(nullptr, utf8_output);
   }

--- a/src/icelake/icelake_convert_utf32_to_utf8.inl.cpp
+++ b/src/icelake/icelake_convert_utf32_to_utf8.inl.cpp
@@ -11,7 +11,6 @@ avx512_convert_utf32_to_utf8(const char32_t *buf, size_t len,
   const __m256i v_f800 = _mm256_set1_epi16((uint16_t)0xf800);
   const __m256i v_c080 = _mm256_set1_epi16((uint16_t)0xc080);
   const __m256i v_7fffffff = _mm256_set1_epi32((uint32_t)0x7fffffff);
-  __m256i running_max = _mm256_setzero_si256();
   __m256i forbidden_bytemask = _mm256_setzero_si256();
 
   const size_t safety_margin =
@@ -21,7 +20,6 @@ avx512_convert_utf32_to_utf8(const char32_t *buf, size_t len,
   while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
     __m256i in = _mm256_loadu_si256((__m256i *)buf);
     __m256i nextin = _mm256_loadu_si256((__m256i *)buf + 1);
-    running_max = _mm256_max_epu32(_mm256_max_epu32(in, running_max), nextin);
 
     // Pack 32-bit UTF-32 code units to 16-bit UTF-16 code units with unsigned
     // saturation
@@ -271,12 +269,6 @@ avx512_convert_utf32_to_utf8(const char32_t *buf, size_t len,
   } // while
 
   // check for invalid input
-  const __m256i v_10ffff = _mm256_set1_epi32((uint32_t)0x10ffff);
-  if (static_cast<uint32_t>(_mm256_movemask_epi8(_mm256_cmpeq_epi32(
-          _mm256_max_epu32(running_max, v_10ffff), v_10ffff))) != 0xffffffff) {
-    return std::make_pair(nullptr, utf8_output);
-  }
-
   if (static_cast<uint32_t>(_mm256_movemask_epi8(forbidden_bytemask)) != 0) {
     return std::make_pair(nullptr, utf8_output);
   }

--- a/src/westmere/sse_convert_utf32_to_utf8.cpp
+++ b/src/westmere/sse_convert_utf32_to_utf8.cpp
@@ -13,7 +13,6 @@ sse_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
       (uint32_t)0xffff0000); // 1111 1111 1111 1111 0000 0000 0000 0000
   const __m128i v_7fffffff = _mm_set1_epi32(
       (uint32_t)0x7fffffff); // 0111 1111 1111 1111 1111 1111 1111 1111
-  __m128i running_max = _mm_setzero_si128();
   __m128i forbidden_bytemask = _mm_setzero_si128();
   const size_t safety_margin =
       12; // to avoid overruns, see issue
@@ -28,11 +27,6 @@ sse_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
     __m128i in = _mm_loadu_si128((__m128i *)buf);
     __m128i nextin = _mm_loadu_si128(
         (__m128i *)buf + 1); // These two values can hold only 8 UTF32 chars
-    running_max = _mm_max_epu32(
-        _mm_max_epu32(in, running_max), // take element-wise max char32_t from
-                                        // in and running_max vector
-        nextin); // and take element-wise max element from nextin and
-                 // running_max vector
 
     // Pack 32-bit UTF-32 code units to 16-bit UTF-16 code units with unsigned
     // saturation
@@ -60,9 +54,6 @@ sse_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
     if (_mm_testz_si128(in_16, v_ff80)) { // if the first two blocks are ASCII
       __m128i thirdin = _mm_loadu_si128((__m128i *)buf + 2);
       __m128i fourthin = _mm_loadu_si128((__m128i *)buf + 3);
-      running_max = _mm_max_epu32(
-          _mm_max_epu32(thirdin, running_max),
-          fourthin); // take the running max of all 4 vectors thus far
       __m128i nextin_16 = _mm_packus_epi32(
           _mm_and_si128(thirdin, v_7fffffff),
           _mm_and_si128(fourthin,
@@ -316,12 +307,6 @@ sse_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
   } // while
 
   // check for invalid input
-  const __m128i v_10ffff = _mm_set1_epi32((uint32_t)0x10ffff);
-  if (static_cast<uint16_t>(_mm_movemask_epi8(_mm_cmpeq_epi32(
-          _mm_max_epu32(running_max, v_10ffff), v_10ffff))) != 0xffff) {
-    return std::make_pair(nullptr, utf8_output);
-  }
-
   if (static_cast<uint32_t>(_mm_movemask_epi8(forbidden_bytemask)) != 0) {
     return std::make_pair(nullptr, utf8_output);
   }


### PR DESCRIPTION
There is not point in vectorized validating for code points greater than 0x10_ffff. The blocks having code points with non-zero higher 16-bits are processed by a scalar code that detects this kind of error anyway.