### PR TITLE
porting single-compress optimization to arm

### DIFF
--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -2702,6 +2702,7 @@ trim_partial_utf16(std::span<const char16_t> valid_utf16_input) noexcept {
 #endif   // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_BASE64
+#define SIMDUTF_NEED_TRAILING_ZERO 1
 // base64_options are used to specify the base64 encoding options.
 // ASCII spaces are ' ', '\t', '\n', '\r', '\f'
 // garbage characters are characters that are not part of the base64 alphabet

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -2702,9 +2702,9 @@ trim_partial_utf16(std::span<const char16_t> valid_utf16_input) noexcept {
 #endif   // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_BASE64
-#ifndef SIMDUTF_NEED_TRAILING_ZEROES
-#define SIMDUTF_NEED_TRAILING_ZEROES 1
-#endif
+  #ifndef SIMDUTF_NEED_TRAILING_ZEROES
+    #define SIMDUTF_NEED_TRAILING_ZEROES 1
+  #endif
 // base64_options are used to specify the base64 encoding options.
 // ASCII spaces are ' ', '\t', '\n', '\r', '\f'
 // garbage characters are characters that are not part of the base64 alphabet

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -2702,7 +2702,9 @@ trim_partial_utf16(std::span<const char16_t> valid_utf16_input) noexcept {
 #endif   // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_BASE64
-#define SIMDUTF_NEED_TRAILING_ZERO 1
+#ifndef SIMDUTF_NEED_TRAILING_ZEROES
+#define SIMDUTF_NEED_TRAILING_ZEROES 1
+#endif
 // base64_options are used to specify the base64 encoding options.
 // ASCII spaces are ' ', '\t', '\n', '\r', '\f'
 // garbage characters are characters that are not part of the base64 alphabet

--- a/src/arm64/arm_base64.cpp
+++ b/src/arm64/arm_base64.cpp
@@ -330,7 +330,12 @@ static size_t compress_block_single(block64 *b, uint64_t mask, char *output) {
   const int8_t pos = pos64 & 0xf;
 
   // Predefine the index vector
+#ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
+  const uint8x16_t v1 = simdutf_make_uint8x16_t(0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                                                10, 11, 12, 13, 14, 15);
+#else  // SIMDUTF_REGULAR_VISUAL_STUDIO
   const uint8x16_t v1 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+#endif // SIMDUTF_REGULAR_VISUAL_STUDIO
 
   switch (pos64 >> 4) {
   case 0b00: {

--- a/src/arm64/arm_base64.cpp
+++ b/src/arm64/arm_base64.cpp
@@ -325,7 +325,6 @@ void base64_decode_block(char *out, const char *src) {
   vst3q_u8((uint8_t *)out, outvec);
 }
 
-
 #if defined(_MSC_VER) && !defined(__clang__)
 static inline size_t simdutf_tzcnt_u64(uint64_t num) {
   unsigned long ret;
@@ -341,67 +340,72 @@ static inline size_t simdutf_tzcnt_u64(uint64_t num) {
 }
 #endif
 
-static size_t
-compress_block_single(block64 *b, uint64_t mask, char *output) {
-    const size_t pos64 = simdutf_tzcnt_u64(mask);
-    const int8_t pos = pos64 & 0xf;
-    
-    // Predefine the index vector
-    const uint8x16_t v1 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
-    
-    switch (pos64 >> 4) {
-    case 0b00: {
-        const uint8x16_t v0 = vmovq_n_s8((uint8_t)(pos - 1));
-        const uint8x16_t v2 = vreinterpretq_u8_s8(vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0)));           // Compare greater than
-        const uint8x16_t sh = vsubq_u8(v1, v2);           // Subtract
-        const uint8x16_t compressed = vqtbl1q_u8(b->chunks[0], sh); // Table lookup (shuffle)
+static size_t compress_block_single(block64 *b, uint64_t mask, char *output) {
+  const size_t pos64 = simdutf_tzcnt_u64(mask);
+  const int8_t pos = pos64 & 0xf;
 
-        vst1q_u8((uint8_t*)(output + 0 * 16), compressed);
-        vst1q_u8((uint8_t*)(output + 1 * 16 - 1), b->chunks[1]);
-        vst1q_u8((uint8_t*)(output + 2 * 16 - 1), b->chunks[2]);
-        vst1q_u8((uint8_t*)(output + 3 * 16 - 1), b->chunks[3]);
-    } break;
-    
-    case 0b01: {
-        vst1q_u8((uint8_t*)(output + 0 * 16), b->chunks[0]);
-        
-        const uint8x16_t v0 = vmovq_n_u8((uint8_t)(pos - 1));
-        const uint8x16_t v2 = vreinterpretq_u8_s8(vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0)));
-        const uint8x16_t sh = vsubq_u8(v1, v2);
-        const uint8x16_t compressed = vqtbl1q_u8(b->chunks[1], sh);
+  // Predefine the index vector
+  const uint8x16_t v1 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 
-        vst1q_u8((uint8_t*)(output + 1 * 16), compressed);
-        vst1q_u8((uint8_t*)(output + 2 * 16 - 1), b->chunks[2]);
-        vst1q_u8((uint8_t*)(output + 3 * 16 - 1), b->chunks[3]);
-    } break;
-    
-    case 0b10: {
-        vst1q_u8((uint8_t*)(output + 0 * 16), b->chunks[0]);
-        vst1q_u8((uint8_t*)(output + 1 * 16), b->chunks[1]);
-        
-        const uint8x16_t v0 = vmovq_n_u8((uint8_t)(pos - 1));
-        const uint8x16_t v2 = vreinterpretq_u8_s8(vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0)));
-        const uint8x16_t sh = vsubq_u8(v1, v2);
-        const uint8x16_t compressed = vqtbl1q_u8(b->chunks[2], sh);
+  switch (pos64 >> 4) {
+  case 0b00: {
+    const uint8x16_t v0 = vmovq_n_u8((uint8_t)(pos - 1));
+    const uint8x16_t v2 = vreinterpretq_u8_s8(
+        vcgtq_s8(vreinterpretq_s8_u8(v1),
+                 vreinterpretq_s8_u8(v0))); // Compare greater than
+    const uint8x16_t sh = vsubq_u8(v1, v2); // Subtract
+    const uint8x16_t compressed =
+        vqtbl1q_u8(b->chunks[0], sh); // Table lookup (shuffle)
 
-        vst1q_u8((uint8_t*)(output + 2 * 16), compressed);
-        vst1q_u8((uint8_t*)(output + 3 * 16 - 1), b->chunks[3]);
-    } break;
-    
-    case 0b11: {
-        vst1q_u8((uint8_t*)(output + 0 * 16), b->chunks[0]);
-        vst1q_u8((uint8_t*)(output + 1 * 16), b->chunks[1]);
-        vst1q_u8((uint8_t*)(output + 2 * 16), b->chunks[2]);
-        
-        const uint8x16_t v0 = vmovq_n_u8((uint8_t)(pos - 1));
-        const uint8x16_t v2 = vreinterpretq_u8_s8(vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0)));
-        const uint8x16_t sh = vsubq_u8(v1, v2);
-        const uint8x16_t compressed = vqtbl1q_u8(b->chunks[3], sh);
+    vst1q_u8((uint8_t *)(output + 0 * 16), compressed);
+    vst1q_u8((uint8_t *)(output + 1 * 16 - 1), b->chunks[1]);
+    vst1q_u8((uint8_t *)(output + 2 * 16 - 1), b->chunks[2]);
+    vst1q_u8((uint8_t *)(output + 3 * 16 - 1), b->chunks[3]);
+  } break;
 
-        vst1q_u8((uint8_t*)(output + 3 * 16), compressed);
-    } break;
-    }
-    return 63;
+  case 0b01: {
+    vst1q_u8((uint8_t *)(output + 0 * 16), b->chunks[0]);
+
+    const uint8x16_t v0 = vmovq_n_u8((uint8_t)(pos - 1));
+    const uint8x16_t v2 = vreinterpretq_u8_s8(
+        vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0)));
+    const uint8x16_t sh = vsubq_u8(v1, v2);
+    const uint8x16_t compressed = vqtbl1q_u8(b->chunks[1], sh);
+
+    vst1q_u8((uint8_t *)(output + 1 * 16), compressed);
+    vst1q_u8((uint8_t *)(output + 2 * 16 - 1), b->chunks[2]);
+    vst1q_u8((uint8_t *)(output + 3 * 16 - 1), b->chunks[3]);
+  } break;
+
+  case 0b10: {
+    vst1q_u8((uint8_t *)(output + 0 * 16), b->chunks[0]);
+    vst1q_u8((uint8_t *)(output + 1 * 16), b->chunks[1]);
+
+    const uint8x16_t v0 = vmovq_n_u8((uint8_t)(pos - 1));
+    const uint8x16_t v2 = vreinterpretq_u8_s8(
+        vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0)));
+    const uint8x16_t sh = vsubq_u8(v1, v2);
+    const uint8x16_t compressed = vqtbl1q_u8(b->chunks[2], sh);
+
+    vst1q_u8((uint8_t *)(output + 2 * 16), compressed);
+    vst1q_u8((uint8_t *)(output + 3 * 16 - 1), b->chunks[3]);
+  } break;
+
+  case 0b11: {
+    vst1q_u8((uint8_t *)(output + 0 * 16), b->chunks[0]);
+    vst1q_u8((uint8_t *)(output + 1 * 16), b->chunks[1]);
+    vst1q_u8((uint8_t *)(output + 2 * 16), b->chunks[2]);
+
+    const uint8x16_t v0 = vmovq_n_u8((uint8_t)(pos - 1));
+    const uint8x16_t v2 = vreinterpretq_u8_s8(
+        vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0)));
+    const uint8x16_t sh = vsubq_u8(v1, v2);
+    const uint8x16_t compressed = vqtbl1q_u8(b->chunks[3], sh);
+
+    vst1q_u8((uint8_t *)(output + 3 * 16), compressed);
+  } break;
+  }
+  return 63;
 }
 
 template <typename T> bool is_power_of_two(T x) { return (x & (x - 1)) == 0; }
@@ -482,7 +486,7 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
         // optimization opportunity: check for simple masks like those made of
         // continuous 1s followed by continuous 0s. And masks containing a
         // single bad character.
-        if(is_power_of_two(badcharmask)) {
+        if (is_power_of_two(badcharmask)) {
           bufferptr += compress_block_single(&b, badcharmask, bufferptr);
         } else {
           bufferptr += compress_block(&b, badcharmask, bufferptr);

--- a/src/arm64/arm_base64.cpp
+++ b/src/arm64/arm_base64.cpp
@@ -350,9 +350,9 @@ static size_t compress_block_single(block64 *b, uint64_t mask, char *output) {
   switch (pos64 >> 4) {
   case 0b00: {
     const uint8x16_t v0 = vmovq_n_u8((uint8_t)(pos - 1));
-    const uint8x16_t v2 = vreinterpretq_u8_s8(
+    const uint8x16_t v2 =
         vcgtq_s8(vreinterpretq_s8_u8(v1),
-                 vreinterpretq_s8_u8(v0))); // Compare greater than
+                 vreinterpretq_s8_u8(v0));  // Compare greater than
     const uint8x16_t sh = vsubq_u8(v1, v2); // Subtract
     const uint8x16_t compressed =
         vqtbl1q_u8(b->chunks[0], sh); // Table lookup (shuffle)
@@ -367,8 +367,8 @@ static size_t compress_block_single(block64 *b, uint64_t mask, char *output) {
     vst1q_u8((uint8_t *)(output + 0 * 16), b->chunks[0]);
 
     const uint8x16_t v0 = vmovq_n_u8((uint8_t)(pos - 1));
-    const uint8x16_t v2 = vreinterpretq_u8_s8(
-        vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0)));
+    const uint8x16_t v2 =
+        vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0));
     const uint8x16_t sh = vsubq_u8(v1, v2);
     const uint8x16_t compressed = vqtbl1q_u8(b->chunks[1], sh);
 
@@ -382,8 +382,8 @@ static size_t compress_block_single(block64 *b, uint64_t mask, char *output) {
     vst1q_u8((uint8_t *)(output + 1 * 16), b->chunks[1]);
 
     const uint8x16_t v0 = vmovq_n_u8((uint8_t)(pos - 1));
-    const uint8x16_t v2 = vreinterpretq_u8_s8(
-        vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0)));
+    const uint8x16_t v2 =
+        vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0));
     const uint8x16_t sh = vsubq_u8(v1, v2);
     const uint8x16_t compressed = vqtbl1q_u8(b->chunks[2], sh);
 
@@ -397,8 +397,8 @@ static size_t compress_block_single(block64 *b, uint64_t mask, char *output) {
     vst1q_u8((uint8_t *)(output + 2 * 16), b->chunks[2]);
 
     const uint8x16_t v0 = vmovq_n_u8((uint8_t)(pos - 1));
-    const uint8x16_t v2 = vreinterpretq_u8_s8(
-        vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0)));
+    const uint8x16_t v2 =
+        vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0));
     const uint8x16_t sh = vsubq_u8(v1, v2);
     const uint8x16_t compressed = vqtbl1q_u8(b->chunks[3], sh);
 

--- a/src/arm64/arm_base64.cpp
+++ b/src/arm64/arm_base64.cpp
@@ -325,23 +325,8 @@ void base64_decode_block(char *out, const char *src) {
   vst3q_u8((uint8_t *)out, outvec);
 }
 
-#if defined(_MSC_VER) && !defined(__clang__)
-static inline size_t simdutf_tzcnt_u64(uint64_t num) {
-  unsigned long ret;
-  if (num == 0) {
-    return 64;
-  }
-  _BitScanForward64(&ret, num);
-  return ret;
-}
-#else // GCC or Clang
-static inline size_t simdutf_tzcnt_u64(uint64_t num) {
-  return num ? __builtin_ctzll(num) : 64;
-}
-#endif
-
 static size_t compress_block_single(block64 *b, uint64_t mask, char *output) {
-  const size_t pos64 = simdutf_tzcnt_u64(mask);
+  const size_t pos64 = trailing_zeroes(mask);
   const int8_t pos = pos64 & 0xf;
 
   // Predefine the index vector

--- a/src/arm64/arm_base64.cpp
+++ b/src/arm64/arm_base64.cpp
@@ -325,6 +325,87 @@ void base64_decode_block(char *out, const char *src) {
   vst3q_u8((uint8_t *)out, outvec);
 }
 
+
+#if defined(_MSC_VER) && !defined(__clang__)
+static inline size_t simdutf_tzcnt_u64(uint64_t num) {
+  unsigned long ret;
+  if (num == 0) {
+    return 64;
+  }
+  _BitScanForward64(&ret, num);
+  return ret;
+}
+#else // GCC or Clang
+static inline size_t simdutf_tzcnt_u64(uint64_t num) {
+  return num ? __builtin_ctzll(num) : 64;
+}
+#endif
+
+static size_t
+compress_block_single(block64 *b, uint64_t mask, char *output) {
+    const size_t pos64 = simdutf_tzcnt_u64(mask);
+    const int8_t pos = pos64 & 0xf;
+    
+    // Predefine the index vector
+    const uint8x16_t v1 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    
+    switch (pos64 >> 4) {
+    case 0b00: {
+        const uint8x16_t v0 = vmovq_n_s8((uint8_t)(pos - 1));
+        const uint8x16_t v2 = vreinterpretq_u8_s8(vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0)));           // Compare greater than
+        const uint8x16_t sh = vsubq_u8(v1, v2);           // Subtract
+        const uint8x16_t compressed = vqtbl1q_u8(b->chunks[0], sh); // Table lookup (shuffle)
+
+        vst1q_u8((uint8_t*)(output + 0 * 16), compressed);
+        vst1q_u8((uint8_t*)(output + 1 * 16 - 1), b->chunks[1]);
+        vst1q_u8((uint8_t*)(output + 2 * 16 - 1), b->chunks[2]);
+        vst1q_u8((uint8_t*)(output + 3 * 16 - 1), b->chunks[3]);
+    } break;
+    
+    case 0b01: {
+        vst1q_u8((uint8_t*)(output + 0 * 16), b->chunks[0]);
+        
+        const uint8x16_t v0 = vmovq_n_u8((uint8_t)(pos - 1));
+        const uint8x16_t v2 = vreinterpretq_u8_s8(vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0)));
+        const uint8x16_t sh = vsubq_u8(v1, v2);
+        const uint8x16_t compressed = vqtbl1q_u8(b->chunks[1], sh);
+
+        vst1q_u8((uint8_t*)(output + 1 * 16), compressed);
+        vst1q_u8((uint8_t*)(output + 2 * 16 - 1), b->chunks[2]);
+        vst1q_u8((uint8_t*)(output + 3 * 16 - 1), b->chunks[3]);
+    } break;
+    
+    case 0b10: {
+        vst1q_u8((uint8_t*)(output + 0 * 16), b->chunks[0]);
+        vst1q_u8((uint8_t*)(output + 1 * 16), b->chunks[1]);
+        
+        const uint8x16_t v0 = vmovq_n_u8((uint8_t)(pos - 1));
+        const uint8x16_t v2 = vreinterpretq_u8_s8(vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0)));
+        const uint8x16_t sh = vsubq_u8(v1, v2);
+        const uint8x16_t compressed = vqtbl1q_u8(b->chunks[2], sh);
+
+        vst1q_u8((uint8_t*)(output + 2 * 16), compressed);
+        vst1q_u8((uint8_t*)(output + 3 * 16 - 1), b->chunks[3]);
+    } break;
+    
+    case 0b11: {
+        vst1q_u8((uint8_t*)(output + 0 * 16), b->chunks[0]);
+        vst1q_u8((uint8_t*)(output + 1 * 16), b->chunks[1]);
+        vst1q_u8((uint8_t*)(output + 2 * 16), b->chunks[2]);
+        
+        const uint8x16_t v0 = vmovq_n_u8((uint8_t)(pos - 1));
+        const uint8x16_t v2 = vreinterpretq_u8_s8(vcgtq_s8(vreinterpretq_s8_u8(v1), vreinterpretq_s8_u8(v0)));
+        const uint8x16_t sh = vsubq_u8(v1, v2);
+        const uint8x16_t compressed = vqtbl1q_u8(b->chunks[3], sh);
+
+        vst1q_u8((uint8_t*)(output + 3 * 16), compressed);
+    } break;
+    }
+    return 63;
+}
+
+template <typename T> bool is_power_of_two(T x) { return (x & (x - 1)) == 0; }
+
 template <bool base64_url, bool ignore_garbage, typename char_type>
 full_result
 compress_decode_base64(char *dst, const char_type *src, size_t srclen,
@@ -401,7 +482,11 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
         // optimization opportunity: check for simple masks like those made of
         // continuous 1s followed by continuous 0s. And masks containing a
         // single bad character.
-        bufferptr += compress_block(&b, badcharmask, bufferptr);
+        if(is_power_of_two(badcharmask)) {
+          bufferptr += compress_block_single(&b, badcharmask, bufferptr);
+        } else {
+          bufferptr += compress_block(&b, badcharmask, bufferptr);
+        }
       } else {
         // optimization opportunity: if bufferptr == buffer and mask == 0, we
         // can avoid the call to compress_block and decode directly.

--- a/src/haswell/avx2_base64.cpp
+++ b/src/haswell/avx2_base64.cpp
@@ -397,7 +397,7 @@ static inline void base64_decode_block_safe(char *out, block64 *b) {
 
 simdutf_really_inline static size_t
 compress_block_single(block64 *b, uint64_t mask, char *output) {
-  const size_t pos64 = _tzcnt_u64(mask);
+  const size_t pos64 = trailing_zeroes(mask);
   const int8_t pos = pos64 & 0xf;
   switch (pos64 >> 4) {
   case 0b00: {

--- a/src/simdutf/haswell/bitmanipulation.h
+++ b/src/simdutf/haswell/bitmanipulation.h
@@ -17,7 +17,7 @@ simdutf_really_inline long long int count_ones(uint64_t input_num) {
 #endif
 
 #if SIMDUTF_NEED_TRAILING_ZEROES
-simdutf_inline int trailing_zeroes(uint64_t input_num) {
+simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
   #if SIMDUTF_REGULAR_VISUAL_STUDIO
   return (int)_tzcnt_u64(input_num);
   #else  // SIMDUTF_REGULAR_VISUAL_STUDIO

--- a/src/westmere/sse_base64.cpp
+++ b/src/westmere/sse_base64.cpp
@@ -527,7 +527,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
           to_base64_mask<base64_url, ignore_garbage>(&b, &error);
       if (error && !ignore_garbage) {
         src -= 64;
-        size_t error_offset = simdutf_tzcnt_u64(error);
+        size_t error_offset = trailing_zeroes(error);
         return {error_code::INVALID_BASE64_CHARACTER,
                 size_t(src - srcinit + error_offset), size_t(dst - dstinit)};
       }

--- a/src/westmere/sse_base64.cpp
+++ b/src/westmere/sse_base64.cpp
@@ -301,21 +301,6 @@ static inline uint64_t to_base64_mask(block64 *b, uint64_t *error) {
   return m0 | (m1 << 16) | (m2 << 32) | (m3 << 48);
 }
 
-#if defined(_MSC_VER) && !defined(__clang__)
-static inline size_t simdutf_tzcnt_u64(uint64_t num) {
-  unsigned long ret;
-  if (num == 0) {
-    return 64;
-  }
-  _BitScanForward64(&ret, num);
-  return ret;
-}
-#else // GCC or Clang
-static inline size_t simdutf_tzcnt_u64(uint64_t num) {
-  return num ? __builtin_ctzll(num) : 64;
-}
-#endif
-
 static inline void copy_block(block64 *b, char *output) {
   _mm_storeu_si128(reinterpret_cast<__m128i *>(output), b->chunks[0]);
   _mm_storeu_si128(reinterpret_cast<__m128i *>(output + 16), b->chunks[1]);
@@ -414,7 +399,7 @@ static inline void base64_decode_block_safe(char *out, block64 *b) {
 
 simdutf_really_inline static size_t
 compress_block_single(block64 *b, uint64_t mask, char *output) {
-  const size_t pos64 = simdutf_tzcnt_u64(mask);
+  const size_t pos64 = trailing_zeroes(mask);
   const int8_t pos = pos64 & 0xf;
   switch (pos64 >> 4) {
   case 0b00: {


### PR DESCRIPTION
@WojciechMula recently pushed a nice optimization to the Westmere and Haswell kernels. We can port it to ARM.

Here are the results on my M2 macBook.

Command:
```
cmake --build build --target benchmark_base64  && ./build/benchmarks/base64/benchmark_base64 -d ../base64data/dns/swedenzonebase.txt
```

Before:
```
simdutf::arm64                           :   5.52 GB/s  2.51 % 
simdutf::arm64 (accept garbage)          :   5.70 GB/s  1.78 % 
```

After:
```
simdutf::arm64                           :   6.20 GB/s  3.11 % 
simdutf::arm64 (accept garbage)          :   6.86 GB/s  2.43 % 
```

So that's a performance boost of about 10%... which is well worth it.

The downside of this approach is more branching and slightly more complexity, so it is possible that the gains do not always translate into benefits. However, we do expect the branches to be predictible because inputs are going to be regular in some ways (in practice).