### PR TITLE
tests: enable tests for big-endian architectures

### DIFF
--- a/tests/convert_latin1_to_utf16be_tests.cpp
+++ b/tests/convert_latin1_to_utf16be_tests.cpp
@@ -8,7 +8,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
 
 using simdutf::tests::helpers::transcode_latin1_to_utf16_test_base;
 
@@ -20,19 +21,15 @@ TEST_LOOP(trials, convert_all_latin) {
   simdutf::tests::helpers::RandomIntRanges random({{0x00, 0xff}}, seed);
 
   auto procedure = [&implementation](const char *latin1, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    size_t len =
-        implementation.convert_latin1_to_utf16be(latin1, size, utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), size, utf16le);
-    return len;
+                                     char16_t *utf16) -> size_t {
+    return implementation.convert_latin1_to_utf16be(latin1, size, utf16);
   };
   auto size_procedure = [&implementation]([[maybe_unused]] const char *latin1,
                                           size_t size) -> size_t {
     return implementation.utf16_length_from_latin1(size);
   };
   for (size_t size : input_size) {
-    transcode_latin1_to_utf16_test_base test(random, size);
+    transcode_latin1_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }

--- a/tests/convert_latin1_to_utf16le_tests.cpp
+++ b/tests/convert_latin1_to_utf16le_tests.cpp
@@ -7,7 +7,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness LE = simdutf::endianness::LITTLE;
 
 using simdutf::tests::helpers::transcode_latin1_to_utf16_test_base;
 
@@ -27,7 +28,7 @@ TEST_LOOP(trials, convert_all_latin) {
     return implementation.utf16_length_from_latin1(size);
   };
   for (size_t size : input_size) {
-    transcode_latin1_to_utf16_test_base test(random, size);
+    transcode_latin1_to_utf16_test_base test(LE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }

--- a/tests/convert_utf16be_to_latin1_tests.cpp
+++ b/tests/convert_utf16be_to_latin1_tests.cpp
@@ -9,7 +9,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
 
 using simdutf::tests::helpers::transcode_utf16_to_latin1_test_base;
 
@@ -23,13 +24,13 @@ TEST_LOOP(trials, convert_random_inputs) {
   for (size_t size : input_size) {
     std::vector<char16_t> utf16(size);
     for (size_t i = 0; i < size; i++) {
-      utf16[i] = r();
+      utf16[i] = to_utf16be(r());
     }
     size_t buffer_size = implementation.latin1_length_from_utf16(size);
     std::vector<char> latin1(buffer_size);
     size_t actual_size = implementation.convert_utf16be_to_latin1(
         utf16.data(), size, latin1.data());
-    if (simdutf::tests::reference::validate_utf16_to_latin1(utf16.data(),
+    if (simdutf::tests::reference::validate_utf16_to_latin1(BE, utf16.data(),
                                                             size)) {
       ASSERT_EQUAL(buffer_size, actual_size);
     } else {
@@ -40,18 +41,11 @@ TEST_LOOP(trials, convert_random_inputs) {
 
 TEST_LOOP(trials, convert_2_UTF16_bytes) {
   // range for 1, 2 or 3 UTF-8 bytes
-  simdutf::tests::helpers::RandomIntRanges random(
-      {
-          {0x0000, 0x00ff},
-      },
-      seed);
+  simdutf::tests::helpers::RandomInt random(0x0000, 0x00ff, seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *latin1) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_latin1(utf16be.data(), size,
-                                                    latin1);
+    return implementation.convert_utf16be_to_latin1(utf16, size, latin1);
   };
   auto size_procedure =
       [&implementation]([[maybe_unused]] const char16_t *utf16,
@@ -59,7 +53,7 @@ TEST_LOOP(trials, convert_2_UTF16_bytes) {
     return implementation.latin1_length_from_utf16(size);
   };
   for (size_t size : input_size) {
-    transcode_utf16_to_latin1_test_base test(random, size);
+    transcode_utf16_to_latin1_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -69,35 +63,16 @@ TEST(convert_fails_if_input_too_large) {
   uint32_t seed{12};
   simdutf::tests::helpers::RandomInt generator(0x00ff, 0xffff, seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *latin1) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    auto result =
-        implementation.convert_utf16be_to_latin1(utf16be.data(), size, latin1);
+    auto result = implementation.convert_utf16be_to_latin1(utf16, size, latin1);
     return result;
   };
   const size_t size = 64;
-  transcode_utf16_to_latin1_test_base test(
-      []() { return '*'; },
-      size + 32); // for big endian, test encodes in BE. e.g. '*' becomes 0x2a00
-                  // instead of 0x002a
+  transcode_utf16_to_latin1_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (size_t j = 0; j < 1000; j++) {
-    uint16_t wrong_value = generator();
-#if SIMDUTF_IS_BIG_ENDIAN // Big endian systems invert the declared generator's
-                          // numbers when committed to memory.
-    // Each codepoints above 255 are thus mirrored.
-    // e.g. abcd becomes cdab, and vice versa. This is for most codepoints,not a
-    // cause for concern. One case is however problematic, that of the numbers
-    // in the BE format 0xYY00 where the mirror image indicates a number beneath
-    // 255 which is undesirable in this particular test.
-    if ((wrong_value & 0xFF00) != 0) {
-      // In this case, we swap bytes of the generated value:
-      wrong_value = uint16_t((wrong_value >> 8) | (wrong_value << 8));
-    }
-#endif
-
+    const uint16_t wrong_value = to_utf16be(generator());
     for (size_t i = 0; i < size; i++) {
       auto old = test.input_utf16[i];
       test.input_utf16[i] = wrong_value;

--- a/tests/convert_utf16be_to_latin1_tests_with_errors.cpp
+++ b/tests/convert_utf16be_to_latin1_tests_with_errors.cpp
@@ -10,15 +10,14 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
 
 using simdutf::tests::helpers::transcode_utf16_to_latin1_test_base;
 
 constexpr int trials = 1000;
 } // namespace
-#if SIMDUTF_IS_BIG_ENDIAN
-// guarding little endian tests
-#else
+
 TEST(issue_convert_utf16be_to_latin1_with_errors_461) {
   const unsigned char data[] = {0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                 0x00, 0x20, 0x00, 0x20, 0x00, 0x20, 0x00, 0x20,
@@ -57,18 +56,16 @@ TEST(issue_convert_utf16be_to_latin1_with_errors_cbf29ce484222384) {
   ASSERT_EQUAL(r.count, 0);
   ASSERT_EQUAL(r.error, simdutf::error_code::TOO_LARGE);
 }
-#endif
 
 TEST_LOOP(trials, convert_2_UTF16_bytes) {
   // range for 1, 2 or 3 UTF-8 bytes
   simdutf::tests::helpers::RandomIntRanges random({{0x0000, 0x00ff}}, seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *latin1) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    simdutf::result res = implementation.convert_utf16be_to_latin1_with_errors(
-        utf16be.data(), size, latin1);
+    const simdutf::result res =
+        implementation.convert_utf16be_to_latin1_with_errors(utf16, size,
+                                                             latin1);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
     return res.count;
   };
@@ -78,7 +75,7 @@ TEST_LOOP(trials, convert_2_UTF16_bytes) {
     return implementation.latin1_length_from_utf16(size);
   };
   for (size_t size : input_size) {
-    transcode_utf16_to_latin1_test_base test(random, size);
+    transcode_utf16_to_latin1_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -89,39 +86,22 @@ TEST(convert_fails_if_input_too_large) {
   simdutf::tests::helpers::RandomInt generator(0xff, 0xffff, seed);
 
   const size_t size = 64;
-  transcode_utf16_to_latin1_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_latin1_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (size_t j = 0; j < 1000; j++) {
-
-    uint16_t wrong_value = generator();
-#if SIMDUTF_IS_BIG_ENDIAN // Big endian systems invert the declared generator's
-                          // numbers when committed to memory.
-    // Each codepoints above 255 are thus mirrored.
-    // e.g. abcd becomes cdab, and vice versa. This is for most codepoints,not a
-    // cause for concern. One case is however problematic, that of the numbers
-    // in the BE format 0xYY00 where the mirror image indicates a number beneath
-    // 255 which is undesirable in this particular test.
-    if ((wrong_value & 0xFF00) != 0) {
-      // In this case, we swap bytes of the generated value:
-      wrong_value = uint16_t((wrong_value >> 8) | (wrong_value << 8));
-    }
-#endif
+    const auto wrong_value = to_utf16be(generator());
     for (size_t i = 0; i < size; i++) {
-
-      auto procedure = [&implementation, &i](const char16_t *utf16le,
-                                             size_t size,
+      auto procedure = [&implementation, &i](const char16_t *utf16, size_t size,
                                              char *latin1) -> size_t {
-        std::vector<char16_t> utf16be(size);
-        implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-        simdutf::result res =
-            implementation.convert_utf16be_to_latin1_with_errors(utf16be.data(),
-                                                                 size, latin1);
-        ASSERT_EQUAL(res.error, 5);
+        const simdutf::result res =
+            implementation.convert_utf16be_to_latin1_with_errors(utf16, size,
+                                                                 latin1);
+        ASSERT_EQUAL(res.error, simdutf::error_code::TOO_LARGE);
         ASSERT_EQUAL(res.count, i);
         return 0;
       };
 
-      auto old = test.input_utf16[i];
+      const auto old = test.input_utf16[i];
       test.input_utf16[i] = wrong_value;
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i] = old;

--- a/tests/convert_utf16be_to_utf32_tests.cpp
+++ b/tests/convert_utf16be_to_utf32_tests.cpp
@@ -9,7 +9,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
 
 using simdutf::tests::helpers::transcode_utf16_to_utf32_test_base;
 
@@ -22,20 +23,16 @@ TEST_LOOP(trials, convert_2_UTF16_bytes) {
       {{0x0000, 0x007f}, {0x0080, 0x07ff}, {0x0800, 0xd7ff}, {0xe000, 0xffff}},
       seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf32(utf16be.data(), size, utf32);
+    return implementation.convert_utf16be_to_utf32(utf16, size, utf32);
   };
-  auto size_procedure = [&implementation](const char16_t *utf16le,
+  auto size_procedure = [&implementation](const char16_t *utf16,
                                           size_t size) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.utf32_length_from_utf16be(utf16be.data(), size);
+    return implementation.utf32_length_from_utf16be(utf16, size);
   };
   for (size_t size : input_size) {
-    transcode_utf16_to_utf32_test_base test(random, size);
+    transcode_utf16_to_utf32_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -46,126 +43,96 @@ TEST_LOOP(trials, convert_with_surrogates) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0800, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf32(utf16be.data(), size, utf32);
+    return implementation.convert_utf16be_to_utf32(utf16, size, utf32);
   };
-  auto size_procedure = [&implementation](const char16_t *utf16le,
+  auto size_procedure = [&implementation](const char16_t *utf16,
                                           size_t size) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.utf32_length_from_utf16be(utf16be.data(), size);
+    return implementation.utf32_length_from_utf16be(utf16, size);
   };
   for (size_t size : input_size) {
-    transcode_utf16_to_utf32_test_base test(random, size);
+    transcode_utf16_to_utf32_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
 }
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(convert_fails_if_there_is_sole_low_surrogate) {
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf32(utf16be.data(), size, utf32);
+    return implementation.convert_utf16be_to_utf32(utf16, size, utf32);
   };
   const size_t size = 64;
-  transcode_utf16_to_utf32_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf32_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (char16_t low_surrogate = 0xdc00; low_surrogate <= 0xdfff;
        low_surrogate++) {
     for (size_t i = 0; i < size; i++) {
       const auto old = test.input_utf16[i];
-      test.input_utf16[i] = low_surrogate;
+      test.input_utf16[i] = to_utf16be(low_surrogate);
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i] = old;
     }
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(convert_fails_if_there_is_sole_high_surrogate) {
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf32(utf16be.data(), size, utf32);
+    return implementation.convert_utf16be_to_utf32(utf16, size, utf32);
   };
 
   const size_t size = 64;
-  transcode_utf16_to_utf32_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf32_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (char16_t high_surrogate = 0xdc00; high_surrogate <= 0xdfff;
        high_surrogate++) {
     for (size_t i = 0; i < size; i++) {
-
       const auto old = test.input_utf16[i];
-      test.input_utf16[i] = high_surrogate;
+      test.input_utf16[i] = to_utf16be(high_surrogate);
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i] = old;
     }
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(
     convert_fails_if_there_is_low_surrogate_is_followed_by_another_low_surrogate) {
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf32(utf16be.data(), size, utf32);
+    return implementation.convert_utf16be_to_utf32(utf16, size, utf32);
   };
 
   const size_t size = 64;
-  transcode_utf16_to_utf32_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf32_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (char16_t low_surrogate = 0xdc00; low_surrogate <= 0xdfff;
        low_surrogate++) {
     for (size_t i = 0; i < size - 1; i++) {
-
       const auto old0 = test.input_utf16[i + 0];
       const auto old1 = test.input_utf16[i + 1];
-      test.input_utf16[i + 0] = low_surrogate;
-      test.input_utf16[i + 1] = low_surrogate;
+      test.input_utf16[i + 0] = to_utf16be(low_surrogate);
+      test.input_utf16[i + 1] = to_utf16be(low_surrogate);
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i + 0] = old0;
       test.input_utf16[i + 1] = old1;
     }
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(convert_fails_if_there_is_surrogate_pair_is_followed_by_high_surrogate) {
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf32(utf16be.data(), size, utf32);
+    return implementation.convert_utf16be_to_utf32(utf16, size, utf32);
   };
 
   const size_t size = 64;
-  transcode_utf16_to_utf32_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf32_test_base test(BE, []() { return '*'; }, size + 32);
 
-  const char16_t low_surrogate = 0xd801;
-  const char16_t high_surrogate = 0xdc02;
+  const char16_t low_surrogate = to_utf16be(0xd801);
+  const char16_t high_surrogate = to_utf16be(0xdc02);
   for (size_t i = 0; i < size - 2; i++) {
-
     const auto old0 = test.input_utf16[i + 0];
     const auto old1 = test.input_utf16[i + 1];
     const auto old2 = test.input_utf16[i + 2];
@@ -178,102 +145,19 @@ TEST(convert_fails_if_there_is_surrogate_pair_is_followed_by_high_surrogate) {
     test.input_utf16[i + 2] = old2;
   }
 }
-#endif
-
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
-namespace {
-std::vector<std::vector<char16_t>> all_combinations() {
-  const char16_t V_1byte_start =
-      0x0042; // non-surrogate word the yields 1 UTF-8 byte
-  const char16_t V_2bytes_start =
-      0x017f; // non-surrogate word the yields 2 UTF-8 bytes
-  const char16_t V_3bytes_start =
-      0xefff;                // non-surrogate word the yields 3 UTF-8 bytes
-  const char16_t L = 0xd9ca; // low surrogate
-  const char16_t H = 0xde42; // high surrogate
-
-  std::vector<std::vector<char16_t>> result;
-  std::vector<char16_t> row(32, '*');
-
-  std::array<int, 8> pattern{0};
-  while (true) {
-    // if (result.size() > 5) break;
-
-    // 1. produce output
-    char16_t V_1byte = V_1byte_start;
-    char16_t V_2bytes = V_2bytes_start;
-    char16_t V_3bytes = V_3bytes_start;
-    for (int i = 0; i < 8; i++) {
-      switch (pattern[i]) {
-      case 0:
-        row[i] = V_1byte++;
-        break;
-      case 1:
-        row[i] = V_2bytes++;
-        break;
-      case 2:
-        row[i] = V_3bytes++;
-        break;
-      case 3:
-        row[i] = L;
-        break;
-      case 4:
-        row[i] = H;
-        break;
-      default:
-        abort();
-      }
-    } // for
-
-    if (row[7] == L) {
-      row[8] = H; // make input valid
-      result.push_back(row);
-
-      row[8] = V_1byte; // broken input
-      result.push_back(row);
-    } else {
-      row[8] = V_1byte;
-      result.push_back(row);
-    }
-
-    // next pattern
-    int i = 0;
-    int carry = 1;
-    for (/**/; i < 8 && carry; i++) {
-      pattern[i] += carry;
-      if (pattern[i] == 5) {
-        pattern[i] = 0;
-        carry = 1;
-      } else
-        carry = 0;
-    }
-
-    if (carry == 1 and i == 8)
-      break;
-
-  } // while
-
-  return result;
-}
-} // namespace
 
 TEST(all_possible_8_codepoint_combinations) {
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf32(utf16be.data(), size, utf32);
+    return implementation.convert_utf16be_to_utf32(utf16, size, utf32);
   };
 
   std::vector<char32_t> output_utf32(256, ' ');
-  const auto &combinations = all_combinations();
+  const auto &combinations = all_utf16_combinations(BE);
   for (const auto &input_utf16 : combinations) {
-
-    if (simdutf::tests::reference::validate_utf16(input_utf16.data(),
+    if (simdutf::tests::reference::validate_utf16(BE, input_utf16.data(),
                                                   input_utf16.size())) {
-      transcode_utf16_to_utf32_test_base test(input_utf16);
+      transcode_utf16_to_utf32_test_base test(BE, input_utf16);
       ASSERT_TRUE(test(procedure));
     } else {
       ASSERT_FALSE(procedure(input_utf16.data(), input_utf16.size(),
@@ -281,6 +165,5 @@ TEST(all_possible_8_codepoint_combinations) {
     }
   }
 }
-#endif
 
 TEST_MAIN

--- a/tests/convert_utf16be_to_utf32_with_errors_tests.cpp
+++ b/tests/convert_utf16be_to_utf32_with_errors_tests.cpp
@@ -8,16 +8,14 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
 
 using simdutf::tests::helpers::transcode_utf16_to_utf32_test_base;
 
 constexpr int trials = 1000;
 } // namespace
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(issue_convert_utf16be_to_utf32_with_errors_7f6091b746e6e764) {
   alignas(2) const unsigned char data[] = {
       0xc2, 0x90, 0x00, 0x00, 0x00, 0x00, 0x53, 0x53, 0x00, 0x00, 0x00, 0x00,
@@ -204,7 +202,6 @@ TEST(issue_convert_utf16be_to_utf32_with_errors_7f6091b746e6e764) {
   ASSERT_EQUAL(r.error, simdutf::error_code::SURROGATE);
   ASSERT_EQUAL(r.count, 945);
 }
-#endif
 
 TEST_LOOP(trials, convert_2_UTF16_bytes) {
   // range for 1, 2 or 3 UTF-8 bytes
@@ -212,21 +209,19 @@ TEST_LOOP(trials, convert_2_UTF16_bytes) {
       {{0x0000, 0x007f}, {0x0080, 0x07ff}, {0x0800, 0xd7ff}, {0xe000, 0xffff}},
       seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    simdutf::result res = implementation.convert_utf16be_to_utf32_with_errors(
-        utf16be.data(), size, utf32);
+    const simdutf::result res =
+        implementation.convert_utf16be_to_utf32_with_errors(utf16, size, utf32);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
     return res.count;
   };
   auto size_procedure = [&implementation](const char16_t *utf16,
                                           size_t size) -> size_t {
-    return implementation.utf32_length_from_utf16le(utf16, size);
+    return implementation.utf32_length_from_utf16be(utf16, size);
   };
   for (size_t size : input_size) {
-    transcode_utf16_to_utf32_test_base test(random, size);
+    transcode_utf16_to_utf32_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -236,139 +231,112 @@ TEST_LOOP(trials, convert_with_surrogates) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0800, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    simdutf::result res = implementation.convert_utf16be_to_utf32_with_errors(
-        utf16be.data(), size, utf32);
+    const simdutf::result res =
+        implementation.convert_utf16be_to_utf32_with_errors(utf16, size, utf32);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
     return res.count;
   };
   auto size_procedure = [&implementation](const char16_t *utf16,
                                           size_t size) -> size_t {
-    return implementation.utf32_length_from_utf16le(utf16, size);
+    return implementation.utf32_length_from_utf16be(utf16, size);
   };
   for (size_t size : input_size) {
-    transcode_utf16_to_utf32_test_base test(random, size);
+    transcode_utf16_to_utf32_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
 }
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(convert_fails_if_there_is_sole_low_surrogate) {
   const size_t size = 64;
-  transcode_utf16_to_utf32_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf32_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (char16_t low_surrogate = 0xdc00; low_surrogate <= 0xdfff;
        low_surrogate++) {
     for (size_t i = 0; i < size; i++) {
-      auto procedure = [&implementation, &i](const char16_t *utf16le,
-                                             size_t size,
+      auto procedure = [&implementation, &i](const char16_t *utf16, size_t size,
                                              char32_t *utf32) -> size_t {
-        std::vector<char16_t> utf16be(size);
-        implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-        simdutf::result res =
-            implementation.convert_utf16be_to_utf32_with_errors(utf16be.data(),
-                                                                size, utf32);
+        const simdutf::result res =
+            implementation.convert_utf16be_to_utf32_with_errors(utf16, size,
+                                                                utf32);
         ASSERT_EQUAL(res.error, simdutf::error_code::SURROGATE);
         ASSERT_EQUAL(res.count, i);
         return 0;
       };
       const auto old = test.input_utf16[i];
-      test.input_utf16[i] = low_surrogate;
+      test.input_utf16[i] = to_utf16be(low_surrogate);
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i] = old;
     }
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(convert_fails_if_there_is_sole_high_surrogate) {
   const size_t size = 64;
-  transcode_utf16_to_utf32_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf32_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (char16_t high_surrogate = 0xdc00; high_surrogate <= 0xdfff;
        high_surrogate++) {
     for (size_t i = 0; i < size; i++) {
-      auto procedure = [&implementation, &i](const char16_t *utf16le,
-                                             size_t size,
+      auto procedure = [&implementation, &i](const char16_t *utf16, size_t size,
                                              char32_t *utf32) -> size_t {
-        std::vector<char16_t> utf16be(size);
-        implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-        simdutf::result res =
-            implementation.convert_utf16be_to_utf32_with_errors(utf16be.data(),
-                                                                size, utf32);
+        const simdutf::result res =
+            implementation.convert_utf16be_to_utf32_with_errors(utf16, size,
+                                                                utf32);
         ASSERT_EQUAL(res.error, simdutf::error_code::SURROGATE);
         ASSERT_EQUAL(res.count, i);
         return 0;
       };
       const auto old = test.input_utf16[i];
-      test.input_utf16[i] = high_surrogate;
+      test.input_utf16[i] = to_utf16be(high_surrogate);
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i] = old;
     }
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(
     convert_fails_if_there_is_low_surrogate_is_followed_by_another_low_surrogate) {
   const size_t size = 64;
-  transcode_utf16_to_utf32_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf32_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (char16_t low_surrogate = 0xdc00; low_surrogate <= 0xdfff;
        low_surrogate++) {
     for (size_t i = 0; i < size - 1; i++) {
-      auto procedure = [&implementation, &i](const char16_t *utf16le,
-                                             size_t size,
+      auto procedure = [&implementation, &i](const char16_t *utf16, size_t size,
                                              char32_t *utf32) -> size_t {
-        std::vector<char16_t> utf16be(size);
-        implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-        simdutf::result res =
-            implementation.convert_utf16be_to_utf32_with_errors(utf16be.data(),
-                                                                size, utf32);
+        const simdutf::result res =
+            implementation.convert_utf16be_to_utf32_with_errors(utf16, size,
+                                                                utf32);
         ASSERT_EQUAL(res.error, simdutf::error_code::SURROGATE);
         ASSERT_EQUAL(res.count, i);
         return 0;
       };
       const auto old0 = test.input_utf16[i + 0];
       const auto old1 = test.input_utf16[i + 1];
-      test.input_utf16[i + 0] = low_surrogate;
-      test.input_utf16[i + 1] = low_surrogate;
+      test.input_utf16[i + 0] = to_utf16be(low_surrogate);
+      test.input_utf16[i + 1] = to_utf16be(low_surrogate);
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i + 0] = old0;
       test.input_utf16[i + 1] = old1;
     }
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(convert_fails_if_there_is_surrogate_pair_is_followed_by_high_surrogate) {
   const size_t size = 64;
-  transcode_utf16_to_utf32_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf32_test_base test(BE, []() { return '*'; }, size + 32);
 
-  const char16_t low_surrogate = 0xd801;
-  const char16_t high_surrogate = 0xdc02;
+  const char16_t low_surrogate = to_utf16be(0xd801);
+  const char16_t high_surrogate = to_utf16be(0xdc02);
   for (size_t i = 0; i < size - 2; i++) {
-    auto procedure = [&implementation, &i](const char16_t *utf16le, size_t size,
+    auto procedure = [&implementation, &i](const char16_t *utf16, size_t size,
                                            char32_t *utf32) -> size_t {
-      std::vector<char16_t> utf16be(size);
-      implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-      simdutf::result res = implementation.convert_utf16be_to_utf32_with_errors(
-          utf16be.data(), size, utf32);
+      const simdutf::result res =
+          implementation.convert_utf16be_to_utf32_with_errors(utf16, size,
+                                                              utf32);
       ASSERT_EQUAL(res.error, simdutf::error_code::SURROGATE);
       ASSERT_EQUAL(res.count, i + 2);
       return 0;
@@ -385,6 +353,5 @@ TEST(convert_fails_if_there_is_surrogate_pair_is_followed_by_high_surrogate) {
     test.input_utf16[i + 2] = old2;
   }
 }
-#endif
 
 TEST_MAIN

--- a/tests/convert_utf16be_to_utf8_tests.cpp
+++ b/tests/convert_utf16be_to_utf8_tests.cpp
@@ -9,7 +9,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
 
 using simdutf::tests::helpers::transcode_utf16_to_utf8_test_base;
 
@@ -20,21 +21,16 @@ TEST(convert_pure_ASCII) {
   size_t counter = 0;
   auto generator = [&counter]() -> uint32_t { return counter++ & 0x7f; };
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf8(utf16be.data(), size, utf8);
+    return implementation.convert_utf16be_to_utf8(utf16, size, utf8);
   };
-  auto size_procedure = [&implementation](const char16_t *utf16le,
+  auto size_procedure = [&implementation](const char16_t *utf16,
                                           size_t size) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.utf8_length_from_utf16be(utf16be.data(), size);
+    return implementation.utf8_length_from_utf16be(utf16, size);
   };
-  std::array<size_t, 1> input_size{16};
   for (size_t size : input_size) {
-    transcode_utf16_to_utf8_test_base test(generator, size);
+    transcode_utf16_to_utf8_test_base test(BE, generator, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -44,20 +40,16 @@ TEST_LOOP(trials, convert_into_1_or_2_UTF8_bytes) {
   simdutf::tests::helpers::RandomInt random(
       0x0000, 0x07ff, seed); // range for 1 or 2 UTF-8 bytes
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf8(utf16be.data(), size, utf8);
+    return implementation.convert_utf16be_to_utf8(utf16, size, utf8);
   };
-  auto size_procedure = [&implementation](const char16_t *utf16le,
+  auto size_procedure = [&implementation](const char16_t *utf16,
                                           size_t size) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.utf8_length_from_utf16be(utf16be.data(), size);
+    return implementation.utf8_length_from_utf16be(utf16, size);
   };
   for (size_t size : input_size) {
-    transcode_utf16_to_utf8_test_base test(random, size);
+    transcode_utf16_to_utf8_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -69,20 +61,16 @@ TEST_LOOP(trials, convert_into_1_or_2_or_3_UTF8_bytes) {
       {{0x0000, 0x007f}, {0x0080, 0x07ff}, {0x0800, 0xd7ff}, {0xe000, 0xffff}},
       seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf8(utf16be.data(), size, utf8);
+    return implementation.convert_utf16be_to_utf8(utf16, size, utf8);
   };
-  auto size_procedure = [&implementation](const char16_t *utf16le,
+  auto size_procedure = [&implementation](const char16_t *utf16,
                                           size_t size) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.utf8_length_from_utf16be(utf16be.data(), size);
+    return implementation.utf8_length_from_utf16be(utf16, size);
   };
   for (size_t size : input_size) {
-    transcode_utf16_to_utf8_test_base test(random, size);
+    transcode_utf16_to_utf8_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -93,126 +81,96 @@ TEST_LOOP(trials, convert_into_3_or_4_UTF8_bytes) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0800, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf8(utf16be.data(), size, utf8);
+    return implementation.convert_utf16be_to_utf8(utf16, size, utf8);
   };
-  auto size_procedure = [&implementation](const char16_t *utf16le,
+  auto size_procedure = [&implementation](const char16_t *utf16,
                                           size_t size) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.utf8_length_from_utf16be(utf16be.data(), size);
+    return implementation.utf8_length_from_utf16be(utf16, size);
   };
   for (size_t size : input_size) {
-    transcode_utf16_to_utf8_test_base test(random, size);
+    transcode_utf16_to_utf8_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
 }
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(convert_fails_if_there_is_sole_low_surrogate) {
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf8(utf16be.data(), size, utf8);
+    return implementation.convert_utf16be_to_utf8(utf16, size, utf8);
   };
   const size_t size = 64;
-  transcode_utf16_to_utf8_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf8_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (char16_t low_surrogate = 0xdc00; low_surrogate <= 0xdfff;
        low_surrogate++) {
     for (size_t i = 0; i < size; i++) {
       const auto old = test.input_utf16[i];
-      test.input_utf16[i] = low_surrogate;
+      test.input_utf16[i] = to_utf16be(low_surrogate);
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i] = old;
     }
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(convert_fails_if_there_is_sole_high_surrogate) {
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf8(utf16be.data(), size, utf8);
+    return implementation.convert_utf16be_to_utf8(utf16, size, utf8);
   };
 
   const size_t size = 64;
-  transcode_utf16_to_utf8_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf8_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (char16_t high_surrogate = 0xdc00; high_surrogate <= 0xdfff;
        high_surrogate++) {
     for (size_t i = 0; i < size; i++) {
-
       const auto old = test.input_utf16[i];
-      test.input_utf16[i] = high_surrogate;
+      test.input_utf16[i] = to_utf16be(high_surrogate);
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i] = old;
     }
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(
     convert_fails_if_there_is_low_surrogate_is_followed_by_another_low_surrogate) {
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf8(utf16be.data(), size, utf8);
+    return implementation.convert_utf16be_to_utf8(utf16, size, utf8);
   };
 
   const size_t size = 64;
-  transcode_utf16_to_utf8_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf8_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (char16_t low_surrogate = 0xdc00; low_surrogate <= 0xdfff;
        low_surrogate++) {
     for (size_t i = 0; i < size - 1; i++) {
-
       const auto old0 = test.input_utf16[i + 0];
       const auto old1 = test.input_utf16[i + 1];
-      test.input_utf16[i + 0] = low_surrogate;
-      test.input_utf16[i + 1] = low_surrogate;
+      test.input_utf16[i + 0] = to_utf16be(low_surrogate);
+      test.input_utf16[i + 1] = to_utf16be(low_surrogate);
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i + 0] = old0;
       test.input_utf16[i + 1] = old1;
     }
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(convert_fails_if_there_is_surrogate_pair_is_followed_by_high_surrogate) {
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf8(utf16be.data(), size, utf8);
+    return implementation.convert_utf16be_to_utf8(utf16, size, utf8);
   };
 
   const size_t size = 64;
-  transcode_utf16_to_utf8_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf8_test_base test(BE, []() { return '*'; }, size + 32);
 
-  const char16_t low_surrogate = 0xd801;
-  const char16_t high_surrogate = 0xdc02;
+  const char16_t low_surrogate = to_utf16be(0xd801);
+  const char16_t high_surrogate = to_utf16be(0xdc02);
   for (size_t i = 0; i < size - 2; i++) {
-
     const auto old0 = test.input_utf16[i + 0];
     const auto old1 = test.input_utf16[i + 1];
     const auto old2 = test.input_utf16[i + 2];
@@ -225,102 +183,19 @@ TEST(convert_fails_if_there_is_surrogate_pair_is_followed_by_high_surrogate) {
     test.input_utf16[i + 2] = old2;
   }
 }
-#endif
-
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
-namespace {
-std::vector<std::vector<char16_t>> all_combinations() {
-  const char16_t V_1byte_start =
-      0x0042; // non-surrogate word the yields 1 UTF-8 byte
-  const char16_t V_2bytes_start =
-      0x017f; // non-surrogate word the yields 2 UTF-8 bytes
-  const char16_t V_3bytes_start =
-      0xefff;                // non-surrogate word the yields 3 UTF-8 bytes
-  const char16_t L = 0xd9ca; // low surrogate
-  const char16_t H = 0xde42; // high surrogate
-
-  std::vector<std::vector<char16_t>> result;
-  std::vector<char16_t> row(32, '*');
-
-  std::array<int, 8> pattern{0};
-  while (true) {
-    // if (result.size() > 5) break;
-
-    // 1. produce output
-    char16_t V_1byte = V_1byte_start;
-    char16_t V_2bytes = V_2bytes_start;
-    char16_t V_3bytes = V_3bytes_start;
-    for (int i = 0; i < 8; i++) {
-      switch (pattern[i]) {
-      case 0:
-        row[i] = V_1byte++;
-        break;
-      case 1:
-        row[i] = V_2bytes++;
-        break;
-      case 2:
-        row[i] = V_3bytes++;
-        break;
-      case 3:
-        row[i] = L;
-        break;
-      case 4:
-        row[i] = H;
-        break;
-      default:
-        abort();
-      }
-    } // for
-
-    if (row[7] == L) {
-      row[8] = H; // make input valid
-      result.push_back(row);
-
-      row[8] = V_1byte; // broken input
-      result.push_back(row);
-    } else {
-      row[8] = V_1byte;
-      result.push_back(row);
-    }
-
-    // next pattern
-    int i = 0;
-    int carry = 1;
-    for (/**/; i < 8 && carry; i++) {
-      pattern[i] += carry;
-      if (pattern[i] == 5) {
-        pattern[i] = 0;
-        carry = 1;
-      } else
-        carry = 0;
-    }
-
-    if (carry == 1 and i == 8)
-      break;
-
-  } // while
-
-  return result;
-}
-} // namespace
 
 TEST(all_possible_8_codepoint_combinations) {
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_utf16be_to_utf8(utf16be.data(), size, utf8);
+    return implementation.convert_utf16be_to_utf8(utf16, size, utf8);
   };
 
   std::vector<char> output_utf8(256, ' ');
-  const auto &combinations = all_combinations();
+  const auto &combinations = all_utf16_combinations(BE);
   for (const auto &input_utf16 : combinations) {
-
-    if (simdutf::tests::reference::validate_utf16(input_utf16.data(),
+    if (simdutf::tests::reference::validate_utf16(BE, input_utf16.data(),
                                                   input_utf16.size())) {
-      transcode_utf16_to_utf8_test_base test(input_utf16);
+      transcode_utf16_to_utf8_test_base test(BE, input_utf16);
       ASSERT_TRUE(test(procedure));
     } else {
       ASSERT_FALSE(procedure(input_utf16.data(), input_utf16.size(),
@@ -328,7 +203,6 @@ TEST(all_possible_8_codepoint_combinations) {
     }
   }
 }
-#endif
 
 TEST(issue_443) {
   alignas(2) const unsigned char crash[] = {0x20, 0x20};
@@ -338,4 +212,5 @@ TEST(issue_443) {
       (const char16_t *)crash, crash_len / sizeof(char16_t), output.data());
   ASSERT_EQUAL(r, 3); // becomes 3 bytes \xe2\x80\x80
 }
+
 TEST_MAIN

--- a/tests/convert_utf16be_to_utf8_with_errors_tests.cpp
+++ b/tests/convert_utf16be_to_utf8_with_errors_tests.cpp
@@ -8,7 +8,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
 
 using simdutf::tests::helpers::transcode_utf16_to_utf8_test_base;
 
@@ -28,22 +29,21 @@ TEST(convert_pure_ASCII) {
   size_t counter = 0;
   auto generator = [&counter]() -> uint32_t { return counter++ & 0x7f; };
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    simdutf::result res = implementation.convert_utf16be_to_utf8_with_errors(
-        utf16be.data(), size, utf8);
+    simdutf::result res =
+        implementation.convert_utf16be_to_utf8_with_errors(utf16, size, utf8);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
     return res.count;
   };
+
   auto size_procedure = [&implementation](const char16_t *utf16,
                                           size_t size) -> size_t {
-    return implementation.utf8_length_from_utf16le(utf16, size);
+    return implementation.utf8_length_from_utf16be(utf16, size);
   };
-  std::array<size_t, 1> input_size{16};
+
   for (size_t size : input_size) {
-    transcode_utf16_to_utf8_test_base test(generator, size);
+    transcode_utf16_to_utf8_test_base test(BE, generator, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -53,21 +53,21 @@ TEST_LOOP(trials, convert_into_1_or_2_UTF8_bytes) {
   simdutf::tests::helpers::RandomInt random(
       0x0000, 0x07ff, seed); // range for 1 or 2 UTF-8 bytes
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    simdutf::result res = implementation.convert_utf16be_to_utf8_with_errors(
-        utf16be.data(), size, utf8);
+    simdutf::result res =
+        implementation.convert_utf16be_to_utf8_with_errors(utf16, size, utf8);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
     return res.count;
   };
+
   auto size_procedure = [&implementation](const char16_t *utf16,
                                           size_t size) -> size_t {
-    return implementation.utf8_length_from_utf16le(utf16, size);
+    return implementation.utf8_length_from_utf16be(utf16, size);
   };
+
   for (size_t size : input_size) {
-    transcode_utf16_to_utf8_test_base test(random, size);
+    transcode_utf16_to_utf8_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -79,21 +79,19 @@ TEST_LOOP(trials, convert_into_1_or_2_or_3_UTF8_bytes) {
       {{0x0000, 0x007f}, {0x0080, 0x07ff}, {0x0800, 0xd7ff}, {0xe000, 0xffff}},
       seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    simdutf::result res = implementation.convert_utf16be_to_utf8_with_errors(
-        utf16be.data(), size, utf8);
+    simdutf::result res =
+        implementation.convert_utf16be_to_utf8_with_errors(utf16, size, utf8);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
     return res.count;
   };
   auto size_procedure = [&implementation](const char16_t *utf16,
                                           size_t size) -> size_t {
-    return implementation.utf8_length_from_utf16le(utf16, size);
+    return implementation.utf8_length_from_utf16be(utf16, size);
   };
   for (size_t size : input_size) {
-    transcode_utf16_to_utf8_test_base test(random, size);
+    transcode_utf16_to_utf8_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -104,139 +102,111 @@ TEST_LOOP(trials, convert_into_3_or_4_UTF8_bytes) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0800, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    simdutf::result res = implementation.convert_utf16be_to_utf8_with_errors(
-        utf16be.data(), size, utf8);
+    const simdutf::result res =
+        implementation.convert_utf16be_to_utf8_with_errors(utf16, size, utf8);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
     return res.count;
   };
   auto size_procedure = [&implementation](const char16_t *utf16,
                                           size_t size) -> size_t {
-    return implementation.utf8_length_from_utf16le(utf16, size);
+    return implementation.utf8_length_from_utf16be(utf16, size);
   };
   for (size_t size : input_size) {
-    transcode_utf16_to_utf8_test_base test(random, size);
+    transcode_utf16_to_utf8_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
 }
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(convert_fails_if_there_is_sole_low_surrogate) {
   const size_t size = 64;
-  transcode_utf16_to_utf8_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf8_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (char16_t low_surrogate = 0xdc00; low_surrogate <= 0xdfff;
        low_surrogate++) {
     for (size_t i = 0; i < size; i++) {
-      auto procedure = [&implementation, &i](const char16_t *utf16le,
-                                             size_t size,
-                                             char *utf8) -> size_t {
-        std::vector<char16_t> utf16be(size);
-        implementation.change_endianness_utf16(utf16le, size, utf16be.data());
+      auto procedure = [&implementation, i](const char16_t *utf16, size_t size,
+                                            char *utf8) -> size_t {
         simdutf::result res =
-            implementation.convert_utf16be_to_utf8_with_errors(utf16be.data(),
-                                                               size, utf8);
+            implementation.convert_utf16be_to_utf8_with_errors(utf16, size,
+                                                               utf8);
         ASSERT_EQUAL(res.error, simdutf::error_code::SURROGATE);
         ASSERT_EQUAL(res.count, i);
         return 0;
       };
       const auto old = test.input_utf16[i];
-      test.input_utf16[i] = low_surrogate;
+      test.input_utf16[i] = to_utf16be(low_surrogate);
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i] = old;
     }
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(convert_fails_if_there_is_sole_high_surrogate) {
   const size_t size = 64;
-  transcode_utf16_to_utf8_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf8_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (char16_t high_surrogate = 0xdc00; high_surrogate <= 0xdfff;
        high_surrogate++) {
     for (size_t i = 0; i < size; i++) {
-      auto procedure = [&implementation, &i](const char16_t *utf16le,
-                                             size_t size,
+      auto procedure = [&implementation, &i](const char16_t *utf16, size_t size,
                                              char *utf8) -> size_t {
-        std::vector<char16_t> utf16be(size);
-        implementation.change_endianness_utf16(utf16le, size, utf16be.data());
         simdutf::result res =
-            implementation.convert_utf16be_to_utf8_with_errors(utf16be.data(),
-                                                               size, utf8);
+            implementation.convert_utf16be_to_utf8_with_errors(utf16, size,
+                                                               utf8);
         ASSERT_EQUAL(res.error, simdutf::error_code::SURROGATE);
         ASSERT_EQUAL(res.count, i);
         return 0;
       };
       const auto old = test.input_utf16[i];
-      test.input_utf16[i] = high_surrogate;
+      test.input_utf16[i] = to_utf16be(high_surrogate);
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i] = old;
     }
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(
     convert_fails_if_there_is_low_surrogate_is_followed_by_another_low_surrogate) {
   const size_t size = 64;
-  transcode_utf16_to_utf8_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf8_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (char16_t low_surrogate = 0xdc00; low_surrogate <= 0xdfff;
        low_surrogate++) {
     for (size_t i = 0; i < size - 1; i++) {
-      auto procedure = [&implementation, &i](const char16_t *utf16le,
-                                             size_t size,
+      auto procedure = [&implementation, &i](const char16_t *utf16, size_t size,
                                              char *utf8) -> size_t {
-        std::vector<char16_t> utf16be(size);
-        implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-        simdutf::result res =
-            implementation.convert_utf16be_to_utf8_with_errors(utf16be.data(),
-                                                               size, utf8);
+        const simdutf::result res =
+            implementation.convert_utf16be_to_utf8_with_errors(utf16, size,
+                                                               utf8);
         ASSERT_EQUAL(res.error, simdutf::error_code::SURROGATE);
         ASSERT_EQUAL(res.count, i);
         return 0;
       };
       const auto old0 = test.input_utf16[i + 0];
       const auto old1 = test.input_utf16[i + 1];
-      test.input_utf16[i + 0] = low_surrogate;
-      test.input_utf16[i + 1] = low_surrogate;
+      test.input_utf16[i + 0] = to_utf16be(low_surrogate);
+      test.input_utf16[i + 1] = to_utf16be(low_surrogate);
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i + 0] = old0;
       test.input_utf16[i + 1] = old1;
     }
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(convert_fails_if_there_is_surrogate_pair_is_followed_by_high_surrogate) {
   const size_t size = 64;
-  transcode_utf16_to_utf8_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf8_test_base test(BE, []() { return '*'; }, size + 32);
 
-  const char16_t low_surrogate = 0xd801;
-  const char16_t high_surrogate = 0xdc02;
+  const char16_t low_surrogate = to_utf16be(0xd801);
+  const char16_t high_surrogate = to_utf16be(0xdc02);
   for (size_t i = 0; i < size - 2; i++) {
-    auto procedure = [&implementation, &i](const char16_t *utf16le, size_t size,
+    auto procedure = [&implementation, &i](const char16_t *utf16, size_t size,
                                            char *utf8) -> size_t {
-      std::vector<char16_t> utf16be(size);
-      implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-      simdutf::result res = implementation.convert_utf16be_to_utf8_with_errors(
-          utf16be.data(), size, utf8);
+      const simdutf::result res =
+          implementation.convert_utf16be_to_utf8_with_errors(utf16, size, utf8);
       ASSERT_EQUAL(res.error, simdutf::error_code::SURROGATE);
       ASSERT_EQUAL(res.count, i + 2);
       return 0;
@@ -253,7 +223,7 @@ TEST(convert_fails_if_there_is_surrogate_pair_is_followed_by_high_surrogate) {
     test.input_utf16[i + 2] = old2;
   }
 }
-#endif
+
 TEST(issue_445) {
   alignas(2) const unsigned char crash[] = {0x20, 0x20, 0xdd, 0x20};
   const unsigned int crash_len = 4;
@@ -263,4 +233,5 @@ TEST(issue_445) {
   ASSERT_EQUAL(r.count, 1);
   ASSERT_EQUAL(r.error, simdutf::error_code::SURROGATE);
 }
+
 TEST_MAIN

--- a/tests/convert_utf16le_to_utf32_tests.cpp
+++ b/tests/convert_utf16le_to_utf32_tests.cpp
@@ -9,7 +9,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness LE = simdutf::endianness::LITTLE;
 
 using simdutf::tests::helpers::transcode_utf16_to_utf32_test_base;
 
@@ -31,7 +32,7 @@ TEST_LOOP(trials, convert_2_UTF16_bytes) {
     return implementation.utf32_length_from_utf16le(utf16, size);
   };
   for (size_t size : input_size) {
-    transcode_utf16_to_utf32_test_base test(random, size);
+    transcode_utf16_to_utf32_test_base test(LE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -50,38 +51,31 @@ TEST_LOOP(trials, convert_with_surrogates) {
     return implementation.utf32_length_from_utf16le(utf16, size);
   };
   for (size_t size : input_size) {
-    transcode_utf16_to_utf32_test_base test(random, size);
+    transcode_utf16_to_utf32_test_base test(LE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
 }
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(convert_fails_if_there_is_sole_low_surrogate) {
   auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
     return implementation.convert_utf16le_to_utf32(utf16, size, utf32);
   };
   const size_t size = 64;
-  transcode_utf16_to_utf32_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf32_test_base test(LE, []() { return '*'; }, size + 32);
 
   for (char16_t low_surrogate = 0xdc00; low_surrogate <= 0xdfff;
        low_surrogate++) {
     for (size_t i = 0; i < size; i++) {
       const auto old = test.input_utf16[i];
-      test.input_utf16[i] = low_surrogate;
+      test.input_utf16[i] = to_utf16le(low_surrogate);
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i] = old;
     }
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(convert_fails_if_there_is_sole_high_surrogate) {
   auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
@@ -89,24 +83,19 @@ TEST(convert_fails_if_there_is_sole_high_surrogate) {
   };
 
   const size_t size = 64;
-  transcode_utf16_to_utf32_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf32_test_base test(LE, []() { return '*'; }, size + 32);
 
   for (char16_t high_surrogate = 0xd800; high_surrogate <= 0xdbff;
        high_surrogate++) {
     for (size_t i = 0; i < size; i++) {
-
       const auto old = test.input_utf16[i];
-      test.input_utf16[i] = high_surrogate;
+      test.input_utf16[i] = to_utf16le(high_surrogate);
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i] = old;
     }
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(
     convert_fails_if_there_is_low_surrogate_followed_by_another_low_surrogate) {
   auto procedure = [&implementation](const char16_t *utf16, size_t size,
@@ -115,27 +104,22 @@ TEST(
   };
 
   const size_t size = 64;
-  transcode_utf16_to_utf32_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf32_test_base test(LE, []() { return '*'; }, size + 32);
 
   for (char16_t low_surrogate = 0xdc00; low_surrogate <= 0xdfff;
        low_surrogate++) {
     for (size_t i = 0; i < size - 1; i++) {
-
       const auto old0 = test.input_utf16[i + 0];
       const auto old1 = test.input_utf16[i + 1];
-      test.input_utf16[i + 0] = low_surrogate;
-      test.input_utf16[i + 1] = low_surrogate;
+      test.input_utf16[i + 0] = to_utf16le(low_surrogate);
+      test.input_utf16[i + 1] = to_utf16le(low_surrogate);
       ASSERT_TRUE(test(procedure));
       test.input_utf16[i + 0] = old0;
       test.input_utf16[i + 1] = old1;
     }
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
 TEST(convert_fails_if_there_is_surrogate_pair_followed_by_high_surrogate) {
   auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
@@ -143,12 +127,11 @@ TEST(convert_fails_if_there_is_surrogate_pair_followed_by_high_surrogate) {
   };
 
   const size_t size = 64;
-  transcode_utf16_to_utf32_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf16_to_utf32_test_base test(LE, []() { return '*'; }, size + 32);
 
-  const char16_t low_surrogate = 0xd801;
-  const char16_t high_surrogate = 0xdc02;
+  const char16_t low_surrogate = to_utf16le(0xd801);
+  const char16_t high_surrogate = to_utf16le(0xdc02);
   for (size_t i = 0; i < size - 2; i++) {
-
     const auto old0 = test.input_utf16[i + 0];
     const auto old1 = test.input_utf16[i + 1];
     const auto old2 = test.input_utf16[i + 2];
@@ -161,86 +144,6 @@ TEST(convert_fails_if_there_is_surrogate_pair_followed_by_high_surrogate) {
     test.input_utf16[i + 2] = old2;
   }
 }
-#endif
-
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
-namespace {
-std::vector<std::vector<char16_t>> all_combinations() {
-  const char16_t V_1byte_start =
-      0x0042; // non-surrogate word the yields 1 UTF-8 byte
-  const char16_t V_2bytes_start =
-      0x017f; // non-surrogate word the yields 2 UTF-8 bytes
-  const char16_t V_3bytes_start =
-      0xefff;                // non-surrogate word the yields 3 UTF-8 bytes
-  const char16_t L = 0xd9ca; // low surrogate
-  const char16_t H = 0xde42; // high surrogate
-
-  std::vector<std::vector<char16_t>> result;
-  std::vector<char16_t> row(32, '*');
-
-  std::array<int, 8> pattern{0};
-  while (true) {
-    // if (result.size() > 5) break;
-
-    // 1. produce output
-    char16_t V_1byte = V_1byte_start;
-    char16_t V_2bytes = V_2bytes_start;
-    char16_t V_3bytes = V_3bytes_start;
-    for (int i = 0; i < 8; i++) {
-      switch (pattern[i]) {
-      case 0:
-        row[i] = V_1byte++;
-        break;
-      case 1:
-        row[i] = V_2bytes++;
-        break;
-      case 2:
-        row[i] = V_3bytes++;
-        break;
-      case 3:
-        row[i] = L;
-        break;
-      case 4:
-        row[i] = H;
-        break;
-      default:
-        abort();
-      }
-    } // for
-
-    if (row[7] == L) {
-      row[8] = H; // make input valid
-      result.push_back(row);
-
-      row[8] = V_1byte; // broken input
-      result.push_back(row);
-    } else {
-      row[8] = V_1byte;
-      result.push_back(row);
-    }
-
-    // next pattern
-    int i = 0;
-    int carry = 1;
-    for (/**/; i < 8 && carry; i++) {
-      pattern[i] += carry;
-      if (pattern[i] == 5) {
-        pattern[i] = 0;
-        carry = 1;
-      } else
-        carry = 0;
-    }
-
-    if (carry == 1 and i == 8)
-      break;
-
-  } // while
-
-  return result;
-}
-} // namespace
 
 TEST(all_possible_8_codepoint_combinations) {
   auto procedure = [&implementation](const char16_t *utf16, size_t size,
@@ -249,12 +152,12 @@ TEST(all_possible_8_codepoint_combinations) {
   };
 
   std::vector<char32_t> output_utf32(256, ' ');
-  const auto &combinations = all_combinations();
+  const auto &combinations = all_utf16_combinations(LE);
   for (const auto &input_utf16 : combinations) {
 
-    if (simdutf::tests::reference::validate_utf16(input_utf16.data(),
+    if (simdutf::tests::reference::validate_utf16(LE, input_utf16.data(),
                                                   input_utf16.size())) {
-      transcode_utf16_to_utf32_test_base test(input_utf16);
+      transcode_utf16_to_utf32_test_base test(LE, input_utf16);
       ASSERT_TRUE(test(procedure));
     } else {
       ASSERT_FALSE(procedure(input_utf16.data(), input_utf16.size(),
@@ -262,6 +165,5 @@ TEST(all_possible_8_codepoint_combinations) {
     }
   }
 }
-#endif
 
 TEST_MAIN

--- a/tests/convert_utf32_to_utf16be_tests.cpp
+++ b/tests/convert_utf32_to_utf16be_tests.cpp
@@ -8,7 +8,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
 
 using simdutf::tests::helpers::transcode_utf32_to_utf16_test_base;
 
@@ -21,19 +22,15 @@ TEST_LOOP(trials, convert_into_2_UTF16_bytes) {
       {{0x0000, 0xd7ff}, {0xe000, 0xffff}}, seed);
 
   auto procedure = [&implementation](const char32_t *utf32, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    size_t len =
-        implementation.convert_utf32_to_utf16be(utf32, size, utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), size, utf16le);
-    return len;
+                                     char16_t *utf16) -> size_t {
+    return implementation.convert_utf32_to_utf16be(utf32, size, utf16);
   };
   auto size_procedure = [&implementation](const char32_t *utf32,
                                           size_t size) -> size_t {
     return implementation.utf16_length_from_utf32(utf32, size);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -44,19 +41,15 @@ TEST_LOOP(trials, convert_into_4_UTF16_bytes) {
   simdutf::tests::helpers::RandomIntRanges random({{0x10000, 0x10ffff}}, seed);
 
   auto procedure = [&implementation](const char32_t *utf32, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(2 * size);
-    size_t len =
-        implementation.convert_utf32_to_utf16be(utf32, size, utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), len, utf16le);
-    return len;
+                                     char16_t *utf16) -> size_t {
+    return implementation.convert_utf32_to_utf16be(utf32, size, utf16);
   };
   auto size_procedure = [&implementation](const char32_t *utf32,
                                           size_t size) -> size_t {
     return implementation.utf16_length_from_utf32(utf32, size);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -68,19 +61,15 @@ TEST_LOOP(trials, convert_into_2_or_4_UTF16_bytes) {
       {{0x0000, 0xd7ff}, {0xe000, 0xffff}, {0x10000, 0x10ffff}}, seed);
 
   auto procedure = [&implementation](const char32_t *utf32, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(2 * size);
-    size_t len =
-        implementation.convert_utf32_to_utf16be(utf32, size, utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), len, utf16le);
-    return len;
+                                     char16_t *utf16be) -> size_t {
+    return implementation.convert_utf32_to_utf16be(utf32, size, utf16be);
   };
   auto size_procedure = [&implementation](const char32_t *utf32,
                                           size_t size) -> size_t {
     return implementation.utf16_length_from_utf32(utf32, size);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -88,15 +77,11 @@ TEST_LOOP(trials, convert_into_2_or_4_UTF16_bytes) {
 
 TEST(convert_fails_if_there_is_surrogate) {
   auto procedure = [&implementation](const char32_t *utf32, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(2 * size);
-    size_t len =
-        implementation.convert_utf32_to_utf16be(utf32, size, utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), len, utf16le);
-    return len;
+                                     char16_t *utf16be) -> size_t {
+    return implementation.convert_utf32_to_utf16be(utf32, size, utf16be);
   };
   const size_t size = 64;
-  transcode_utf32_to_utf16_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf32_to_utf16_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (char32_t surrogate = 0xd800; surrogate <= 0xdfff; surrogate++) {
     for (size_t i = 0; i < size; i++) {
@@ -113,18 +98,15 @@ TEST(convert_fails_if_input_too_large) {
   simdutf::tests::helpers::RandomInt generator(0x110000, 0xffffffff, seed);
 
   auto procedure = [&implementation](const char32_t *utf32, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(2 * size);
-    size_t len =
-        implementation.convert_utf32_to_utf16be(utf32, size, utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), len, utf16le);
-    return len;
+                                     char16_t *utf16be) -> size_t {
+    return implementation.convert_utf32_to_utf16be(utf32, size, utf16be);
   };
+
   const size_t size = 64;
-  transcode_utf32_to_utf16_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf32_to_utf16_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (size_t j = 0; j < 1000; j++) {
-    uint32_t wrong_value = generator();
+    const uint32_t wrong_value = generator();
     for (size_t i = 0; i < size; i++) {
       auto old = test.input_utf32[i];
       test.input_utf32[i] = wrong_value;

--- a/tests/convert_utf32_to_utf16be_with_errors_tests.cpp
+++ b/tests/convert_utf32_to_utf16be_with_errors_tests.cpp
@@ -8,7 +8,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
 
 using simdutf::tests::helpers::transcode_utf32_to_utf16_test_base;
 
@@ -43,12 +44,10 @@ TEST_LOOP(trials, convert_into_2_UTF16_bytes) {
       {{0x0000, 0xd7ff}, {0xe000, 0xffff}}, seed);
 
   auto procedure = [&implementation](const char32_t *utf32, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(size);
+                                     char16_t *utf16be) -> size_t {
     simdutf::result res = implementation.convert_utf32_to_utf16be_with_errors(
-        utf32, size, utf16be.data());
+        utf32, size, utf16be);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
-    implementation.change_endianness_utf16(utf16be.data(), res.count, utf16le);
     return res.count;
   };
   auto size_procedure = [&implementation](const char32_t *utf32,
@@ -56,7 +55,7 @@ TEST_LOOP(trials, convert_into_2_UTF16_bytes) {
     return implementation.utf16_length_from_utf32(utf32, size);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -67,12 +66,11 @@ TEST_LOOP(trials, convert_into_4_UTF16_bytes) {
   simdutf::tests::helpers::RandomIntRanges random({{0x10000, 0x10ffff}}, seed);
 
   auto procedure = [&implementation](const char32_t *utf32, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(2 * size);
-    simdutf::result res = implementation.convert_utf32_to_utf16be_with_errors(
-        utf32, size, utf16be.data());
+                                     char16_t *utf16be) -> size_t {
+    const simdutf::result res =
+        implementation.convert_utf32_to_utf16be_with_errors(utf32, size,
+                                                            utf16be);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
-    implementation.change_endianness_utf16(utf16be.data(), res.count, utf16le);
     return res.count;
   };
   auto size_procedure = [&implementation](const char32_t *utf32,
@@ -80,7 +78,7 @@ TEST_LOOP(trials, convert_into_4_UTF16_bytes) {
     return implementation.utf16_length_from_utf32(utf32, size);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -92,12 +90,11 @@ TEST_LOOP(trials, convert_into_2_or_4_UTF16_bytes) {
       {{0x0000, 0xd7ff}, {0xe000, 0xffff}, {0x10000, 0x10ffff}}, seed);
 
   auto procedure = [&implementation](const char32_t *utf32, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(2 * size);
-    simdutf::result res = implementation.convert_utf32_to_utf16be_with_errors(
-        utf32, size, utf16be.data());
+                                     char16_t *utf16be) -> size_t {
+    const simdutf::result res =
+        implementation.convert_utf32_to_utf16be_with_errors(utf32, size,
+                                                            utf16be);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
-    implementation.change_endianness_utf16(utf16be.data(), res.count, utf16le);
     return res.count;
   };
   auto size_procedure = [&implementation](const char32_t *utf32,
@@ -105,7 +102,7 @@ TEST_LOOP(trials, convert_into_2_or_4_UTF16_bytes) {
     return implementation.utf16_length_from_utf32(utf32, size);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -113,17 +110,15 @@ TEST_LOOP(trials, convert_into_2_or_4_UTF16_bytes) {
 
 TEST(convert_fails_if_there_is_surrogate) {
   const size_t size = 64;
-  transcode_utf32_to_utf16_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf32_to_utf16_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (char32_t surrogate = 0xd800; surrogate <= 0xdfff; surrogate++) {
     for (size_t i = 0; i < size; i++) {
-      auto procedure = [&implementation,
-                        &i](const char32_t *utf32, size_t size,
-                            [[maybe_unused]] char16_t *utf16le) -> size_t {
-        std::vector<char16_t> utf16be(2 * size);
-        simdutf::result res =
+      auto procedure = [&implementation, &i](const char32_t *utf32, size_t size,
+                                             char16_t *utf16be) -> size_t {
+        const simdutf::result res =
             implementation.convert_utf32_to_utf16be_with_errors(utf32, size,
-                                                                utf16be.data());
+                                                                utf16be);
         ASSERT_EQUAL(res.error, simdutf::error_code::SURROGATE);
         ASSERT_EQUAL(res.count, i);
         return 0;
@@ -141,18 +136,16 @@ TEST(convert_fails_if_input_too_large) {
   simdutf::tests::helpers::RandomInt generator(0x110000, 0xffffffff, seed);
 
   const size_t size = 64;
-  transcode_utf32_to_utf16_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf32_to_utf16_test_base test(BE, []() { return '*'; }, size + 32);
 
   for (size_t j = 0; j < 1000; j++) {
     uint32_t wrong_value = generator();
     for (size_t i = 0; i < size; i++) {
-      auto procedure = [&implementation,
-                        &i](const char32_t *utf32, size_t size,
-                            [[maybe_unused]] char16_t *utf16le) -> size_t {
-        std::vector<char16_t> utf16be(2 * size);
-        simdutf::result res =
+      auto procedure = [&implementation, &i](const char32_t *utf32, size_t size,
+                                             char16_t *utf16be) -> size_t {
+        const simdutf::result res =
             implementation.convert_utf32_to_utf16be_with_errors(utf32, size,
-                                                                utf16be.data());
+                                                                utf16be);
         ASSERT_EQUAL(res.error, simdutf::error_code::TOO_LARGE);
         ASSERT_EQUAL(res.count, i);
         return 0;

--- a/tests/convert_utf32_to_utf16le_tests.cpp
+++ b/tests/convert_utf32_to_utf16le_tests.cpp
@@ -7,7 +7,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness LE = simdutf::endianness::LITTLE;
 
 using simdutf::tests::helpers::transcode_utf32_to_utf16_test_base;
 
@@ -28,7 +29,7 @@ TEST_LOOP(trials, convert_into_2_UTF16_bytes) {
     return implementation.utf16_length_from_utf32(utf32, size);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(LE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -47,7 +48,7 @@ TEST_LOOP(trials, convert_into_4_UTF16_bytes) {
     return implementation.utf16_length_from_utf32(utf32, size);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(LE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -67,7 +68,7 @@ TEST_LOOP(trials, convert_into_2_or_4_UTF16_bytes) {
     return implementation.utf16_length_from_utf32(utf32, size);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(LE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -79,7 +80,7 @@ TEST(convert_fails_if_there_is_surrogate) {
     return implementation.convert_utf32_to_utf16le(utf32, size, utf16);
   };
   const size_t size = 64;
-  transcode_utf32_to_utf16_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf32_to_utf16_test_base test(LE, []() { return '*'; }, size + 32);
 
   for (char32_t surrogate = 0xd800; surrogate <= 0xdfff; surrogate++) {
     for (size_t i = 0; i < size; i++) {
@@ -100,7 +101,7 @@ TEST(convert_fails_if_input_too_large) {
     return implementation.convert_utf32_to_utf16le(utf32, size, utf16);
   };
   const size_t size = 64;
-  transcode_utf32_to_utf16_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf32_to_utf16_test_base test(LE, []() { return '*'; }, size + 32);
 
   for (size_t j = 0; j < 1000; j++) {
     uint32_t wrong_value = generator();

--- a/tests/convert_utf32_to_utf16le_with_errors_tests.cpp
+++ b/tests/convert_utf32_to_utf16le_with_errors_tests.cpp
@@ -8,15 +8,14 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+const std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness LE = simdutf::endianness::LITTLE;
 
 using simdutf::tests::helpers::transcode_utf32_to_utf16_test_base;
 
 constexpr int trials = 1000;
 } // namespace
-#if SIMDUTF_IS_BIG_ENDIAN
-//
-#else
+
 TEST(issue_convert_utf32_to_utf16le_with_errors_97798701a75ebb21) {
   alignas(4) const unsigned char data[] = {
       0xfa, 0x04, 0x03, 0x03, 0x00, 0xef, 0xa1, 0xa5, 0x20, 0xef,
@@ -42,7 +41,6 @@ TEST(issue_convert_utf32_to_utf16le_with_errors_97798701a75ebb21) {
   ASSERT_EQUAL(r.error, simdutf::error_code::TOO_LARGE);
   ASSERT_EQUAL(r.count, 0);
 }
-#endif
 
 TEST_LOOP(trials, convert_into_2_UTF16_bytes) {
   // range for 2 UTF-16 bytes
@@ -61,7 +59,7 @@ TEST_LOOP(trials, convert_into_2_UTF16_bytes) {
     return implementation.utf16_length_from_utf32(utf32, size);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(LE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -83,7 +81,7 @@ TEST_LOOP(trials, convert_into_4_UTF16_bytes) {
     return implementation.utf16_length_from_utf32(utf32, size);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(LE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -106,7 +104,7 @@ TEST_LOOP(trials, convert_into_2_or_4_UTF16_bytes) {
     return implementation.utf16_length_from_utf32(utf32, size);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(LE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -114,7 +112,7 @@ TEST_LOOP(trials, convert_into_2_or_4_UTF16_bytes) {
 
 TEST(convert_fails_if_there_is_surrogate) {
   const size_t size = 64;
-  transcode_utf32_to_utf16_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf32_to_utf16_test_base test(LE, []() { return '*'; }, size + 32);
 
   for (char32_t surrogate = 0xd800; surrogate <= 0xdfff; surrogate++) {
     for (size_t i = 0; i < size; i++) {
@@ -140,7 +138,7 @@ TEST(convert_fails_if_input_too_large) {
   simdutf::tests::helpers::RandomInt generator(0x110000, 0xffffffff, seed);
 
   const size_t size = 64;
-  transcode_utf32_to_utf16_test_base test([]() { return '*'; }, size + 32);
+  transcode_utf32_to_utf16_test_base test(LE, []() { return '*'; }, size + 32);
 
   for (size_t j = 0; j < 1000; j++) {
     uint32_t wrong_value = generator();

--- a/tests/convert_utf32_to_utf8_with_errors_tests.cpp
+++ b/tests/convert_utf32_to_utf8_with_errors_tests.cpp
@@ -16,9 +16,7 @@ using simdutf::tests::helpers::transcode_utf32_to_utf8_test_base;
 constexpr int trials = 1000;
 } // namespace
 
-#if SIMDUTF_IS_BIG_ENDIAN
-//
-#else
+#if !SIMDUTF_IS_BIG_ENDIAN
 TEST(issue_convert_utf32_to_utf8_with_errors_1b8034ed546f4bf7) {
   alignas(4) const unsigned char data[] = {
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -26,8 +24,8 @@ TEST(issue_convert_utf32_to_utf8_with_errors_1b8034ed546f4bf7) {
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
       0xff, 0xf6, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xd5,
       0xd5, 0xd5, 0xd5, 0xd8, 0x00, 0xe2, 0x00, 0xda, 0x59, 0xdc, 0x00, 0x00};
-  constexpr std::size_t data_len_bytes = sizeof(data);
-  constexpr std::size_t data_len = data_len_bytes / sizeof(char32_t);
+  constexpr size_t data_len_bytes = sizeof(data);
+  constexpr size_t data_len = data_len_bytes / sizeof(char32_t);
   const auto validation1 = implementation.validate_utf32_with_errors(
       (const char32_t *)data, data_len);
   ASSERT_EQUAL(validation1.count, 11);
@@ -45,6 +43,7 @@ TEST(issue_convert_utf32_to_utf8_with_errors_1b8034ed546f4bf7) {
   ASSERT_EQUAL(r.error, simdutf::error_code::TOO_LARGE);
   ASSERT_EQUAL(r.count, 11);
 }
+
 TEST(issue_convert_utf32_to_utf8_with_errors_cbf29ce484222315) {
   const unsigned char data[] = {
       0x20, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00,

--- a/tests/convert_utf8_to_utf16be_with_errors_tests.cpp
+++ b/tests/convert_utf8_to_utf16be_with_errors_tests.cpp
@@ -10,7 +10,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
 
 using simdutf::tests::helpers::transcode_utf8_to_utf16_test_base;
 
@@ -137,12 +138,9 @@ TEST_LOOP(trials, convert_pure_ASCII) {
   auto generator = [&counter]() -> uint32_t { return counter++ & 0x7f; };
 
   auto procedure = [&implementation](const char *utf8, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(
-        2 * size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
-    simdutf::result res = implementation.convert_utf8_to_utf16be_with_errors(
-        utf8, size, utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), res.count, utf16le);
+                                     char16_t *utf16be) -> size_t {
+    const simdutf::result res =
+        implementation.convert_utf8_to_utf16be_with_errors(utf8, size, utf16be);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
     return res.count;
   };
@@ -152,7 +150,7 @@ TEST_LOOP(trials, convert_pure_ASCII) {
   };
 
   for (size_t size : input_size) {
-    transcode_utf8_to_utf16_test_base test(generator, size);
+    transcode_utf8_to_utf16_test_base test(BE, generator, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -163,21 +161,20 @@ TEST_LOOP(trials, convert_1_or_2_UTF8_bytes) {
       0x0000, 0x07ff, seed); // range for 1 or 2 UTF-8 bytes
 
   auto procedure = [&implementation](const char *utf8, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(
-        2 * size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
-    simdutf::result res = implementation.convert_utf8_to_utf16be_with_errors(
-        utf8, size, utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), res.count, utf16le);
+                                     char16_t *utf16be) -> size_t {
+    const simdutf::result res =
+        implementation.convert_utf8_to_utf16be_with_errors(utf8, size, utf16be);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
     return res.count;
   };
+
   auto size_procedure = [&implementation](const char *utf8,
                                           size_t size) -> size_t {
     return implementation.utf16_length_from_utf8(utf8, size);
   };
+
   for (size_t size : input_size) {
-    transcode_utf8_to_utf16_test_base test(random, size);
+    transcode_utf8_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -189,21 +186,20 @@ TEST_LOOP(trials, convert_1_or_2_or_3_UTF8_bytes) {
       {{0x0000, 0xd7ff}, {0xe000, 0xffff}}, seed);
 
   auto procedure = [&implementation](const char *utf8, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(
-        2 * size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
-    simdutf::result res = implementation.convert_utf8_to_utf16be_with_errors(
-        utf8, size, utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), res.count, utf16le);
+                                     char16_t *utf16be) -> size_t {
+    const simdutf::result res =
+        implementation.convert_utf8_to_utf16be_with_errors(utf8, size, utf16be);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
     return res.count;
   };
+
   auto size_procedure = [&implementation](const char *utf8,
                                           size_t size) -> size_t {
     return implementation.utf16_length_from_utf8(utf8, size);
   };
+
   for (size_t size : input_size) {
-    transcode_utf8_to_utf16_test_base test(random, size);
+    transcode_utf8_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -215,21 +211,20 @@ TEST_LOOP(trials, convert_3_or_4_UTF8_bytes) {
       seed); // range for 3 or 4 UTF-8 bytes
 
   auto procedure = [&implementation](const char *utf8, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(
-        2 * size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
-    simdutf::result res = implementation.convert_utf8_to_utf16be_with_errors(
-        utf8, size, utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), res.count, utf16le);
+                                     char16_t *utf16be) -> size_t {
+    const simdutf::result res =
+        implementation.convert_utf8_to_utf16be_with_errors(utf8, size, utf16be);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
     return res.count;
   };
+
   auto size_procedure = [&implementation](const char *utf8,
                                           size_t size) -> size_t {
     return implementation.utf16_length_from_utf8(utf8, size);
   };
+
   for (size_t size : input_size) {
-    transcode_utf8_to_utf16_test_base test(random, size);
+    transcode_utf8_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -240,21 +235,20 @@ TEST_LOOP(trials, convert_3_UTF8_bytes) {
                                             seed); // range for 3 UTF-8 bytes
 
   auto procedure = [&implementation](const char *utf8, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(
-        2 * size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
-    simdutf::result res = implementation.convert_utf8_to_utf16be_with_errors(
-        utf8, size, utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), res.count, utf16le);
+                                     char16_t *utf16be) -> size_t {
+    const simdutf::result res =
+        implementation.convert_utf8_to_utf16be_with_errors(utf8, size, utf16be);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
     return res.count;
   };
+
   auto size_procedure = [&implementation](const char *utf8,
                                           size_t size) -> size_t {
     return implementation.utf16_length_from_utf8(utf8, size);
   };
+
   for (size_t size : input_size) {
-    transcode_utf8_to_utf16_test_base test(random, size);
+    transcode_utf8_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -265,21 +259,20 @@ TEST_LOOP(trials, convert_2_UTF8_bytes) {
                                             seed); // range for 2 UTF-8 bytes
 
   auto procedure = [&implementation](const char *utf8, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(
-        2 * size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
-    simdutf::result res = implementation.convert_utf8_to_utf16be_with_errors(
-        utf8, size, utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), res.count, utf16le);
+                                     char16_t *utf16be) -> size_t {
+    const simdutf::result res =
+        implementation.convert_utf8_to_utf16be_with_errors(utf8, size, utf16be);
     ASSERT_EQUAL(res.error, simdutf::error_code::SUCCESS);
     return res.count;
   };
+
   auto size_procedure = [&implementation](const char *utf8,
                                           size_t size) -> size_t {
     return implementation.utf16_length_from_utf8(utf8, size);
   };
+
   for (size_t size : input_size) {
-    transcode_utf8_to_utf16_test_base test(random, size);
+    transcode_utf8_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }
@@ -289,20 +282,16 @@ TEST_LOOP(trials, header_bits_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
 
-  transcode_utf8_to_utf16_test_base test(random, fix_size);
+  transcode_utf8_to_utf16_test_base test(BE, random, fix_size);
 
   for (unsigned int i = 0; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11000000) !=
         0b10000000) { // Only process leading bytes
-      auto procedure = [&implementation,
-                        &i](const char *utf8, size_t size,
-                            [[maybe_unused]] char16_t *utf16le) -> size_t {
-        std::vector<char16_t> utf16be(
-            2 *
-            size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
-        simdutf::result res =
+      auto procedure = [&implementation, &i](const char *utf8, size_t size,
+                                             char16_t *utf16be) -> size_t {
+        const simdutf::result res =
             implementation.convert_utf8_to_utf16be_with_errors(utf8, size,
-                                                               utf16be.data());
+                                                               utf16be);
         ASSERT_EQUAL(res.error, simdutf::error_code::HEADER_BITS);
         ASSERT_EQUAL(res.count, i);
         return 0;
@@ -318,21 +307,18 @@ TEST_LOOP(trials, header_bits_error) {
 TEST_LOOP(trials, too_short_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
-  transcode_utf8_to_utf16_test_base test(random, fix_size);
+  transcode_utf8_to_utf16_test_base test(BE, random, fix_size);
   unsigned int leading_byte_pos = 0;
   for (unsigned int i = 0; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11000000) ==
         0b10000000) { // Only process continuation bytes by making them leading
                       // bytes
-      auto procedure = [&implementation, &leading_byte_pos](
-                           const char *utf8, size_t size,
-                           [[maybe_unused]] char16_t *utf16le) -> size_t {
-        std::vector<char16_t> utf16be(
-            2 *
-            size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
-        simdutf::result res =
+      auto procedure = [&implementation,
+                        &leading_byte_pos](const char *utf8, size_t size,
+                                           char16_t *utf16be) -> size_t {
+        const simdutf::result res =
             implementation.convert_utf8_to_utf16be_with_errors(utf8, size,
-                                                               utf16be.data());
+                                                               utf16be);
         ASSERT_EQUAL(res.error, simdutf::error_code::TOO_SHORT);
         ASSERT_EQUAL(res.count, leading_byte_pos);
         return 0;
@@ -350,20 +336,18 @@ TEST_LOOP(trials, too_short_error) {
 TEST_LOOP(trials, too_long_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
-  transcode_utf8_to_utf16_test_base test(random, fix_size);
+
+  transcode_utf8_to_utf16_test_base test(BE, random, fix_size);
+
   for (unsigned int i = 1; i < fix_size; i++) {
     if (((test.input_utf8[i] & 0b11000000) !=
          0b10000000)) { // Only process leading bytes by making them
                         // continuation bytes
-      auto procedure = [&implementation,
-                        &i](const char *utf8, size_t size,
-                            [[maybe_unused]] char16_t *utf16) -> size_t {
-        std::vector<char16_t> utf16be(
-            2 *
-            size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
-        simdutf::result res =
+      auto procedure = [&implementation, &i](const char *utf8, size_t size,
+                                             char16_t *utf16be) -> size_t {
+        const simdutf::result res =
             implementation.convert_utf8_to_utf16be_with_errors(utf8, size,
-                                                               utf16be.data());
+                                                               utf16be);
         ASSERT_EQUAL(res.error, simdutf::error_code::TOO_LONG);
         ASSERT_EQUAL(res.count, i);
         return 0;
@@ -379,20 +363,18 @@ TEST_LOOP(trials, too_long_error) {
 TEST_LOOP(trials, overlong_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
-  transcode_utf8_to_utf16_test_base test(random, fix_size);
+
+  transcode_utf8_to_utf16_test_base test(BE, random, fix_size);
+
   for (unsigned int i = 1; i < fix_size; i++) {
     if ((unsigned char)test.input_utf8[i] >=
         (unsigned char)0b11000000) { // Only non-ASCII leading bytes can be
                                      // overlong
-      auto procedure = [&implementation,
-                        &i](const char *utf8, size_t size,
-                            [[maybe_unused]] char16_t *utf16le) -> size_t {
-        std::vector<char16_t> utf16be(
-            2 *
-            size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
-        simdutf::result res =
+      auto procedure = [&implementation, &i](const char *utf8, size_t size,
+                                             char16_t *utf16be) -> size_t {
+        const simdutf::result res =
             implementation.convert_utf8_to_utf16be_with_errors(utf8, size,
-                                                               utf16be.data());
+                                                               utf16be);
         ASSERT_EQUAL(res.error, simdutf::error_code::OVERLONG);
         ASSERT_EQUAL(res.count, i);
         return 0;
@@ -421,19 +403,17 @@ TEST_LOOP(trials, overlong_error) {
 TEST_LOOP(trials, too_large_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
-  transcode_utf8_to_utf16_test_base test(random, fix_size);
+
+  transcode_utf8_to_utf16_test_base test(BE, random, fix_size);
+
   for (unsigned int i = 1; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11111000) ==
         0b11110000) { // Can only have too large error in 4-bytes case
-      auto procedure = [&implementation,
-                        &i](const char *utf8, size_t size,
-                            [[maybe_unused]] char16_t *utf16le) -> size_t {
-        std::vector<char16_t> utf16be(
-            2 *
-            size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
-        simdutf::result res =
+      auto procedure = [&implementation, &i](const char *utf8, size_t size,
+                                             char16_t *utf16be) -> size_t {
+        const simdutf::result res =
             implementation.convert_utf8_to_utf16be_with_errors(utf8, size,
-                                                               utf16be.data());
+                                                               utf16be);
         ASSERT_EQUAL(res.error, simdutf::error_code::TOO_LARGE);
         ASSERT_EQUAL(res.count, i);
         return 0;
@@ -451,19 +431,17 @@ TEST_LOOP(trials, too_large_error) {
 TEST_LOOP(trials, surrogate_error) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0000, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
-  transcode_utf8_to_utf16_test_base test(random, fix_size);
+
+  transcode_utf8_to_utf16_test_base test(BE, random, fix_size);
+
   for (unsigned int i = 1; i < fix_size; i++) {
     if ((test.input_utf8[i] & 0b11110000) ==
         0b11100000) { // Can only have surrogate error in 3-bytes case
-      auto procedure = [&implementation,
-                        &i](const char *utf8, size_t size,
-                            [[maybe_unused]] char16_t *utf16le) -> size_t {
-        std::vector<char16_t> utf16be(
-            2 *
-            size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
-        simdutf::result res =
+      auto procedure = [&implementation, &i](const char *utf8, size_t size,
+                                             char16_t *utf16be) -> size_t {
+        const simdutf::result res =
             implementation.convert_utf8_to_utf16be_with_errors(utf8, size,
-                                                               utf16be.data());
+                                                               utf16be);
         ASSERT_EQUAL(res.error, simdutf::error_code::SURROGATE);
         ASSERT_EQUAL(res.count, i);
         return 0;

--- a/tests/convert_valid_utf16be_to_latin1_tests.cpp
+++ b/tests/convert_valid_utf16be_to_latin1_tests.cpp
@@ -8,7 +8,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
 
 using simdutf::tests::helpers::transcode_utf16_to_latin1_test_base;
 
@@ -17,19 +18,11 @@ constexpr int trials = 1000;
 
 TEST_LOOP(trials, convert_2_UTF16_bytes) {
   // range for 1, 2 or 3 UTF-8 bytes
-  simdutf::tests::helpers::RandomIntRanges random(
-      {
-          {0x0000, 0x00ff},
-      },
-      seed);
+  simdutf::tests::helpers::RandomInt random(0x0000, 0x00ff, seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *latin1) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-
-    return implementation.convert_valid_utf16be_to_latin1(utf16be.data(), size,
-                                                          latin1);
+    return implementation.convert_valid_utf16be_to_latin1(utf16, size, latin1);
   };
   auto size_procedure =
       [&implementation]([[maybe_unused]] const char16_t *utf16,
@@ -37,7 +30,7 @@ TEST_LOOP(trials, convert_2_UTF16_bytes) {
     return implementation.latin1_length_from_utf16(size);
   };
   for (size_t size : input_size) {
-    transcode_utf16_to_latin1_test_base test(random, size);
+    transcode_utf16_to_latin1_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }

--- a/tests/convert_valid_utf16be_to_utf32_tests.cpp
+++ b/tests/convert_valid_utf16be_to_utf32_tests.cpp
@@ -9,7 +9,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
 
 using simdutf::tests::helpers::transcode_utf16_to_utf32_test_base;
 
@@ -22,16 +23,13 @@ TEST_LOOP(trials, convert_2_UTF16_bytes) {
       {{0x0000, 0x007f}, {0x0080, 0x07ff}, {0x0800, 0xd7ff}, {0xe000, 0xffff}},
       seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_valid_utf16be_to_utf32(utf16be.data(), size,
-                                                         utf32);
+    return implementation.convert_valid_utf16be_to_utf32(utf16, size, utf32);
   };
 
   for (size_t size : input_size) {
-    transcode_utf16_to_utf32_test_base test(random, size);
+    transcode_utf16_to_utf32_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }
@@ -41,118 +39,32 @@ TEST_LOOP(trials, convert_with_surrogate_pairs) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0800, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_valid_utf16be_to_utf32(utf16be.data(), size,
-                                                         utf32);
+    return implementation.convert_valid_utf16be_to_utf32(utf16, size, utf32);
   };
 
   for (size_t size : input_size) {
-    transcode_utf16_to_utf32_test_base test(random, size);
+    transcode_utf16_to_utf32_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
-namespace {
-std::vector<std::vector<char16_t>> all_combinations() {
-  const char16_t V_1byte_start =
-      0x0042; // non-surrogate word the yields 1 UTF-8 byte
-  const char16_t V_2bytes_start =
-      0x017f; // non-surrogate word the yields 2 UTF-8 bytes
-  const char16_t V_3bytes_start =
-      0xefff;                // non-surrogate word the yields 3 UTF-8 bytes
-  const char16_t L = 0xd9ca; // low surrogate
-  const char16_t H = 0xde42; // high surrogate
-
-  std::vector<std::vector<char16_t>> result;
-  std::vector<char16_t> row(32, '*');
-
-  std::array<int, 8> pattern{0};
-  while (true) {
-    // if (result.size() > 5) break;
-
-    // 1. produce output
-    char16_t V_1byte = V_1byte_start;
-    char16_t V_2bytes = V_2bytes_start;
-    char16_t V_3bytes = V_3bytes_start;
-    for (int i = 0; i < 8; i++) {
-      switch (pattern[i]) {
-      case 0:
-        row[i] = V_1byte++;
-        break;
-      case 1:
-        row[i] = V_2bytes++;
-        break;
-      case 2:
-        row[i] = V_3bytes++;
-        break;
-      case 3:
-        row[i] = L;
-        break;
-      case 4:
-        row[i] = H;
-        break;
-      default:
-        abort();
-      }
-    } // for
-
-    if (row[7] == L) {
-      row[8] = H; // make input valid
-      result.push_back(row);
-
-      row[8] = V_1byte; // broken input
-      result.push_back(row);
-    } else {
-      row[8] = V_1byte;
-      result.push_back(row);
-    }
-
-    // next pattern
-    int i = 0;
-    int carry = 1;
-    for (/**/; i < 8 && carry; i++) {
-      pattern[i] += carry;
-      if (pattern[i] == 5) {
-        pattern[i] = 0;
-        carry = 1;
-      } else
-        carry = 0;
-    }
-
-    if (carry == 1 and i == 8)
-      break;
-
-  } // while
-
-  return result;
-}
-} // namespace
-
 TEST(all_possible_8_codepoint_combinations) {
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_valid_utf16be_to_utf32(utf16be.data(), size,
-                                                         utf32);
+    return implementation.convert_valid_utf16be_to_utf32(utf16, size, utf32);
   };
 
   std::vector<char> output_utf32(256, ' ');
-  const auto &combinations = all_combinations();
+  const auto &combinations = all_utf16_combinations(BE);
   for (const auto &input_utf16 : combinations) {
-    if (simdutf::tests::reference::validate_utf16(input_utf16.data(),
+    if (simdutf::tests::reference::validate_utf16(BE, input_utf16.data(),
                                                   input_utf16.size())) {
-      transcode_utf16_to_utf32_test_base test(input_utf16);
+      transcode_utf16_to_utf32_test_base test(BE, input_utf16);
       ASSERT_TRUE(test(procedure));
     }
   }
 }
-#endif
 
 TEST_MAIN

--- a/tests/convert_valid_utf16be_to_utf8_tests.cpp
+++ b/tests/convert_valid_utf16be_to_utf8_tests.cpp
@@ -9,7 +9,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
 
 using simdutf::tests::helpers::transcode_utf16_to_utf8_test_base;
 
@@ -20,17 +21,13 @@ TEST(convert_pure_ASCII) {
   size_t counter = 0;
   auto generator = [&counter]() -> uint32_t { return counter++ & 0x7f; };
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_valid_utf16be_to_utf8(utf16be.data(), size,
-                                                        utf8);
+    return implementation.convert_valid_utf16be_to_utf8(utf16, size, utf8);
   };
 
-  std::array<size_t, 1> input_size{16};
   for (size_t size : input_size) {
-    transcode_utf16_to_utf8_test_base test(generator, size);
+    transcode_utf16_to_utf8_test_base test(BE, generator, size);
     ASSERT_TRUE(test(procedure));
   }
 }
@@ -39,16 +36,13 @@ TEST_LOOP(trials, convert_into_1_or_2_UTF8_bytes) {
   simdutf::tests::helpers::RandomInt random(
       0x0000, 0x07ff, seed); // range for 1 or 2 UTF-8 bytes
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_valid_utf16be_to_utf8(utf16be.data(), size,
-                                                        utf8);
+    return implementation.convert_valid_utf16be_to_utf8(utf16, size, utf8);
   };
 
   for (size_t size : input_size) {
-    transcode_utf16_to_utf8_test_base test(random, size);
+    transcode_utf16_to_utf8_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }
@@ -59,16 +53,13 @@ TEST_LOOP(trials, convert_into_1_or_2_or_3_UTF8_bytes) {
       {{0x0000, 0x007f}, {0x0080, 0x07ff}, {0x0800, 0xd7ff}, {0xe000, 0xffff}},
       seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_valid_utf16be_to_utf8(utf16be.data(), size,
-                                                        utf8);
+    return implementation.convert_valid_utf16be_to_utf8(utf16, size, utf8);
   };
 
   for (size_t size : input_size) {
-    transcode_utf16_to_utf8_test_base test(random, size);
+    transcode_utf16_to_utf8_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }
@@ -78,118 +69,32 @@ TEST_LOOP(trials, convert_into_3_or_4_UTF8_bytes) {
   simdutf::tests::helpers::RandomIntRanges random(
       {{0x0800, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
 
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_valid_utf16be_to_utf8(utf16be.data(), size,
-                                                        utf8);
+    return implementation.convert_valid_utf16be_to_utf8(utf16, size, utf8);
   };
 
   for (size_t size : input_size) {
-    transcode_utf16_to_utf8_test_base test(random, size);
+    transcode_utf16_to_utf8_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
-namespace {
-std::vector<std::vector<char16_t>> all_combinations() {
-  const char16_t V_1byte_start =
-      0x0042; // non-surrogate word the yields 1 UTF-8 byte
-  const char16_t V_2bytes_start =
-      0x017f; // non-surrogate word the yields 2 UTF-8 bytes
-  const char16_t V_3bytes_start =
-      0xefff;                // non-surrogate word the yields 3 UTF-8 bytes
-  const char16_t L = 0xd9ca; // low surrogate
-  const char16_t H = 0xde42; // high surrogate
-
-  std::vector<std::vector<char16_t>> result;
-  std::vector<char16_t> row(32, '*');
-
-  std::array<int, 8> pattern{0};
-  while (true) {
-    // if (result.size() > 5) break;
-
-    // 1. produce output
-    char16_t V_1byte = V_1byte_start;
-    char16_t V_2bytes = V_2bytes_start;
-    char16_t V_3bytes = V_3bytes_start;
-    for (int i = 0; i < 8; i++) {
-      switch (pattern[i]) {
-      case 0:
-        row[i] = V_1byte++;
-        break;
-      case 1:
-        row[i] = V_2bytes++;
-        break;
-      case 2:
-        row[i] = V_3bytes++;
-        break;
-      case 3:
-        row[i] = L;
-        break;
-      case 4:
-        row[i] = H;
-        break;
-      default:
-        abort();
-      }
-    } // for
-
-    if (row[7] == L) {
-      row[8] = H; // make input valid
-      result.push_back(row);
-
-      row[8] = V_1byte; // broken input
-      result.push_back(row);
-    } else {
-      row[8] = V_1byte;
-      result.push_back(row);
-    }
-
-    // next pattern
-    int i = 0;
-    int carry = 1;
-    for (/**/; i < 8 && carry; i++) {
-      pattern[i] += carry;
-      if (pattern[i] == 5) {
-        pattern[i] = 0;
-        carry = 1;
-      } else
-        carry = 0;
-    }
-
-    if (carry == 1 and i == 8)
-      break;
-
-  } // while
-
-  return result;
-}
-} // namespace
-
 TEST(all_possible_8_codepoint_combinations) {
-  auto procedure = [&implementation](const char16_t *utf16le, size_t size,
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *utf8) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    implementation.change_endianness_utf16(utf16le, size, utf16be.data());
-    return implementation.convert_valid_utf16be_to_utf8(utf16be.data(), size,
-                                                        utf8);
+    return implementation.convert_valid_utf16be_to_utf8(utf16, size, utf8);
   };
 
   std::vector<char> output_utf8(256, ' ');
-  const auto &combinations = all_combinations();
+  const auto &combinations = all_utf16_combinations(BE);
   for (const auto &input_utf16 : combinations) {
-    if (simdutf::tests::reference::validate_utf16(input_utf16.data(),
+    if (simdutf::tests::reference::validate_utf16(BE, input_utf16.data(),
                                                   input_utf16.size())) {
-      transcode_utf16_to_utf8_test_base test(input_utf16);
+      transcode_utf16_to_utf8_test_base test(BE, input_utf16);
       ASSERT_TRUE(test(procedure));
     }
   }
 }
-#endif
 
 TEST_MAIN

--- a/tests/convert_valid_utf16le_to_latin1_tests.cpp
+++ b/tests/convert_valid_utf16le_to_latin1_tests.cpp
@@ -7,7 +7,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness LE = simdutf::endianness::LITTLE;
 
 using simdutf::tests::helpers::transcode_utf16_to_latin1_test_base;
 
@@ -16,11 +17,7 @@ constexpr int trials = 1000;
 
 TEST_LOOP(trials, convert_2_UTF16_bytes) {
   // range for 1, 2 or 3 UTF-8 bytes
-  simdutf::tests::helpers::RandomIntRanges random(
-      {
-          {0x0000, 0x00ff},
-      },
-      seed);
+  simdutf::tests::helpers::RandomInt random(0x0000, 0x00ff, seed);
 
   auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char *latin1) -> size_t {
@@ -32,7 +29,7 @@ TEST_LOOP(trials, convert_2_UTF16_bytes) {
     return implementation.latin1_length_from_utf16(size);
   };
   for (size_t size : input_size) {
-    transcode_utf16_to_latin1_test_base test(random, size);
+    transcode_utf16_to_latin1_test_base test(LE, random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
   }

--- a/tests/convert_valid_utf16le_to_utf32_tests.cpp
+++ b/tests/convert_valid_utf16le_to_utf32_tests.cpp
@@ -9,7 +9,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness LE = simdutf::endianness::LITTLE;
 
 using simdutf::tests::helpers::transcode_utf16_to_utf32_test_base;
 
@@ -28,7 +29,7 @@ TEST_LOOP(trials, convert_2_UTF16_bytes) {
   };
 
   for (size_t size : input_size) {
-    transcode_utf16_to_utf32_test_base test(random, size);
+    transcode_utf16_to_utf32_test_base test(LE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }
@@ -44,90 +45,12 @@ TEST_LOOP(trials, convert_with_surrogate_pairs) {
   };
 
   for (size_t size : input_size) {
-    transcode_utf16_to_utf32_test_base test(random, size);
+    transcode_utf16_to_utf32_test_base test(LE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port the next test.
-#else
-namespace {
-std::vector<std::vector<char16_t>> all_combinations() {
-  const char16_t V_1byte_start =
-      0x0042; // non-surrogate word the yields 1 UTF-8 byte
-  const char16_t V_2bytes_start =
-      0x017f; // non-surrogate word the yields 2 UTF-8 bytes
-  const char16_t V_3bytes_start =
-      0xefff;                // non-surrogate word the yields 3 UTF-8 bytes
-  const char16_t L = 0xd9ca; // low surrogate
-  const char16_t H = 0xde42; // high surrogate
-
-  std::vector<std::vector<char16_t>> result;
-  std::vector<char16_t> row(32, '*');
-
-  std::array<int, 8> pattern{0};
-  while (true) {
-    // if (result.size() > 5) break;
-
-    // 1. produce output
-    char16_t V_1byte = V_1byte_start;
-    char16_t V_2bytes = V_2bytes_start;
-    char16_t V_3bytes = V_3bytes_start;
-    for (int i = 0; i < 8; i++) {
-      switch (pattern[i]) {
-      case 0:
-        row[i] = V_1byte++;
-        break;
-      case 1:
-        row[i] = V_2bytes++;
-        break;
-      case 2:
-        row[i] = V_3bytes++;
-        break;
-      case 3:
-        row[i] = L;
-        break;
-      case 4:
-        row[i] = H;
-        break;
-      default:
-        abort();
-      }
-    } // for
-
-    if (row[7] == L) {
-      row[8] = H; // make input valid
-      result.push_back(row);
-
-      row[8] = V_1byte; // broken input
-      result.push_back(row);
-    } else {
-      row[8] = V_1byte;
-      result.push_back(row);
-    }
-
-    // next pattern
-    int i = 0;
-    int carry = 1;
-    for (/**/; i < 8 && carry; i++) {
-      pattern[i] += carry;
-      if (pattern[i] == 5) {
-        pattern[i] = 0;
-        carry = 1;
-      } else
-        carry = 0;
-    }
-
-    if (carry == 1 and i == 8)
-      break;
-
-  } // while
-
-  return result;
-}
-} // namespace
-
+#if 0 // XXX
 TEST(all_possible_8_codepoint_combinations) {
   auto procedure = [&implementation](const char16_t *utf16, size_t size,
                                      char32_t *utf32) -> size_t {
@@ -135,11 +58,11 @@ TEST(all_possible_8_codepoint_combinations) {
   };
 
   std::vector<char> output_utf32(256, ' ');
-  const auto &combinations = all_combinations();
+  const auto &combinations = all_utf16_combinations(LE);
   for (const auto &input_utf16 : combinations) {
-    if (simdutf::tests::reference::validate_utf16(input_utf16.data(),
+    if (simdutf::tests::reference::validate_utf16(LE, input_utf16.data(),
                                                   input_utf16.size())) {
-      transcode_utf16_to_utf32_test_base test(input_utf16);
+      transcode_utf16_to_utf32_test_base test(LE, input_utf16);
       ASSERT_TRUE(test(procedure));
     }
   }

--- a/tests/convert_valid_utf32_to_utf16be_tests.cpp
+++ b/tests/convert_valid_utf32_to_utf16be_tests.cpp
@@ -8,7 +8,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
 
 using simdutf::tests::helpers::transcode_utf32_to_utf16_test_base;
 
@@ -21,15 +22,11 @@ TEST_LOOP(trials, convert_into_2_UTF16_bytes) {
       {{0x0000, 0xd7ff}, {0xe000, 0xffff}}, seed);
 
   auto procedure = [&implementation](const char32_t *utf32, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    size_t len =
-        implementation.convert_utf32_to_utf16be(utf32, size, utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), len, utf16le);
-    return len;
+                                     char16_t *utf16be) -> size_t {
+    return implementation.convert_utf32_to_utf16be(utf32, size, utf16be);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }
@@ -39,15 +36,11 @@ TEST_LOOP(trials, convert_into_4_UTF16_bytes) {
   simdutf::tests::helpers::RandomIntRanges random({{0x10000, 0x10ffff}}, seed);
 
   auto procedure = [&implementation](const char32_t *utf32, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(2 * size);
-    size_t len =
-        implementation.convert_utf32_to_utf16be(utf32, size, utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), len, utf16le);
-    return len;
+                                     char16_t *utf16be) -> size_t {
+    return implementation.convert_utf32_to_utf16be(utf32, size, utf16be);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }
@@ -58,15 +51,11 @@ TEST_LOOP(trials, convert_into_2_or_4_UTF16_bytes) {
       {{0x0000, 0xd7ff}, {0xe000, 0xffff}, {0x10000, 0x10ffff}}, seed);
 
   auto procedure = [&implementation](const char32_t *utf32, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(2 * size);
-    size_t len =
-        implementation.convert_utf32_to_utf16be(utf32, size, utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), len, utf16le);
-    return len;
+                                     char16_t *utf16be) -> size_t {
+    return implementation.convert_utf32_to_utf16be(utf32, size, utf16be);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }

--- a/tests/convert_valid_utf32_to_utf16le_tests.cpp
+++ b/tests/convert_valid_utf32_to_utf16le_tests.cpp
@@ -7,7 +7,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness LE = simdutf::endianness::LITTLE;
 
 using simdutf::tests::helpers::transcode_utf32_to_utf16_test_base;
 
@@ -24,7 +25,7 @@ TEST_LOOP(trials, convert_into_2_UTF16_bytes) {
     return implementation.convert_utf32_to_utf16le(utf32, size, utf16);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(LE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }
@@ -38,7 +39,7 @@ TEST_LOOP(trials, convert_into_4_UTF16_bytes) {
     return implementation.convert_utf32_to_utf16le(utf32, size, utf16);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(LE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }
@@ -53,7 +54,7 @@ TEST_LOOP(trials, convert_into_2_or_4_UTF16_bytes) {
     return implementation.convert_utf32_to_utf16le(utf32, size, utf16);
   };
   for (size_t size : input_size) {
-    transcode_utf32_to_utf16_test_base test(random, size);
+    transcode_utf32_to_utf16_test_base test(LE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }

--- a/tests/convert_valid_utf8_to_utf16be_tests.cpp
+++ b/tests/convert_valid_utf8_to_utf16be_tests.cpp
@@ -9,7 +9,8 @@
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
 
 using simdutf::tests::helpers::transcode_utf8_to_utf16_test_base;
 
@@ -21,17 +22,12 @@ TEST_LOOP(trials, convert_pure_ASCII) {
   auto generator = [&counter]() -> uint32_t { return counter++ & 0x7f; };
 
   auto procedure = [&implementation](const char *utf8, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(
-        2 * size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
-    size_t len = implementation.convert_valid_utf8_to_utf16be(utf8, size,
-                                                              utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), len, utf16le);
-    return len;
+                                     char16_t *utf16be) -> size_t {
+    return implementation.convert_valid_utf8_to_utf16be(utf8, size, utf16be);
   };
 
   for (size_t size : input_size) {
-    transcode_utf8_to_utf16_test_base test(generator, size);
+    transcode_utf8_to_utf16_test_base test(BE, generator, size);
     ASSERT_TRUE(test(procedure));
   }
 }
@@ -41,17 +37,12 @@ TEST_LOOP(trials, convert_1_or_2_UTF8_bytes) {
       0x0000, 0x07ff, seed); // range for 1 or 2 UTF-8 bytes
 
   auto procedure = [&implementation](const char *utf8, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(
-        2 * size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
-    size_t len = implementation.convert_valid_utf8_to_utf16be(utf8, size,
-                                                              utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), len, utf16le);
-    return len;
+                                     char16_t *utf16be) -> size_t {
+    return implementation.convert_valid_utf8_to_utf16be(utf8, size, utf16be);
   };
 
   for (size_t size : input_size) {
-    transcode_utf8_to_utf16_test_base test(random, size);
+    transcode_utf8_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }
@@ -62,17 +53,12 @@ TEST_LOOP(trials, convert_1_or_2_or_3_UTF8_bytes) {
       {{0x0000, 0xd7ff}, {0xe000, 0xffff}}, seed);
 
   auto procedure = [&implementation](const char *utf8, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(
-        2 * size); // Assume each UTF-8 byte is converted into two UTF-16 bytes
-    size_t len = implementation.convert_valid_utf8_to_utf16be(utf8, size,
-                                                              utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), len, utf16le);
-    return len;
+                                     char16_t *utf16be) -> size_t {
+    return implementation.convert_valid_utf8_to_utf16be(utf8, size, utf16be);
   };
 
   for (size_t size : input_size) {
-    transcode_utf8_to_utf16_test_base test(random, size);
+    transcode_utf8_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }
@@ -83,16 +69,12 @@ TEST_LOOP(trials, convert_3_or_4_UTF8_bytes) {
       seed); // range for 3 or 4 UTF-8 bytes
 
   auto procedure = [&implementation](const char *utf8, size_t size,
-                                     char16_t *utf16le) -> size_t {
-    std::vector<char16_t> utf16be(size);
-    size_t len = implementation.convert_valid_utf8_to_utf16be(utf8, size,
-                                                              utf16be.data());
-    implementation.change_endianness_utf16(utf16be.data(), len, utf16le);
-    return len;
+                                     char16_t *utf16be) -> size_t {
+    return implementation.convert_valid_utf8_to_utf16be(utf8, size, utf16be);
   };
 
   for (size_t size : input_size) {
-    transcode_utf8_to_utf16_test_base test(random, size);
+    transcode_utf8_to_utf16_test_base test(BE, random, size);
     ASSERT_TRUE(test(procedure));
   }
 }

--- a/tests/count_utf16be.cpp
+++ b/tests/count_utf16be.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include <tests/helpers/random_int.h>
-#include <tests/helpers/transcode_test_base.h>
 #include <tests/helpers/random_utf16.h>
 #include <tests/helpers/test.h>
 
@@ -13,21 +12,18 @@ namespace {
 std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
 
 constexpr size_t trials = 10000;
-
-using simdutf::tests::helpers::transcode_utf8_to_utf16_test_base;
 } // namespace
 
 TEST_LOOP(trials, count_just_one_word) {
   simdutf::tests::helpers::random_utf16 random(seed, 1, 0);
 
   for (size_t size : input_size) {
-    auto generated = random.generate_counted(size);
-    std::vector<char16_t> utf16be(generated.first.size());
-    implementation.change_endianness_utf16(
-        reinterpret_cast<const char16_t *>(generated.first.data()),
-        generated.first.size(), utf16be.data());
-    size_t count = implementation.count_utf16be(utf16be.data(), size);
-    ASSERT_EQUAL(count, generated.second);
+    const auto g = random.generate_counted_be(size);
+    const auto &utf16 = g.first;
+    const auto utf16_count = g.second;
+
+    const size_t count = implementation.count_utf16be(utf16.data(), size);
+    ASSERT_EQUAL(count, utf16_count);
   }
 }
 
@@ -35,13 +31,12 @@ TEST_LOOP(trials, count_1_or_2_UTF16_words) {
   simdutf::tests::helpers::random_utf16 random(seed, 1, 1);
 
   for (size_t size : input_size) {
-    auto generated = random.generate_counted(size);
-    std::vector<char16_t> utf16be(generated.first.size());
-    implementation.change_endianness_utf16(
-        reinterpret_cast<const char16_t *>(generated.first.data()),
-        generated.first.size(), utf16be.data());
-    size_t count = implementation.count_utf16be(utf16be.data(), size);
-    ASSERT_EQUAL(count, generated.second);
+    const auto g = random.generate_counted_be(size);
+    const auto &utf16 = g.first;
+    const auto utf16_count = g.second;
+
+    const size_t count = implementation.count_utf16be(utf16.data(), size);
+    ASSERT_EQUAL(count, utf16_count);
   }
 }
 
@@ -49,14 +44,12 @@ TEST_LOOP(trials, count_2_UTF16_words) {
   simdutf::tests::helpers::random_utf16 random(seed, 0, 1);
 
   for (size_t size : input_size) {
+    const auto g = random.generate_counted_be(size);
+    const auto &utf16 = g.first;
+    const auto utf16_count = g.second;
 
-    auto generated = random.generate_counted(size);
-    std::vector<char16_t> utf16be(generated.first.size());
-    implementation.change_endianness_utf16(
-        reinterpret_cast<const char16_t *>(generated.first.data()),
-        generated.first.size(), utf16be.data());
-    size_t count = implementation.count_utf16be(utf16be.data(), size);
-    ASSERT_EQUAL(count, generated.second);
+    const size_t count = implementation.count_utf16be(utf16.data(), size);
+    ASSERT_EQUAL(count, utf16_count);
   }
 }
 

--- a/tests/count_utf16le.cpp
+++ b/tests/count_utf16le.cpp
@@ -3,27 +3,23 @@
 #include <array>
 
 #include <tests/helpers/random_int.h>
-#include <tests/helpers/transcode_test_base.h>
 #include <tests/helpers/random_utf16.h>
 #include <tests/helpers/test.h>
 
 namespace {
-std::array<size_t, 9> input_size{7, 12, 16, 64, 67, 128, 256, 511, 1000};
+constexpr std::array<size_t, 9> input_size{7,   12,  16,  64,  67,
+                                           128, 256, 511, 1000};
 
 constexpr size_t trials = 10000;
-
-using simdutf::tests::helpers::transcode_utf8_to_utf16_test_base;
 } // namespace
 
 TEST_LOOP(trials, count_just_one_word) {
   simdutf::tests::helpers::random_utf16 random(seed, 1, 0);
 
   for (size_t size : input_size) {
-    auto generated = random.generate_counted(size);
-    ASSERT_EQUAL(
-        implementation.count_utf16le(
-            reinterpret_cast<const char16_t *>(generated.first.data()), size),
-        generated.second);
+    const auto generated = random.generate_counted_le(size);
+    ASSERT_EQUAL(implementation.count_utf16le(generated.first.data(), size),
+                 generated.second);
   }
 }
 
@@ -31,11 +27,9 @@ TEST_LOOP(trials, count_1_or_2_UTF16_words) {
   simdutf::tests::helpers::random_utf16 random(seed, 1, 1);
 
   for (size_t size : input_size) {
-    auto generated = random.generate_counted(size);
-    ASSERT_EQUAL(
-        implementation.count_utf16le(
-            reinterpret_cast<const char16_t *>(generated.first.data()), size),
-        generated.second);
+    auto generated = random.generate_counted_le(size);
+    ASSERT_EQUAL(implementation.count_utf16le(generated.first.data(), size),
+                 generated.second);
   }
 }
 
@@ -43,12 +37,9 @@ TEST_LOOP(trials, count_2_UTF16_words) {
   simdutf::tests::helpers::random_utf16 random(seed, 0, 1);
 
   for (size_t size : input_size) {
-
-    auto generated = random.generate_counted(size);
-    ASSERT_EQUAL(
-        implementation.count_utf16le(
-            reinterpret_cast<const char16_t *>(generated.first.data()), size),
-        generated.second);
+    const auto generated = random.generate_counted_le(size);
+    ASSERT_EQUAL(implementation.count_utf16le(generated.first.data(), size),
+                 generated.second);
   }
 }
 

--- a/tests/helpers/random_utf16.cpp
+++ b/tests/helpers/random_utf16.cpp
@@ -9,8 +9,54 @@ namespace simdutf {
 namespace tests {
 namespace helpers {
 
-std::vector<char16_t> random_utf16::generate(size_t size) {
-  return generate_counted(size).first;
+std::vector<char16_t> random_utf16::generate_le(size_t size) {
+  auto result = generate_counted(size).first;
+  if (!match_system(endianness::LITTLE)) {
+    change_endianness_utf16(result.data(), result.size(), result.data());
+  }
+
+  return result;
+}
+
+std::vector<char16_t> random_utf16::generate_be(size_t size) {
+  auto result = generate_counted(size).first;
+  if (!match_system(endianness::BIG)) {
+    change_endianness_utf16(result.data(), result.size(), result.data());
+  }
+
+  return result;
+}
+
+std::vector<char16_t> random_utf16::generate_le(size_t size, long seed) {
+  gen.seed(seed);
+  return generate_le(size);
+}
+
+std::vector<char16_t> random_utf16::generate_be(size_t size, long seed) {
+  gen.seed(seed);
+  return generate_be(size);
+}
+
+std::pair<std::vector<char16_t>, size_t>
+random_utf16::generate_counted_le(size_t size) {
+  auto res = generate_counted(size);
+  if (!match_system(endianness::LITTLE)) {
+    change_endianness_utf16(res.first.data(), res.first.size(),
+                            res.first.data());
+  }
+
+  return res;
+}
+
+std::pair<std::vector<char16_t>, size_t>
+random_utf16::generate_counted_be(size_t size) {
+  auto res = generate_counted(size);
+  if (!match_system(endianness::BIG)) {
+    change_endianness_utf16(res.first.data(), res.first.size(),
+                            res.first.data());
+  }
+
+  return res;
 }
 
 std::pair<std::vector<char16_t>, size_t>
@@ -36,18 +82,7 @@ random_utf16::generate_counted(size_t size) {
       break;
     }
   }
-#ifndef SIMDUTF_IS_BIG_ENDIAN
-  #error "SIMDUTF_IS_BIG_ENDIAN should be defined."
-#endif
-#if SIMDUTF_IS_BIG_ENDIAN
-  change_endianness_utf16(result.data(), result.size(), result.data());
-#endif
   return make_pair(result, count);
-}
-
-std::vector<char16_t> random_utf16::generate(size_t size, long seed) {
-  gen.seed(seed);
-  return generate(size);
 }
 
 uint32_t random_utf16::generate() {

--- a/tests/helpers/random_utf16.h
+++ b/tests/helpers/random_utf16.h
@@ -26,8 +26,14 @@ public:
         utf16_length({double(single_word_prob), double(single_word_prob),
                       double(2 * two_words_probability)}) {}
 
-  std::vector<char16_t> generate(size_t size);
-  std::vector<char16_t> generate(size_t size, long seed);
+  std::vector<char16_t> generate_le(size_t size);
+  std::vector<char16_t> generate_be(size_t size);
+  std::vector<char16_t> generate_le(size_t size, long seed);
+  std::vector<char16_t> generate_be(size_t size, long seed);
+  std::pair<std::vector<char16_t>, size_t> generate_counted_le(size_t size);
+  std::pair<std::vector<char16_t>, size_t> generate_counted_be(size_t size);
+
+private:
   std::pair<std::vector<char16_t>, size_t> generate_counted(size_t size);
 
 private:

--- a/tests/helpers/utf16.h
+++ b/tests/helpers/utf16.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "simdutf/encoding_types.h"
+
+template <typename = void>
+char16_t to_utf16(simdutf::endianness byte_order, char16_t chr) {
+  if (!match_system(byte_order)) {
+    return char16_t((uint16_t(chr) << 8) | (uint16_t(chr) >> 8));
+  } else {
+    return chr;
+  }
+}
+
+template <typename = void> char16_t to_utf16be(char16_t chr) {
+  return to_utf16(simdutf::endianness::BIG, chr);
+}
+
+template <typename = void> char16_t to_utf16le(char16_t chr) {
+  return to_utf16(simdutf::endianness::LITTLE, chr);
+}
+
+template <typename = void>
+void to_utf16le_inplace(char16_t *data, size_t size) {
+  for (size_t i = 0; i < size; i++) {
+    data[i] = to_utf16le(data[i]);
+  }
+}

--- a/tests/reference/validate_utf16.cpp
+++ b/tests/reference/validate_utf16.cpp
@@ -8,42 +8,43 @@ namespace simdutf {
 namespace tests {
 namespace reference {
 
-simdutf_warn_unused bool validate_utf16(const char16_t *buf,
+simdutf_warn_unused bool validate_utf16(endianness utf16_endianness,
+                                        const char16_t *buf,
                                         size_t len) noexcept {
   const char16_t *curr = buf;
   const char16_t *end = buf + len;
 
   while (curr != end) {
-#if SIMDUTF_IS_BIG_ENDIAN
-    // By convention, we always take as an input an UTF-16LE.
-    const uint16_t W1 =
-        uint16_t((uint16_t(*curr) << 8) | (uint16_t(*curr) >> 8));
-#else
-    const uint16_t W1 = *curr;
-#endif
+    uint16_t W1;
+    if (!match_system(utf16_endianness)) {
+      W1 = uint16_t((uint16_t(*curr) << 8) | (uint16_t(*curr) >> 8));
+    } else {
+      W1 = *curr;
+    }
 
     curr += 1;
 
-    if (W1 < 0xd800 ||
-        W1 > 0xdfff) { // fast path, code point is equal to character's value
+    // fast path, code point is equal to character's value
+    if (W1 < 0xd800 || W1 > 0xdfff) {
       continue;
     }
 
-    if (W1 > 0xdbff) { // W1 must be in range 0xd800 .. 0xdbff
+    // W1 must be in range 0xd800 .. 0xdbff
+    if (W1 > 0xdbff) {
       return false;
     }
 
-    if (curr ==
-        end) { // required the next word, but we're already at the end of data
+    // required the next word, but we're already at the end of data
+    if (curr == end) {
       return false;
     }
-#if SIMDUTF_IS_BIG_ENDIAN
-    // By convention, we always take as an input an UTF-16LE.
-    const uint16_t W2 =
-        uint16_t((uint16_t(*curr) << 8) | (uint16_t(*curr) >> 8));
-#else
-    const uint16_t W2 = *curr;
-#endif
+
+    uint16_t W2;
+    if (!match_system(utf16_endianness)) {
+      W2 = uint16_t((uint16_t(*curr) << 8) | (uint16_t(*curr) >> 8));
+    } else {
+      W2 = *curr;
+    }
 
     if (W2 < 0xdc00 || W2 > 0xdfff) // W2 = 0xdc00 .. 0xdfff
       return false;

--- a/tests/reference/validate_utf16.h
+++ b/tests/reference/validate_utf16.h
@@ -1,10 +1,12 @@
 #include "simdutf/common_defs.h"
+#include "simdutf/encoding_types.h"
 
 namespace simdutf {
 namespace tests {
 namespace reference {
-// validate UTF-16LE.
-simdutf_warn_unused bool validate_utf16(const char16_t *buf,
+// validate UTF-16
+simdutf_warn_unused bool validate_utf16(endianness utf16_endianness,
+                                        const char16_t *buf,
                                         size_t len) noexcept;
 
 } // namespace reference

--- a/tests/reference/validate_utf16_to_latin1.cpp
+++ b/tests/reference/validate_utf16_to_latin1.cpp
@@ -8,19 +8,19 @@ namespace simdutf {
 namespace tests {
 namespace reference {
 
-simdutf_warn_unused bool validate_utf16_to_latin1(const char16_t *buf,
-                                                  size_t len) noexcept {
+simdutf_warn_unused bool
+validate_utf16_to_latin1(simdutf::endianness utf16_endianness,
+                         const char16_t *buf, size_t len) noexcept {
   const char16_t *curr = buf;
   const char16_t *end = buf + len;
 
   while (curr != end) {
-#if SIMDUTF_IS_BIG_ENDIAN
-    // By convention, we always take as an input an UTF-16LE.
-    const uint16_t W1 =
-        uint16_t((uint16_t(*curr) << 8) | (uint16_t(*curr) >> 8));
-#else
-    const uint16_t W1 = *curr;
-#endif
+    uint16_t W1;
+    if (!match_system(utf16_endianness)) {
+      W1 = (uint16_t(*curr) << 8) | (uint16_t(*curr) >> 8);
+    } else {
+      W1 = *curr;
+    }
 
     curr += 1;
     if (0xff < W1) {

--- a/tests/reference/validate_utf16_to_latin1.h
+++ b/tests/reference/validate_utf16_to_latin1.h
@@ -1,10 +1,12 @@
 #include "simdutf/common_defs.h"
+#include "simdutf/encoding_types.h"
 
 namespace simdutf {
 namespace tests {
 namespace reference {
-simdutf_warn_unused bool validate_utf16_to_latin1(const char16_t *buf,
-                                                  size_t len) noexcept;
+simdutf_warn_unused bool
+validate_utf16_to_latin1(simdutf::endianness utf16_endianness,
+                         const char16_t *buf, size_t len) noexcept;
 
 }
 } // namespace tests

--- a/tests/validate_utf16be_basic_tests.cpp
+++ b/tests/validate_utf16be_basic_tests.cpp
@@ -1,62 +1,45 @@
 #include "simdutf.h"
 
-#ifndef SIMDUTF_IS_BIG_ENDIAN
-  #error "SIMDUTF_IS_BIG_ENDIAN should be defined."
-#endif
-
 #include <array>
 #include <vector>
 
 #include <tests/helpers/random_utf16.h>
 #include <tests/helpers/test.h>
+#include <tests/helpers/utf16.h>
 
 constexpr size_t trials = 1000;
 
 TEST_LOOP(trials, validate_utf16be_returns_true_for_valid_input_single_words) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
-  const auto utf16{generator.generate(512, seed)};
-  std::vector<char16_t> flipped(utf16.size());
-  implementation.change_endianness_utf16(utf16.data(), utf16.size(),
-                                         flipped.data());
+  const auto utf16{generator.generate_be(512, seed)};
+
   ASSERT_TRUE(implementation.validate_utf16be(
-      reinterpret_cast<const char16_t *>(flipped.data()), flipped.size()));
+      reinterpret_cast<const char16_t *>(utf16.data()), utf16.size()));
 }
 
 TEST_LOOP(trials,
           validate_utf16be_returns_true_for_valid_input_surrogate_pairs_short) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
-  const auto utf16{generator.generate(8)};
-  std::vector<char16_t> flipped(utf16.size());
-  implementation.change_endianness_utf16(utf16.data(), utf16.size(),
-                                         flipped.data());
-
+  const auto utf16{generator.generate_be(8)};
   ASSERT_TRUE(implementation.validate_utf16be(
-      reinterpret_cast<const char16_t *>(flipped.data()), flipped.size()));
+      reinterpret_cast<const char16_t *>(utf16.data()), utf16.size()));
 }
 
 TEST_LOOP(trials,
           validate_utf16be_returns_true_for_valid_input_surrogate_pairs) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
-  const auto utf16{generator.generate(512)};
-  std::vector<char16_t> flipped(utf16.size());
-  implementation.change_endianness_utf16(utf16.data(), utf16.size(),
-                                         flipped.data());
-
+  const auto utf16{generator.generate_be(512)};
   ASSERT_TRUE(implementation.validate_utf16be(
-      reinterpret_cast<const char16_t *>(flipped.data()), flipped.size()));
+      reinterpret_cast<const char16_t *>(utf16.data()), utf16.size()));
 }
 
 // mixed = either 16-bit or 32-bit codewords
 TEST(validate_utf16be_returns_true_for_valid_input_mixed) {
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 1};
-  const auto utf16{generator.generate(512)};
-  std::vector<char16_t> flipped(utf16.size());
-  implementation.change_endianness_utf16(utf16.data(), utf16.size(),
-                                         flipped.data());
-
+  const auto utf16{generator.generate_be(512)};
   ASSERT_TRUE(implementation.validate_utf16be(
-      reinterpret_cast<const char16_t *>(flipped.data()), flipped.size()));
+      reinterpret_cast<const char16_t *>(utf16.data()), utf16.size()));
 }
 
 TEST(validate_utf16be_returns_true_for_empty_string) {
@@ -77,32 +60,24 @@ TEST(validate_utf16be_returns_true_for_empty_string) {
    2) Determine if W1 is between 0xD800 and 0xDBFF. If not, the sequence
       is in error [...]
 */
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port this test for big-endian platforms.
-#else
 TEST_LOOP(
     10, validate_utf16be_returns_false_when_input_has_wrong_first_word_value) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
-  auto utf16{generator.generate(128)};
+  auto utf16{generator.generate_be(128)};
   const size_t len = utf16.size();
-
-  std::vector<char16_t> flipped(len);
-  implementation.change_endianness_utf16(utf16.data(), utf16.size(),
-                                         flipped.data());
 
   for (char16_t wrong_value = 0xdc00; wrong_value <= 0xdfff; wrong_value++) {
     for (size_t i = 0; i < utf16.size(); i++) {
-      const char16_t old = flipped[i];
-      flipped[i] = char16_t((wrong_value >> 8) | (wrong_value << 8));
+      const char16_t old = utf16[i];
+      utf16[i] = to_utf16be(wrong_value);
 
       ASSERT_FALSE(implementation.validate_utf16be(
-          reinterpret_cast<const char16_t *>(flipped.data()), len));
+          reinterpret_cast<const char16_t *>(utf16.data()), len));
 
-      flipped[i] = old;
+      utf16[i] = old;
     }
   }
 }
-#endif
 
 /*
  RFC-2781:
@@ -110,40 +85,33 @@ TEST_LOOP(
  3) [..] if W2 is not between 0xDC00 and 0xDFFF, the sequence is in error.
     Terminate.
 */
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port this test for big-endian platforms.
-#else
 TEST(validate_utf16be_returns_false_when_input_has_wrong_second_word_value) {
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
-  auto utf16{generator.generate(128)};
+  auto utf16{generator.generate_be(128)};
   const size_t len = utf16.size();
 
-  std::vector<char16_t> flipped(len);
-  implementation.change_endianness_utf16(utf16.data(), utf16.size(),
-                                         flipped.data());
+  const std::array<char16_t, 5> sample_wrong_second_word{
+      to_utf16be(0x0000), to_utf16be(0x0010), to_utf16be(0xffdb),
+      to_utf16be(0x00e0), to_utf16be(0xffff)};
 
-  const std::array<char16_t, 5> sample_wrong_second_word{0x0000, 0x0010, 0xffdb,
-                                                         0x00e0, 0xffff};
-
-  const char16_t valid_surrogate_W1 = 0x00d8;
+  const char16_t valid_surrogate_W1 = to_utf16be(0xd800);
   for (char16_t W2 : sample_wrong_second_word) {
-    for (size_t i = 0; i < utf16.size() - 1; i++) {
-      const char16_t old_W1 = flipped[i + 0];
-      const char16_t old_W2 = flipped[i + 1];
+    for (size_t i = 0; i < len - 1; i++) {
+      const char16_t old_W1 = utf16[i + 0];
+      const char16_t old_W2 = utf16[i + 1];
 
-      flipped[i + 0] = valid_surrogate_W1;
-      flipped[i + 1] = W2;
+      utf16[i + 0] = valid_surrogate_W1;
+      utf16[i + 1] = W2;
 
       ASSERT_FALSE(implementation.validate_utf16be(
-          reinterpret_cast<const char16_t *>(flipped.data()), len));
+          reinterpret_cast<const char16_t *>(utf16.data()), len));
 
-      flipped[i + 0] = old_W1;
-      flipped[i + 1] = old_W2;
+      utf16[i + 0] = old_W1;
+      utf16[i + 1] = old_W2;
     }
   }
 }
-#endif
 
 /*
  RFC-2781:
@@ -151,27 +119,19 @@ TEST(validate_utf16be_returns_false_when_input_has_wrong_second_word_value) {
  3) If there is no W2 (that is, the sequence ends with W1) [...]
     the sequence is in error. Terminate.
 */
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port this test for big-endian platforms.
-#else
 TEST(validate_utf16be_returns_false_when_input_is_truncated) {
-  const char16_t valid_surrogate_W1 = 0x00d8;
+  const char16_t valid_surrogate_W1 = to_utf16be(0xd800);
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
   for (size_t size = 1; size < 128; size++) {
-    auto utf16{generator.generate(128)};
+    auto utf16{generator.generate_be(128)};
     const size_t len = utf16.size();
 
-    std::vector<char16_t> flipped(len);
-    implementation.change_endianness_utf16(utf16.data(), utf16.size(),
-                                           flipped.data());
-
-    flipped[size - 1] = valid_surrogate_W1;
+    utf16[size - 1] = valid_surrogate_W1;
 
     ASSERT_FALSE(implementation.validate_utf16be(
-        reinterpret_cast<const char16_t *>(flipped.data()), len));
+        reinterpret_cast<const char16_t *>(utf16.data()), len));
   }
 }
-#endif
 
 TEST_MAIN

--- a/tests/validate_utf16le_basic_tests.cpp
+++ b/tests/validate_utf16le_basic_tests.cpp
@@ -1,15 +1,12 @@
 #include "simdutf.h"
 
-#ifndef SIMDUTF_IS_BIG_ENDIAN
-  #error "SIMDUTF_IS_BIG_ENDIAN should be defined."
-#endif
-
 #include <array>
 #include <fstream>
 #include <memory>
 
 #include <tests/helpers/random_utf16.h>
 #include <tests/helpers/test.h>
+#include <tests/helpers/utf16.h>
 
 constexpr size_t trials = 1000;
 
@@ -17,11 +14,9 @@ TEST(issue92) {
   char16_t input[] = u"\u5d00\u0041\u0041\u0041\u0041\u0041\u0041\u0041\u0041"
                      u"\u0041\u0041\u0041\u0041\u0041\u0041\u0041\u0041\u0041"
                      u"\u0041\u0041\u0041\u0041\u0041\u0041";
-  size_t strlen = sizeof(input) / sizeof(char16_t) - 1;
-#if SIMDUTF_IS_BIG_ENDIAN
-  puts("Flipping bytes because you have big endian system.");
-  simdutf::change_endianness_utf16(input, strlen, input);
-#endif
+  size_t strlen = sizeof(input) / sizeof(char16_t);
+  to_utf16le_inplace(input, strlen);
+
   ASSERT_TRUE(implementation.validate_utf16le(input, strlen));
   ASSERT_EQUAL(implementation.utf8_length_from_utf16le(input, strlen),
                2 + strlen);
@@ -35,7 +30,7 @@ TEST(issue92) {
 
 TEST_LOOP(trials, validate_utf16le_returns_true_for_valid_input_single_words) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
-  const auto utf16{generator.generate(512, seed)};
+  const auto utf16{generator.generate_le(512, seed)};
 
   ASSERT_TRUE(implementation.validate_utf16le(
       reinterpret_cast<const char16_t *>(utf16.data()), utf16.size()));
@@ -44,7 +39,7 @@ TEST_LOOP(trials, validate_utf16le_returns_true_for_valid_input_single_words) {
 TEST_LOOP(trials,
           validate_utf16le_returns_true_for_valid_input_surrogate_pairs_short) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
-  const auto utf16{generator.generate(8)};
+  const auto utf16{generator.generate_le(8)};
 
   ASSERT_TRUE(implementation.validate_utf16le(
       reinterpret_cast<const char16_t *>(utf16.data()), utf16.size()));
@@ -53,7 +48,7 @@ TEST_LOOP(trials,
 TEST_LOOP(trials,
           validate_utf16le_returns_true_for_valid_input_surrogate_pairs) {
   simdutf::tests::helpers::random_utf16 generator{seed, 0, 1};
-  const auto utf16{generator.generate(512)};
+  const auto utf16{generator.generate_le(512)};
 
   ASSERT_TRUE(implementation.validate_utf16le(
       reinterpret_cast<const char16_t *>(utf16.data()), utf16.size()));
@@ -63,7 +58,7 @@ TEST_LOOP(trials,
 TEST(validate_utf16le_returns_true_for_valid_input_mixed) {
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 1};
-  const auto utf16{generator.generate(512)};
+  const auto utf16{generator.generate_le(512)};
 
   ASSERT_TRUE(implementation.validate_utf16le(
       reinterpret_cast<const char16_t *>(utf16.data()), utf16.size()));
@@ -87,19 +82,16 @@ TEST(validate_utf16le_returns_true_for_empty_string) {
    2) Determine if W1 is between 0xD800 and 0xDBFF. If not, the sequence
       is in error [...]
 */
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port this test for big-endian platforms.
-#else
 TEST_LOOP(
     10, validate_utf16le_returns_false_when_input_has_wrong_first_word_value) {
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
-  auto utf16{generator.generate(128)};
+  auto utf16{generator.generate_le(128)};
   const size_t len = utf16.size();
 
   for (char16_t wrong_value = 0xdc00; wrong_value <= 0xdfff; wrong_value++) {
     for (size_t i = 0; i < utf16.size(); i++) {
       const char16_t old = utf16[i];
-      utf16[i] = wrong_value;
+      utf16[i] = to_utf16le(wrong_value);
 
       ASSERT_FALSE(implementation.validate_utf16le(utf16.data(), len));
 
@@ -107,7 +99,6 @@ TEST_LOOP(
     }
   }
 }
-#endif
 
 /*
  RFC-2781:
@@ -115,24 +106,21 @@ TEST_LOOP(
  3) [..] if W2 is not between 0xDC00 and 0xDFFF, the sequence is in error.
     Terminate.
 */
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port this test for big-endian platforms.
-#else
 TEST(validate_utf16le_returns_false_when_input_has_wrong_second_word_value) {
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
-  auto utf16{generator.generate(128)};
+  auto utf16{generator.generate_le(128)};
   const size_t len = utf16.size();
   const std::array<char16_t, 5> sample_wrong_second_word{0x0000, 0x1000, 0xdbff,
                                                          0xe000, 0xffff};
-  const char16_t valid_surrogate_W1 = 0xd800;
+  const char16_t valid_surrogate_W1 = to_utf16le(0xd800);
   for (char16_t W2 : sample_wrong_second_word) {
     for (size_t i = 0; i < utf16.size() - 1; i++) {
       const char16_t old_W1 = utf16[i + 0];
       const char16_t old_W2 = utf16[i + 1];
 
       utf16[i + 0] = valid_surrogate_W1;
-      utf16[i + 1] = W2;
+      utf16[i + 1] = to_utf16le(W2);
       ASSERT_FALSE(implementation.validate_utf16le(utf16.data(), len));
 
       utf16[i + 0] = old_W1;
@@ -140,7 +128,6 @@ TEST(validate_utf16le_returns_false_when_input_has_wrong_second_word_value) {
     }
   }
 }
-#endif
 
 /*
  RFC-2781:
@@ -148,15 +135,12 @@ TEST(validate_utf16le_returns_false_when_input_has_wrong_second_word_value) {
  3) If there is no W2 (that is, the sequence ends with W1) [...]
     the sequence is in error. Terminate.
 */
-#if SIMDUTF_IS_BIG_ENDIAN
-// todo: port this test for big-endian platforms.
-#else
 TEST(validate_utf16le_returns_false_when_input_is_truncated) {
-  const char16_t valid_surrogate_W1 = 0xd800;
+  const char16_t valid_surrogate_W1 = to_utf16le(0xd800);
   uint32_t seed{1234};
   simdutf::tests::helpers::random_utf16 generator{seed, 1, 0};
   for (size_t size = 1; size < 128; size++) {
-    auto utf16{generator.generate(128)};
+    auto utf16{generator.generate_le(128)};
     const size_t len = utf16.size();
 
     utf16[size - 1] = valid_surrogate_W1;
@@ -164,16 +148,12 @@ TEST(validate_utf16le_returns_false_when_input_is_truncated) {
     ASSERT_FALSE(implementation.validate_utf16le(utf16.data(), len));
   }
 }
-#endif
 
-#if SIMDUTF_IS_BIG_ENDIAN
-// t odo: port this test for big-endian platforms.
-#else
 TEST(validate_utf16le_extensive_tests) {
-  #ifdef RUN_IN_SPIKE_SIMULATOR
+#ifdef RUN_IN_SPIKE_SIMULATOR
   printf("skipping, cannot be run under Spike");
   return;
-  #endif
+#endif
   const std::string path{"validate_utf16_testcases.txt"};
   std::ifstream file{path};
   if (not file) {
@@ -181,9 +161,9 @@ TEST(validate_utf16le_extensive_tests) {
     return;
   }
 
-  constexpr uint16_t V = 0xfaea;
-  constexpr uint16_t L = 0xd852;
-  constexpr uint16_t H = 0xde12;
+  const uint16_t V = to_utf16le(0xfaea);
+  const uint16_t L = to_utf16le(0xd852);
+  const uint16_t H = to_utf16le(0xde12);
 
   constexpr size_t len = 32;
   char16_t buf[len];
@@ -238,6 +218,5 @@ TEST(validate_utf16le_extensive_tests) {
     ASSERT_EQUAL(implementation.validate_utf16le(buf, len), valid);
   }
 }
-#endif
 
 TEST_MAIN


### PR DESCRIPTION
Refactor tests that deal with the UTF-16 encoding to explicitly set the desired byte order of 16-bit words. This removed a lot of places where we're manually changing endianness. Only in the case of regression tests some manual work was needed.

I checked this on my PowerPC branch. It's (almost) unrelated to the PPC64 port, so I made it a separate PR.