### PR TITLE
A small numbers of constants and functions are not actively used.

### DIFF
--- a/src/simdutf/haswell/simd32-inl.h
+++ b/src/simdutf/haswell/simd32-inl.h
@@ -51,8 +51,8 @@ template <> struct simd32<uint32_t> {
 //----------------------------------------------------------------------
 
 template <> struct simd32<bool> {
-  //static const size_t SIZE = sizeof(__m128i);
-  //static const size_t ELEMENTS = SIZE / sizeof(uint32_t);
+  // static const size_t SIZE = sizeof(__m128i);
+  // static const size_t ELEMENTS = SIZE / sizeof(uint32_t);
 
   __m256i value;
 

--- a/src/simdutf/haswell/simd32-inl.h
+++ b/src/simdutf/haswell/simd32-inl.h
@@ -51,8 +51,8 @@ template <> struct simd32<uint32_t> {
 //----------------------------------------------------------------------
 
 template <> struct simd32<bool> {
-  static const size_t SIZE = sizeof(__m128i);
-  static const size_t ELEMENTS = SIZE / sizeof(uint32_t);
+  //static const size_t SIZE = sizeof(__m128i);
+  //static const size_t ELEMENTS = SIZE / sizeof(uint32_t);
 
   __m256i value;
 

--- a/src/simdutf/haswell/simd64-inl.h
+++ b/src/simdutf/haswell/simd64-inl.h
@@ -1,8 +1,8 @@
 template <typename T> struct simd64;
 
 template <> struct simd64<uint64_t> {
-  //static const size_t SIZE = sizeof(__m256i);
-  //static const size_t ELEMENTS = SIZE / sizeof(uint64_t);
+  // static const size_t SIZE = sizeof(__m256i);
+  // static const size_t ELEMENTS = SIZE / sizeof(uint64_t);
 
   __m256i value;
 

--- a/src/simdutf/haswell/simd64-inl.h
+++ b/src/simdutf/haswell/simd64-inl.h
@@ -1,8 +1,8 @@
 template <typename T> struct simd64;
 
 template <> struct simd64<uint64_t> {
-  static const size_t SIZE = sizeof(__m256i);
-  static const size_t ELEMENTS = SIZE / sizeof(uint64_t);
+  //static const size_t SIZE = sizeof(__m256i);
+  //static const size_t ELEMENTS = SIZE / sizeof(uint64_t);
 
   __m256i value;
 

--- a/src/simdutf/icelake/bitmanipulation.h
+++ b/src/simdutf/icelake/bitmanipulation.h
@@ -17,13 +17,13 @@ simdutf_really_inline long long int count_ones(uint64_t input_num) {
 #endif
 
 #if SIMDUTF_NEED_TRAILING_ZEROES
-//simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
-//  #if SIMDUTF_REGULAR_VISUAL_STUDIO
-//  return (int)_tzcnt_u64(input_num);
-//  #else  // SIMDUTF_REGULAR_VISUAL_STUDIO
-//  return __builtin_ctzll(input_num);
-//  #endif // SIMDUTF_REGULAR_VISUAL_STUDIO
-//}
+// simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
+//   #if SIMDUTF_REGULAR_VISUAL_STUDIO
+//   return (int)_tzcnt_u64(input_num);
+//   #else  // SIMDUTF_REGULAR_VISUAL_STUDIO
+//   return __builtin_ctzll(input_num);
+//   #endif // SIMDUTF_REGULAR_VISUAL_STUDIO
+// }
 #endif
 
 } // unnamed namespace

--- a/src/simdutf/icelake/bitmanipulation.h
+++ b/src/simdutf/icelake/bitmanipulation.h
@@ -17,13 +17,13 @@ simdutf_really_inline long long int count_ones(uint64_t input_num) {
 #endif
 
 #if SIMDUTF_NEED_TRAILING_ZEROES
-simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
-  #if SIMDUTF_REGULAR_VISUAL_STUDIO
-  return (int)_tzcnt_u64(input_num);
-  #else  // SIMDUTF_REGULAR_VISUAL_STUDIO
-  return __builtin_ctzll(input_num);
-  #endif // SIMDUTF_REGULAR_VISUAL_STUDIO
-}
+//simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
+//  #if SIMDUTF_REGULAR_VISUAL_STUDIO
+//  return (int)_tzcnt_u64(input_num);
+//  #else  // SIMDUTF_REGULAR_VISUAL_STUDIO
+//  return __builtin_ctzll(input_num);
+//  #endif // SIMDUTF_REGULAR_VISUAL_STUDIO
+//}
 #endif
 
 } // unnamed namespace

--- a/src/simdutf/lasx/bitmanipulation.h
+++ b/src/simdutf/lasx/bitmanipulation.h
@@ -13,9 +13,9 @@ simdutf_really_inline int count_ones(uint64_t input_num) {
 }
 
 #if SIMDUTF_NEED_TRAILING_ZEROES
-//simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
-//  return __builtin_ctzll(input_num);
-//}
+// simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
+//   return __builtin_ctzll(input_num);
+// }
 #endif
 
 } // unnamed namespace

--- a/src/simdutf/lasx/bitmanipulation.h
+++ b/src/simdutf/lasx/bitmanipulation.h
@@ -13,9 +13,9 @@ simdutf_really_inline int count_ones(uint64_t input_num) {
 }
 
 #if SIMDUTF_NEED_TRAILING_ZEROES
-simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
-  return __builtin_ctzll(input_num);
-}
+//simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
+//  return __builtin_ctzll(input_num);
+//}
 #endif
 
 } // unnamed namespace

--- a/src/simdutf/lsx/bitmanipulation.h
+++ b/src/simdutf/lsx/bitmanipulation.h
@@ -13,9 +13,9 @@ simdutf_really_inline int count_ones(uint64_t input_num) {
 }
 
 #if SIMDUTF_NEED_TRAILING_ZEROES
-//simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
-//  return __builtin_ctzll(input_num);
-//}
+// simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
+//   return __builtin_ctzll(input_num);
+// }
 #endif
 
 } // unnamed namespace

--- a/src/simdutf/lsx/bitmanipulation.h
+++ b/src/simdutf/lsx/bitmanipulation.h
@@ -13,9 +13,9 @@ simdutf_really_inline int count_ones(uint64_t input_num) {
 }
 
 #if SIMDUTF_NEED_TRAILING_ZEROES
-simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
-  return __builtin_ctzll(input_num);
-}
+//simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
+//  return __builtin_ctzll(input_num);
+//}
 #endif
 
 } // unnamed namespace

--- a/src/simdutf/westmere/simd32-inl.h
+++ b/src/simdutf/westmere/simd32-inl.h
@@ -52,8 +52,8 @@ template <> struct simd32<uint32_t> {
 //----------------------------------------------------------------------
 
 template <> struct simd32<bool> {
-  static const size_t SIZE = sizeof(__m128i);
-  static const size_t ELEMENTS = SIZE / sizeof(uint32_t);
+  //static const size_t SIZE = sizeof(__m128i);
+  //static const size_t ELEMENTS = SIZE / sizeof(uint32_t);
 
   __m128i value;
 

--- a/src/simdutf/westmere/simd32-inl.h
+++ b/src/simdutf/westmere/simd32-inl.h
@@ -52,8 +52,8 @@ template <> struct simd32<uint32_t> {
 //----------------------------------------------------------------------
 
 template <> struct simd32<bool> {
-  //static const size_t SIZE = sizeof(__m128i);
-  //static const size_t ELEMENTS = SIZE / sizeof(uint32_t);
+  // static const size_t SIZE = sizeof(__m128i);
+  // static const size_t ELEMENTS = SIZE / sizeof(uint32_t);
 
   __m128i value;
 

--- a/src/simdutf/westmere/simd64-inl.h
+++ b/src/simdutf/westmere/simd64-inl.h
@@ -1,8 +1,8 @@
 template <typename T> struct simd64;
 
 template <> struct simd64<uint64_t> {
-  //static const size_t SIZE = sizeof(__m128i);
-  //static const size_t ELEMENTS = SIZE / sizeof(uint64_t);
+  // static const size_t SIZE = sizeof(__m128i);
+  // static const size_t ELEMENTS = SIZE / sizeof(uint64_t);
 
   __m128i value;
 

--- a/src/simdutf/westmere/simd64-inl.h
+++ b/src/simdutf/westmere/simd64-inl.h
@@ -1,8 +1,8 @@
 template <typename T> struct simd64;
 
 template <> struct simd64<uint64_t> {
-  static const size_t SIZE = sizeof(__m128i);
-  static const size_t ELEMENTS = SIZE / sizeof(uint64_t);
+  //static const size_t SIZE = sizeof(__m128i);
+  //static const size_t ELEMENTS = SIZE / sizeof(uint64_t);
 
   __m128i value;
 


### PR DESCRIPTION
Unfortunately, instead of just optimizing it out, LLVM/clang sees fit to issue warnings. So we comment them out (we may need them later).

This is a bit of a waste of time.

Fixes https://github.com/simdutf/simdutf/issues/709