### PR TITLE
disabling the new tests on big endian systems

### DIFF
--- a/tests/convert_utf8_to_utf16be_tests.cpp
+++ b/tests/convert_utf8_to_utf16be_tests.cpp
@@ -330,6 +330,7 @@ TEST_LOOP(trials, convert_3_or_4_UTF8_bytes) {
   }
 }
 
+#if !SIMDUTF_IS_BIG_ENDIAN
 TEST_LOOP(trials, convert_2_UTF8_bytes) {
   simdutf::tests::helpers::RandomInt random(0x0080, 0x07ff,
                                             seed); // range for 2 UTF-8 bytes
@@ -337,9 +338,7 @@ TEST_LOOP(trials, convert_2_UTF8_bytes) {
   auto procedure = [&implementation](const char *utf8, size_t size,
                                      char16_t *utf16) -> size_t {
     auto result = implementation.convert_utf8_to_utf16be(utf8, size, utf16);
-#if !SIMDUTF_IS_BIG_ENDIAN
     implementation.change_endianness_utf16(utf16, result, utf16);
-#endif // !SIMDUTF_IS_BIG_ENDIAN
     return result;
   };
   auto size_procedure = [&implementation](const char *utf8,
@@ -352,7 +351,9 @@ TEST_LOOP(trials, convert_2_UTF8_bytes) {
     ASSERT_TRUE(test.check_size(size_procedure));
   }
 }
+#endif // !SIMDUTF_IS_BIG_ENDIAN
 
+#if !SIMDUTF_IS_BIG_ENDIAN
 TEST_LOOP(trials, convert_3_UTF8_bytes) {
   simdutf::tests::helpers::RandomInt random(0x0800, 0xd800 - 1,
                                             seed); // range for 3 UTF-8 bytes
@@ -360,9 +361,7 @@ TEST_LOOP(trials, convert_3_UTF8_bytes) {
   auto procedure = [&implementation](const char *utf8, size_t size,
                                      char16_t *utf16) -> size_t {
     auto result = implementation.convert_utf8_to_utf16be(utf8, size, utf16);
-#if !SIMDUTF_IS_BIG_ENDIAN
     implementation.change_endianness_utf16(utf16, result, utf16);
-#endif // !SIMDUTF_IS_BIG_ENDIAN
     return result;
   };
   auto size_procedure = [&implementation](const char *utf8,
@@ -375,6 +374,7 @@ TEST_LOOP(trials, convert_3_UTF8_bytes) {
     ASSERT_TRUE(test.check_size(size_procedure));
   }
 }
+#endif // !SIMDUTF_IS_BIG_ENDIAN
 
 TEST(special_cases) {
   const uint8_t utf8[] = {0xC2, 0xA9};     // copyright sign


### PR DESCRIPTION
We recently added some new tests, just prior to our latest release. But these tests were not vetted on big endian systems. They implicitly assume that we are running under a little endian system.

This PR disables the new tests on big endian systems. They will only run on little endian systems.

Fixes https://github.com/simdutf/simdutf/issues/702