### PR TITLE
tests: add additional UTF-8 to UTF-16 tests

### DIFF
--- a/tests/convert_utf8_to_utf16be_tests.cpp
+++ b/tests/convert_utf8_to_utf16be_tests.cpp
@@ -330,6 +330,44 @@ TEST_LOOP(trials, convert_3_or_4_UTF8_bytes) {
   }
 }
 
+TEST_LOOP(trials, convert_2_UTF8_bytes) {
+  simdutf::tests::helpers::RandomInt random(0x0080, 0x07ff,
+                                            seed); // range for 2 UTF-8 bytes
+
+  auto procedure = [&implementation](const char *utf8, size_t size,
+                                     char16_t *utf16) -> size_t {
+    return implementation.convert_utf8_to_utf16be(utf8, size, utf16);
+  };
+  auto size_procedure = [&implementation](const char *utf8,
+                                          size_t size) -> size_t {
+    return implementation.utf16_length_from_utf8(utf8, size);
+  };
+  for (size_t size : input_size) {
+    transcode_utf8_to_utf16_test_base test(random, size);
+    ASSERT_TRUE(test(procedure));
+    ASSERT_TRUE(test.check_size(size_procedure));
+  }
+}
+
+TEST_LOOP(trials, convert_3_UTF8_bytes) {
+  simdutf::tests::helpers::RandomInt random(0x0800, 0xd800 - 1,
+                                            seed); // range for 3 UTF-8 bytes
+
+  auto procedure = [&implementation](const char *utf8, size_t size,
+                                     char16_t *utf16) -> size_t {
+    return implementation.convert_utf8_to_utf16be(utf8, size, utf16);
+  };
+  auto size_procedure = [&implementation](const char *utf8,
+                                          size_t size) -> size_t {
+    return implementation.utf16_length_from_utf8(utf8, size);
+  };
+  for (size_t size : input_size) {
+    transcode_utf8_to_utf16_test_base test(random, size);
+    ASSERT_TRUE(test(procedure));
+    ASSERT_TRUE(test.check_size(size_procedure));
+  }
+}
+
 TEST(special_cases) {
   const uint8_t utf8[] = {0xC2, 0xA9};     // copyright sign
   const uint8_t expected[] = {0x00, 0xA9}; // expected UTF-16BE

--- a/tests/convert_utf8_to_utf16be_with_errors_tests.cpp
+++ b/tests/convert_utf8_to_utf16be_with_errors_tests.cpp
@@ -235,6 +235,56 @@ TEST_LOOP(trials, convert_3_or_4_UTF8_bytes) {
   }
 }
 
+TEST_LOOP(trials, convert_3_UTF8_bytes) {
+  simdutf::tests::helpers::RandomInt random(0x0800, 0xd800 - 1,
+                                            seed); // range for 3 UTF-8 bytes
+
+  auto procedure = [&implementation](const char *utf8, size_t size,
+                                     char16_t *utf16le) -> size_t {
+    std::vector<char16_t> utf16be(
+        2 * size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
+    simdutf::result res = implementation.convert_utf8_to_utf16be_with_errors(
+        utf8, size, utf16be.data());
+    implementation.change_endianness_utf16(utf16be.data(), res.count, utf16le);
+    ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
+    return res.count;
+  };
+  auto size_procedure = [&implementation](const char *utf8,
+                                          size_t size) -> size_t {
+    return implementation.utf16_length_from_utf8(utf8, size);
+  };
+  for (size_t size : input_size) {
+    transcode_utf8_to_utf16_test_base test(random, size);
+    ASSERT_TRUE(test(procedure));
+    ASSERT_TRUE(test.check_size(size_procedure));
+  }
+}
+
+TEST_LOOP(trials, convert_2_UTF8_bytes) {
+  simdutf::tests::helpers::RandomInt random(0x0080, 0x07ff,
+                                            seed); // range for 2 UTF-8 bytes
+
+  auto procedure = [&implementation](const char *utf8, size_t size,
+                                     char16_t *utf16le) -> size_t {
+    std::vector<char16_t> utf16be(
+        2 * size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
+    simdutf::result res = implementation.convert_utf8_to_utf16be_with_errors(
+        utf8, size, utf16be.data());
+    implementation.change_endianness_utf16(utf16be.data(), res.count, utf16le);
+    ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
+    return res.count;
+  };
+  auto size_procedure = [&implementation](const char *utf8,
+                                          size_t size) -> size_t {
+    return implementation.utf16_length_from_utf8(utf8, size);
+  };
+  for (size_t size : input_size) {
+    transcode_utf8_to_utf16_test_base test(random, size);
+    ASSERT_TRUE(test(procedure));
+    ASSERT_TRUE(test.check_size(size_procedure));
+  }
+}
+
 TEST_LOOP(trials, header_bits_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);

--- a/tests/convert_utf8_to_utf16le_tests.cpp
+++ b/tests/convert_utf8_to_utf16le_tests.cpp
@@ -465,9 +465,28 @@ TEST_LOOP(trials, convert_1_or_2_or_3_UTF8_bytes) {
   }
 }
 
+TEST_LOOP(trials, convert_2_UTF8_bytes) {
+  simdutf::tests::helpers::RandomInt random(0x0080, 0x07ff,
+                                            seed); // range for 2 UTF-8 bytes
+
+  auto procedure = [&implementation](const char *utf8, size_t size,
+                                     char16_t *utf16) -> size_t {
+    return implementation.convert_utf8_to_utf16le(utf8, size, utf16);
+  };
+  auto size_procedure = [&implementation](const char *utf8,
+                                          size_t size) -> size_t {
+    return implementation.utf16_length_from_utf8(utf8, size);
+  };
+  for (size_t size : input_size) {
+    transcode_utf8_to_utf16_test_base test(random, size);
+    ASSERT_TRUE(test(procedure));
+    ASSERT_TRUE(test.check_size(size_procedure));
+  }
+}
+
 TEST_LOOP(trials, convert_3_UTF8_bytes) {
-  simdutf::tests::helpers::RandomIntRanges random(
-      {{0x0800, 0xd800 - 1}}, seed); // range for 3 UTF-8 bytes
+  simdutf::tests::helpers::RandomInt random(0x0800, 0xd800 - 1,
+                                            seed); // range for 3 UTF-8 bytes
 
   auto procedure = [&implementation](const char *utf8, size_t size,
                                      char16_t *utf16) -> size_t {

--- a/tests/convert_utf8_to_utf16le_with_errors_tests.cpp
+++ b/tests/convert_utf8_to_utf16le_with_errors_tests.cpp
@@ -221,6 +221,28 @@ TEST_LOOP(trials, convert_3_or_4_UTF8_bytes) {
   }
 }
 
+TEST_LOOP(trials, convert_3_UTF8_bytes) {
+  simdutf::tests::helpers::RandomInt random(0x0800, 0xd800 - 1,
+                                            seed); // range for 3 UTF-8 bytes
+
+  auto procedure = [&implementation](const char *utf8, size_t size,
+                                     char16_t *utf16) -> size_t {
+    simdutf::result res =
+        implementation.convert_utf8_to_utf16le_with_errors(utf8, size, utf16);
+    ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
+    return res.count;
+  };
+  auto size_procedure = [&implementation](const char *utf8,
+                                          size_t size) -> size_t {
+    return implementation.utf16_length_from_utf8(utf8, size);
+  };
+  for (size_t size : input_size) {
+    transcode_utf8_to_utf16_test_base test(random, size);
+    ASSERT_TRUE(test(procedure));
+    ASSERT_TRUE(test.check_size(size_procedure));
+  }
+}
+
 TEST_LOOP(trials, header_bits_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);


### PR DESCRIPTION
Some implementations (for instace Westmere) have specialised branches handling series of only 2-byte or 3-byte UTF-8 characters. The new tests triggers these execution branches.