### PR TITLE
clang/libc++ fix: do not use std::atomic_ref<const char>

### DIFF
--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -2088,7 +2088,7 @@ size_t atomic_binary_to_base64(const char *input, size_t length, char *output,
     // Under x64, we could use 16-byte aligned loads.
     // Note that we warn users that the performance might be poor.
     for (size_t j = 0; j < current_block_size; ++j) {
-      inbuf[j] = std::atomic_ref<const char>(input[i + j])
+      inbuf[j] = std::atomic_ref<char>(input[i + j])
                      .load(std::memory_order_relaxed);
     }
     const size_t written = binary_to_base64(inbuf.data(), current_block_size,

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -2088,8 +2088,8 @@ size_t atomic_binary_to_base64(const char *input, size_t length, char *output,
     // Under x64, we could use 16-byte aligned loads.
     // Note that we warn users that the performance might be poor.
     for (size_t j = 0; j < current_block_size; ++j) {
-      inbuf[j] = std::atomic_ref<char>(input[i + j])
-                     .load(std::memory_order_relaxed);
+      inbuf[j] = 
+          std::atomic_ref<char>(input[i + j]).load(std::memory_order_relaxed);
     }
     const size_t written = binary_to_base64(inbuf.data(), current_block_size,
                                             outbuf.data(), options);


### PR DESCRIPTION
#660 has introduced `std::atomic_ref<const char>` which doesn't seem to work on clang + libc++ with the following error:

```
/usr/lib/llvm-19/bin/../include/c++/v1/__atomic/atomic_ref.h:145:27: error: cannot initialize a parameter of type 'char *' with an lvalue of type 'const char *'
  145 |     __atomic_load(__ptr_, __ret, std::__to_gcc_order(__order));
      |                           ^~~~~
external/simdutf/simdutf.cpp:17128:23: note: in instantiation of member function 'std::__atomic_ref_base<const char>::load' requested here
 17128 |                      .load(std::memory_order_relaxed);
       |                       ^
```

The godbolt link with a problem: https://godbolt.org/z/dq39PMjcE