### PR TITLE
base64: add specialisation for compressing

### DIFF
--- a/scripts/base64bench_print.py
+++ b/scripts/base64bench_print.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+
+import sys
+from itertools import chain
+from pathlib import Path
+from table import Table
+
+
+HELP = """
+$ base64bench_print.py old.txt old.new
+"""
+
+
+def main():
+    script = sys.argv[0]
+    args = sys.argv[1:]
+    n = len(args)
+    if "-h" in args or "--help" in args or (n != 2):
+        print(HELP)
+        return
+
+    if n == 2:
+        with open(args[0]) as f:
+            old = parse(f.read())
+        with open(args[1]) as f:
+            new = parse(f.read())
+
+        compare(old, new)
+
+
+def compare(old, new):
+    if old.metainfo != new.metainfo:
+        print(old.metainfo)
+        print(new.metainfo)
+        return
+
+    all = {impl: True for impl in chain(old.measurements.keys(), new.measurements.keys())}
+
+    mi = old.metainfo
+    title = '%s of %d bytes from %d input(s)' % (mi.mode, mi.volume, mi.inputs_count)
+
+    table = Table()
+    table.add_header([(title, 4)])
+    table.add_header(["implementation", "old [GB/s]", "new [GB/s]", "speedup"])
+    for impl in all:
+        try:
+            old_speed = old.measurements[impl]
+        except KeyError:
+            old_speed = None
+
+        try:
+            new_speed = new.measurements[impl]
+        except KeyError:
+            new_speed = None
+
+        if old_speed is not None and new_speed is not None:
+            speedup = '%0.2fx' % (new_speed / old_speed)
+            new_speed = '%0.2f' % new_speed
+            old_speed = '%0.2f' % old_speed
+
+        if old_speed is None:
+            old_speed = '--'
+            speedup   = '--'
+
+        if new_speed is None:
+            new_speed = '--'
+            speedup   = '--'
+
+        table.add_row([impl, old_speed, new_speed, speedup])
+
+    print(table)
+
+
+class Data:
+    def __init__(self, mi):
+        self.metainfo = mi
+        self.measurements = {}
+
+
+def parse(string):
+    data = Data(parse_metainfo(string))
+    for line in string.splitlines():
+        line = line.rstrip()
+        if not line:
+            continue
+
+        if not line.startswith('#'):
+            impl, speed = parse_result(line)
+            data.measurements[impl] = speed
+
+    return data
+
+
+def parse_metainfo(string):
+    mi = Metainfo()
+    mi.system = clip(string, '# current system detected as ', '.')
+    mi.volume = int(clip(string, '# volume: ', ' bytes'))
+    mi.max_length = int(clip(string, '# max length: ', ' bytes'))
+    mi.inputs_count = int(clip(string, '# number of inputs: ', '\n'))
+
+    modes = [
+        ('# decode', 'decoding'),
+    ]
+
+    for frag, mode in modes:
+        if frag in string:
+            mi.mode = mode
+            break
+
+    return mi
+
+
+class Metainfo:
+    def __init__(self):
+        self.system = None
+        self.volume = None
+        self.max_length = None
+        self.inputs_count = None
+        self.mode = None
+
+    def __eq__(self, other):
+        return vars(self) == vars(other)
+
+
+def parse_result(line):
+    name, sep, values = line.rpartition(':')
+    name = name.strip()
+
+    values = values.split()
+
+    return (name, float(values[0]))
+
+
+def clip(s, sep1, sep2):
+    before, sep, after = s.partition(sep1)
+    if sep == '':
+        return None
+
+    between, sep, after = after.partition(sep2)
+    assert sep == sep2
+
+    return between
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/benchmark_print.py
+++ b/scripts/benchmark_print.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import sys
-import warnings
 from pathlib import Path
 from table import Table
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,7 @@ else(MSVC)
   endif()
   target_compile_options(simdutf PRIVATE -Wall -Wextra -Weffc++)
   target_compile_options(simdutf PRIVATE -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wconversion -Wno-sign-conversion -Wunused-function)
-  #target_compile_options(simdutf PRIVATE -Wfatal-errors)
+  target_compile_options(simdutf PRIVATE -Wfatal-errors)
 endif(MSVC)
 
 # workaround for GNU GCC poor AVX load/store code generation

--- a/src/haswell/avx2_base64.cpp
+++ b/src/haswell/avx2_base64.cpp
@@ -354,6 +354,8 @@ static inline void load_block(block64 *b, const char16_t *src) {
   b->chunks[1] = _mm256_packus_epi16(m3p, m4p);
 }
 
+template <typename T> bool is_power_of_two(T x) { return (x & (x - 1)) == 0; }
+
 static inline void base64_decode(char *out, __m256i str) {
   // credit: aqrit
   const __m256i pack_shuffle =
@@ -391,6 +393,78 @@ static inline void base64_decode_block_safe(char *out, block64 *b) {
   char buffer[32]; // We enforce safety with a buffer.
   base64_decode(buffer, b->chunks[1]);
   std::memcpy(out + 24, buffer, 24);
+}
+
+simdutf_really_inline static size_t
+compress_block_single(block64 *b, uint64_t mask, char *output) {
+  const size_t pos64 = _tzcnt_u64(mask);
+  const int8_t pos = pos64 & 0xf;
+  switch (pos64 >> 4) {
+  case 0b00: {
+    const __m128i lane0 = _mm256_extracti128_si256(b->chunks[0], 0);
+    const __m128i lane1 = _mm256_extracti128_si256(b->chunks[0], 1);
+
+    const __m128i v0 = _mm_set1_epi8(char(pos - 1));
+    const __m128i v1 =
+        _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    const __m128i v2 = _mm_cmpgt_epi8(v1, v0);
+    const __m128i sh = _mm_sub_epi8(v1, v2);
+    const __m128i compressed = _mm_shuffle_epi8(lane0, sh);
+
+    _mm_storeu_si128((__m128i *)(output + 0 * 16), compressed);
+    _mm_storeu_si128((__m128i *)(output + 1 * 16 - 1), lane1);
+    _mm256_storeu_si256((__m256i *)(output + 2 * 16 - 1), b->chunks[1]);
+  } break;
+  case 0b01: {
+    const __m128i lane0 = _mm256_extracti128_si256(b->chunks[0], 0);
+    const __m128i lane1 = _mm256_extracti128_si256(b->chunks[0], 1);
+    _mm_storeu_si128((__m128i *)(output + 0 * 16), lane0);
+
+    const __m128i v0 = _mm_set1_epi8(char(pos - 1));
+    const __m128i v1 =
+        _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    const __m128i v2 = _mm_cmpgt_epi8(v1, v0);
+    const __m128i sh = _mm_sub_epi8(v1, v2);
+    const __m128i compressed = _mm_shuffle_epi8(lane1, sh);
+
+    _mm_storeu_si128((__m128i *)(output + 1 * 16), compressed);
+    _mm256_storeu_si256((__m256i *)(output + 2 * 16 - 1), b->chunks[1]);
+  } break;
+  case 0b10: {
+    const __m128i lane2 = _mm256_extracti128_si256(b->chunks[1], 0);
+    const __m128i lane3 = _mm256_extracti128_si256(b->chunks[1], 1);
+
+    _mm256_storeu_si256((__m256i *)(output + 0 * 16), b->chunks[0]);
+
+    const __m128i v0 = _mm_set1_epi8(char(pos - 1));
+    const __m128i v1 =
+        _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    const __m128i v2 = _mm_cmpgt_epi8(v1, v0);
+    const __m128i sh = _mm_sub_epi8(v1, v2);
+    const __m128i compressed = _mm_shuffle_epi8(lane2, sh);
+
+    _mm_storeu_si128((__m128i *)(output + 2 * 16), compressed);
+    _mm_storeu_si128((__m128i *)(output + 3 * 16 - 1), lane3);
+  } break;
+  case 0b11: {
+    const __m128i lane2 = _mm256_extracti128_si256(b->chunks[1], 0);
+    const __m128i lane3 = _mm256_extracti128_si256(b->chunks[1], 1);
+
+    _mm256_storeu_si256((__m256i *)(output + 0 * 16), b->chunks[0]);
+    _mm_storeu_si128((__m128i *)(output + 2 * 16), lane2);
+
+    const __m128i v0 = _mm_set1_epi8(char(pos - 1));
+    const __m128i v1 =
+        _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    const __m128i v2 = _mm_cmpgt_epi8(v1, v0);
+    const __m128i sh = _mm_sub_epi8(v1, v2);
+    const __m128i compressed = _mm_shuffle_epi8(lane3, sh);
+
+    _mm_storeu_si128((__m128i *)(output + 3 * 16), compressed);
+  } break;
+  }
+
+  return 63;
 }
 
 template <bool base64_url, bool ignore_garbage, typename chartype>
@@ -463,10 +537,14 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                 size_t(src - srcinit + error_offset), size_t(dst - dstinit)};
       }
       if (badcharmask != 0) {
-        // optimization opportunity: check for simple masks like those made of
-        // continuous 1s followed by continuous 0s. And masks containing a
-        // single bad character.
-        bufferptr += compress_block(&b, badcharmask, bufferptr);
+        if (is_power_of_two(badcharmask)) {
+          // optimization opportunity: check for simple masks like those made of
+          // continuous 1s followed by continuous 0s. And masks containing a
+          // single bad character.
+          bufferptr += compress_block_single(&b, badcharmask, bufferptr);
+        } else {
+          bufferptr += compress_block(&b, badcharmask, bufferptr);
+        }
       } else if (bufferptr != buffer) {
         copy_block(&b, bufferptr);
         bufferptr += 64;


### PR DESCRIPTION
It's often that the whole block of input contains only one "bad" character. To compress such a simple case, a specialised procedure was introduced for *Westemre* and *Haswell* targets.

Performance results for command `./benchmark_base64 -f simdutf -d base64data/email/*` (https://github.com/lemire/base64data)

### Ryzen 7

```
+------------------------------------------------------------------------+
|               decoding of 1976492 bytes from 15 input(s)               |
+------------------------------------+------------+------------+---------+
|           implementation           | old [GB/s] | new [GB/s] | speedup |
+====================================+============+============+=========+
| simdutf::haswell                   |      12.69 |      14.98 | 1.18x   |
+------------------------------------+------------+------------+---------+
| simdutf::haswell (accept garbage)  |      13.82 |      16.68 | 1.21x   |
+------------------------------------+------------+------------+---------+
| simdutf::westmere                  |       8.51 |       9.77 | 1.15x   |
+------------------------------------+------------+------------+---------+
| simdutf::westmere (accept garbage) |       8.95 |      10.83 | 1.21x   |
+------------------------------------+------------+------------+---------+
| simdutf::fallback                  |       2.20 |       2.24 | 1.02x   |
+------------------------------------+------------+------------+---------+
| simdutf::fallback (accept garbage) |       2.20 |       2.22 | 1.01x   |
+------------------------------------+------------+------------+---------+
```

### Skylake-X

```
+------------------------------------------------------------------------+
|               decoding of 1976492 bytes from 15 input(s)               |
+------------------------------------+------------+------------+---------+
|           implementation           | old [GB/s] | new [GB/s] | speedup |
+====================================+============+============+=========+
| simdutf::haswell                   |       7.21 |       8.25 | 1.14x   |
+------------------------------------+------------+------------+---------+
| simdutf::haswell (accept garbage)  |       7.57 |       8.70 | 1.15x   |
+------------------------------------+------------+------------+---------+
| simdutf::westmere                  |       4.89 |       5.35 | 1.09x   |
+------------------------------------+------------+------------+---------+
| simdutf::westmere (accept garbage) |       5.07 |       6.13 | 1.21x   |
+------------------------------------+------------+------------+---------+
| simdutf::fallback                  |       1.88 |       1.87 | 0.99x   |
+------------------------------------+------------+------------+---------+
| simdutf::fallback (accept garbage) |       1.88 |       1.87 | 0.99x   |
+------------------------------------+------------+------------+---------+
```

### Icelake

```
+------------------------------------------------------------------------+
|               decoding of 1976492 bytes from 15 input(s)               |
+------------------------------------+------------+------------+---------+
|           implementation           | old [GB/s] | new [GB/s] | speedup |
+====================================+============+============+=========+
| simdutf::icelake                   |      11.14 |      11.80 | 1.06x   |
+------------------------------------+------------+------------+---------+
| simdutf::icelake (accept garbage)  |      13.79 |      13.80 | 1.00x   |
+------------------------------------+------------+------------+---------+
| simdutf::haswell                   |       8.12 |      10.89 | 1.34x   |
+------------------------------------+------------+------------+---------+
| simdutf::haswell (accept garbage)  |       9.65 |      11.33 | 1.17x   |
+------------------------------------+------------+------------+---------+
| simdutf::westmere                  |       6.00 |       6.97 | 1.16x   |
+------------------------------------+------------+------------+---------+
| simdutf::westmere (accept garbage) |       6.43 |       7.69 | 1.20x   |
+------------------------------------+------------+------------+---------+
```