### PR TITLE
tests: enable multi-threading

### DIFF
--- a/cmake/add_cpp_test.cmake
+++ b/cmake/add_cpp_test.cmake
@@ -1,9 +1,11 @@
+include(GoogleTest)
+
 # Helper so we don't have to repeat ourselves so much
 # Usage: add_cpp_test(testname [COMPILE_ONLY] [SOURCES a.cpp b.cpp ...] [LABELS acceptance per_implementation ...])
 # SOURCES defaults to testname.cpp if not specified.
 function(add_cpp_test TEST_NAME)
   # Parse arguments
-  cmake_parse_arguments(PARSE_ARGV 1 ARGS "COMPILE_ONLY;LIBRARY;WILL_FAIL" "" "SOURCES;LABELS;DEPENDENCY_OF")
+  cmake_parse_arguments(PARSE_ARGV 1 ARGS "COMPILE_ONLY;LIBRARY;WILL_FAIL;NO_TEST_LIST" "" "SOURCES;LABELS;DEPENDENCY_OF")
   if (NOT ARGS_SOURCES)
     list(APPEND ARGS_SOURCES ${TEST_NAME}.cpp)
   endif()
@@ -37,7 +39,11 @@ function(add_cpp_test TEST_NAME)
         target_compile_options(${TEST_NAME} PRIVATE -coverage)
         target_link_options(${TEST_NAME} PRIVATE -coverage)
       endif()
-      add_test(${TEST_NAME} ${TEST_NAME})
+      if (ARGS_NO_TEST_LIST)
+        add_test(${TEST_NAME} ${TEST_NAME})
+      else()
+        gtest_discover_tests(${TEST_NAME})
+      endif()
     endif()
 
     # Add to <label>_tests make targets

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ target_link_libraries(readme_tests
   PUBLIC simdutf::tests::helpers
          simdutf::tests::reference)
 
-add_cpp_test(random_fuzzer)
+add_cpp_test(random_fuzzer NO_TEST_LIST)
 target_link_libraries(random_fuzzer
   PUBLIC simdutf::tests::helpers
          simdutf::tests::reference)
@@ -369,7 +369,7 @@ target_link_libraries(detect_encodings_tests
   PUBLIC simdutf::tests::helpers
          simdutf::tests::reference)
 
-add_cpp_test(basic_fuzzer)
+add_cpp_test(basic_fuzzer NO_TEST_LIST)
 target_link_libraries(basic_fuzzer
   PUBLIC simdutf::tests::helpers
          simdutf::tests::reference)

--- a/tests/basic_fuzzer.cpp
+++ b/tests/basic_fuzzer.cpp
@@ -796,5 +796,5 @@ int main(int argc, char *argv[]) {
     input_size.push_back(std::uniform_int_distribution<uint32_t>{50, 800}(
         gen)); // Range must be less than max_size
   }
-  return simdutf::test::main((argc == 2) ? 1 : argc, argv);
+  return simdutf::test::main((argc == 2) ? 1 : argc, argv, false);
 }

--- a/tests/helpers/test.cpp
+++ b/tests/helpers/test.cpp
@@ -3,10 +3,48 @@
 #include <stdexcept>
 #include <cstdio>
 
+bool starts_with(const std::string &s, const std::string &prefix) {
+  if (s.size() < prefix.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < prefix.size(); i++) {
+    if (s[i] != prefix[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+struct split_result_t {
+  bool valid;
+  std::string before;
+  std::string after;
+};
+
+split_result_t split(const std::string &s, char ch) {
+  const auto pos = s.find(ch);
+
+  if (pos == std::string::npos) {
+    return {false, s, ""};
+  }
+
+  return {true, s.substr(0, pos), s.substr(pos + 1)};
+}
+
 auto simdutf::test::CommandLine::parse(int argc, char *argv[])
     -> simdutf::test::CommandLine {
   CommandLine cmdline;
   cmdline.seed = 42;
+
+  cmdline.exe_name = argv[0];
+  {
+    const auto pos = cmdline.exe_name.rfind('/');
+    if (pos != std::string::npos) {
+      cmdline.exe_name = cmdline.exe_name.substr(pos + 1);
+    }
+  }
 
   std::list<std::string> args;
   for (int i = 1; i < argc; i++) {
@@ -23,6 +61,15 @@ auto simdutf::test::CommandLine::parse(int argc, char *argv[])
 
     if ((arg == "--show-tests") or (arg == "-l")) {
       cmdline.show_tests = true;
+      continue;
+    }
+
+    if (arg == "--gtest_list_tests") {
+      cmdline.gtest_list_tests = true;
+      continue;
+    }
+
+    if (arg == "--gtest_also_run_disabled_tests") {
       continue;
     }
 
@@ -62,6 +109,19 @@ auto simdutf::test::CommandLine::parse(int argc, char *argv[])
         throw std::invalid_argument("Wrong number after " + arg);
       }
       args.pop_front();
+    } else if (starts_with(arg, "--gtest_filter=")) {
+      const auto s1 = split(arg, '=');
+      const auto s2 = split(s1.after, '.');
+      if (not s2.valid) {
+        std::invalid_argument("Missing test suite name '" + arg + "'");
+      }
+
+      if (s2.before != cmdline.exe_name) {
+        std::invalid_argument("Expected suite name '" + cmdline.exe_name +
+                              "', got '" + s2.before + "'");
+      }
+
+      cmdline.tests.push_back(s2.after);
     } else {
       throw std::invalid_argument("Unknown argument '" + arg + "'");
     }
@@ -128,6 +188,13 @@ void print_tests(FILE *file) {
 
 void print_tests() { print_tests(stdout); }
 
+void gtest_list_tests(const std::string &exe_name) {
+  printf("%s.\n", exe_name.c_str());
+  for (const auto &test : simdutf::test::test_procedures()) {
+    printf("  %s\n", test.name.c_str());
+  }
+}
+
 namespace simdutf {
 namespace test {
 
@@ -146,6 +213,12 @@ void run(const CommandLine &cmdline) {
     print_tests();
     return;
   }
+
+  if (cmdline.gtest_list_tests) {
+    gtest_list_tests(cmdline.exe_name);
+    return;
+  }
+
   size_t matching_implementation{0};
 
   for (const auto &implementation : simdutf::get_available_implementations()) {
@@ -179,12 +252,16 @@ void run(const CommandLine &cmdline) {
       return false;
     };
 
-    for (auto test : simdutf::test::test_procedures()) {
+    for (auto &test : simdutf::test::test_procedures()) {
       if (filter(test)) {
+        printf("Running %s...", test.title.c_str());
+        fflush(stdout);
         test(*implementation);
+        puts(" OK");
       }
     }
   }
+
   if (matching_implementation == 0) {
     puts("not a single compatible implementation found, this is an error");
     abort();
@@ -198,11 +275,13 @@ std::list<test_entry> &test_procedures() {
 }
 
 register_test::register_test(const char *name, test_procedure proc) {
-  test_procedures().push_back({name, proc});
+  std::string title = name;
+  std::replace(title.begin(), title.end(), '_', ' ');
+  test_procedures().push_back({name, title, proc});
 }
 
-int main(int argc, char *argv[]) {
-  const auto cmdline = CommandLine::parse(argc, argv);
+int main(int argc, char *argv[], bool use_threads) {
+  auto cmdline = CommandLine::parse(argc, argv);
 
   run(cmdline);
 


### PR DESCRIPTION
single test program may run multiple tests. This change modifies test programs to handle GTests command line options    required by CMake/CTest to discover tests[1]. Thanks to that we may use CTest facilites, especially parallel running.

[1] https://cmake.org/cmake/help/git-master/module/GoogleTest.html#command:gtest_discover_tests.

On my machine `ctest -j` on master takes 31 second, while on this branch only 22 seconds.