### PR TITLE
amalgamate.py: fix parsing of #endif

### DIFF
--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -120,10 +120,13 @@ namespace utf16 {
 #if SIMDUTF_FEATURE_UTF8
   #include "generic/utf8.h"
 #endif // SIMDUTF_FEATURE_UTF8
+
 #if SIMDUTF_FEATURE_UTF16
   #include "generic/utf16.h"
-  #include "generic/validate_utf16.h"
 #endif // SIMDUTF_FEATURE_UTF16
+#if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
+  #include "generic/validate_utf16.h"
+#endif // SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
   // transcoding from UTF-8 to Latin 1

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -73,7 +73,7 @@ simdutf_warn_unused encoding_type implementation::autodetect_encoding(
 }
 #endif // SIMDUTF_FEATURE_DETECT_ENCODING
 
-#ifdef SIMDUTF_FEATURE_BASE64
+#if SIMDUTF_FEATURE_BASE64
 simdutf_warn_unused size_t implementation::maximal_binary_length_from_base64(
     const char *input, size_t length) const noexcept {
   return scalar::base64::maximal_binary_length_from_base64(input, length);

--- a/src/lasx/implementation.cpp
+++ b/src/lasx/implementation.cpp
@@ -199,13 +199,16 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_UTF8
-  // other functions
   #include "generic/utf8.h"
 #endif // SIMDUTF_FEATURE_UTF8
+
 #if SIMDUTF_FEATURE_UTF16
   #include "generic/utf16.h"
-  #include "generic/validate_utf16.h"
 #endif // SIMDUTF_FEATURE_UTF16
+
+#if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
+  #include "generic/validate_utf16.h"
+#endif // SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
 
 //
 // Implementation-specific overrides

--- a/src/lsx/implementation.cpp
+++ b/src/lsx/implementation.cpp
@@ -206,8 +206,11 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
 
 #if SIMDUTF_FEATURE_UTF16
   #include "generic/utf16.h"
-  #include "generic/validate_utf16.h"
 #endif // SIMDUTF_FEATURE_UTF16
+
+#if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
+  #include "generic/validate_utf16.h"
+#endif // SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
 
 //
 // Implementation-specific overrides

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -121,8 +121,10 @@ must_be_2_3_continuation(const simd8<uint8_t> prev2,
 #endif // SIMDUTF_FEATURE_UTF8
 #if SIMDUTF_FEATURE_UTF16
   #include "generic/utf16.h"
-  #include "generic/validate_utf16.h"
 #endif // SIMDUTF_FEATURE_UTF16
+#if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
+  #include "generic/validate_utf16.h"
+#endif // SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
   #include "generic/utf8_to_latin1/utf8_to_latin1.h"
   #include "generic/utf8_to_latin1/valid_utf8_to_latin1.h"


### PR DESCRIPTION
Make it more robust. Also fix markers.

Addressing issue #683.