### PR TITLE
Faster UTF-8 length from UTF-16

### DIFF
--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -138,6 +138,12 @@ Benchmark::Benchmark(std::vector<input::Testcase> &&testcases)
   register_function("utf8_length_from_latin1",
                     &Benchmark::run_utf8_length_from_latin1,
                     simdutf::encoding_type::Latin1);
+  register_function("utf8_length_from_utf16le",
+                    &Benchmark::run_utf8_length_from_utf16le,
+                    simdutf::encoding_type::UTF16_LE);
+  register_function("utf8_length_from_utf16be",
+                    &Benchmark::run_utf8_length_from_utf16be,
+                    simdutf::encoding_type::UTF16_BE);
   register_function("utf8_length_from_utf32",
                     &Benchmark::run_utf8_length_from_utf32,
                     simdutf::encoding_type::UTF32_LE);
@@ -746,6 +752,34 @@ void Benchmark::run_utf8_length_from_latin1(
   }
   size_t char_count = get_active_implementation()->count_utf8(data, size);
   print_summary(result, size, char_count);
+}
+
+void Benchmark::run_utf8_length_from_utf16le(
+    const simdutf::implementation &implementation, size_t iterations) {
+  const char16_t *data = reinterpret_cast<const char16_t *>(input_data.data());
+  const size_t size = input_data.size() / 2;
+  volatile size_t sink{0};
+
+  auto proc = [&implementation, data, size, &sink]() {
+    sink = implementation.utf8_length_from_utf16le(data, size);
+  };
+  count_events(proc, iterations); // warming up!
+  const auto result = count_events(proc, iterations);
+  print_summary(result, size, size);
+}
+
+void Benchmark::run_utf8_length_from_utf16be(
+    const simdutf::implementation &implementation, size_t iterations) {
+  const char16_t *data = reinterpret_cast<const char16_t *>(input_data.data());
+  const size_t size = input_data.size() / 2;
+  volatile size_t sink{0};
+
+  auto proc = [&implementation, data, size, &sink]() {
+    sink = implementation.utf8_length_from_utf16be(data, size);
+  };
+  count_events(proc, iterations); // warming up!
+  const auto result = count_events(proc, iterations);
+  print_summary(result, size, size);
 }
 
 void Benchmark::run_utf8_length_from_utf32(

--- a/benchmarks/src/benchmark.h
+++ b/benchmarks/src/benchmark.h
@@ -112,6 +112,12 @@ private:
   void
   run_utf8_length_from_latin1(const simdutf::implementation &implementation,
                               size_t iterations);
+  void
+  run_utf8_length_from_utf16le(const simdutf::implementation &implementation,
+                               size_t iterations);
+  void
+  run_utf8_length_from_utf16be(const simdutf::implementation &implementation,
+                               size_t iterations);
   void run_utf8_length_from_utf32(const simdutf::implementation &implementation,
                                   size_t iterations);
   void run_convert_latin1_to_utf8(const simdutf::implementation &implementation,

--- a/src/generic/utf16.h
+++ b/src/generic/utf16.h
@@ -46,6 +46,89 @@ simdutf_really_inline size_t utf8_length_from_utf16(const char16_t *in,
                                                                    size - pos);
 }
 
+#ifdef SIMDUTF_SIMD_HAS_BYTEMASK
+template <endianness big_endian>
+simdutf_really_inline size_t utf8_length_from_utf16_bytemask(const char16_t *in,
+                                                             size_t size) {
+  size_t pos = 0;
+
+  using vector_u16 = simd16<uint16_t>;
+  constexpr size_t N = vector_u16::ELEMENTS;
+
+  const auto one = vector_u16::splat(1);
+
+  auto v_count = vector_u16::zero();
+
+  // each char16 yields at least one byte
+  size_t count = size / N * N;
+
+  // in a single iteration the increment is 0, 1 or 2, despite we have
+  // three additions
+  constexpr size_t max_iterations = 65535 / 2;
+  size_t iteration = max_iterations;
+
+  for (; pos < size / N * N; pos += N) {
+    auto input = vector_u16::load(reinterpret_cast<const uint16_t *>(in + pos));
+    if (!match_system(big_endian)) {
+      input = input.swap_bytes();
+    }
+
+    // 0xd800 .. 0xdbff - low surrogate
+    // 0xdc00 .. 0xdfff - high surrogate
+    const auto is_surrogate = ((input & uint16_t(0xf800)) == uint16_t(0xd800));
+
+    // c0 - chars that yield 2- or 3-byte UTF-8 codes
+    const auto c0 = min(input & uint16_t(0xff80), one);
+
+    // c1 - chars that yield 3-byte UTF-8 codes (including surrogates)
+    const auto c1 = min(input & uint16_t(0xf800), one);
+
+    /*
+        Explanation how the counting works.
+
+        In the case of a non-surrogate character we count:
+        * always 1 -- see how `count` is initialized above;
+        * c0 = 1 if the current char yields 2 or 3 bytes;
+        * c1 = 1 if the current char yields 3 bytes.
+
+        Thus, we always have correct count for the current char:
+        from 1, 2 or 3 bytes.
+
+        A trickier part is how we count surrogate pairs. Whether
+        we encounter a surrogate (low or high), we count it as
+        3 chars and then minus 1 (`is_surrogate` is -1 or 0).
+        Each surrogate char yields 2. A surrogate pair, that
+        is a low surrogate followed by a high one, yields
+        the expected 4 bytes.
+
+        It also correctly handles cases when low surrogate is
+        processed by the this loop, but high surrogate is counted
+        by the scalar procedure. The scalar procedure uses exactly
+        the described approach, thanks to that for valid UTF-16
+        strings it always count correctly.
+    */
+    v_count += c0;
+    v_count += c1;
+    v_count += vector_u16(is_surrogate);
+
+    iteration -= 1;
+    if (iteration == 0) {
+      count += v_count.sum();
+      v_count = vector_u16::zero();
+
+      iteration = max_iterations;
+    }
+  }
+
+  if (iteration > 0) {
+    count += v_count.sum();
+  }
+
+  return count + scalar::utf16::utf8_length_from_utf16<big_endian>(in + pos,
+                                                                   size - pos);
+}
+#endif // SIMDUTF_SIMD_HAS_BYTEMASK
+
 template <endianness big_endian>
 simdutf_really_inline size_t utf32_length_from_utf16(const char16_t *in,
                                                      size_t size) {

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -1093,12 +1093,13 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf8(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16le(
     const char16_t *input, size_t length) const noexcept {
-  return utf16::utf8_length_from_utf16<endianness::LITTLE>(input, length);
+  return utf16::utf8_length_from_utf16_bytemask<endianness::LITTLE>(input,
+                                                                    length);
 }
 
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16be(
     const char16_t *input, size_t length) const noexcept {
-  return utf16::utf8_length_from_utf16<endianness::BIG>(input, length);
+  return utf16::utf8_length_from_utf16_bytemask<endianness::BIG>(input, length);
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -1121,12 +1121,13 @@ simdutf_warn_unused size_t implementation::latin1_length_from_utf8(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16le(
     const char16_t *input, size_t length) const noexcept {
-  return utf16::utf8_length_from_utf16<endianness::LITTLE>(input, length);
+  return utf16::utf8_length_from_utf16_bytemask<endianness::LITTLE>(input,
+                                                                    length);
 }
 
 simdutf_warn_unused size_t implementation::utf8_length_from_utf16be(
     const char16_t *input, size_t length) const noexcept {
-  return utf16::utf8_length_from_utf16<endianness::BIG>(input, length);
+  return utf16::utf8_length_from_utf16_bytemask<endianness::BIG>(input, length);
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -388,3 +388,7 @@ add_cpp_test(atomic_base64_tests)
 target_link_libraries(atomic_base64_tests
   PUBLIC simdutf::tests::helpers
          simdutf::tests::reference)
+
+add_cpp_test(utf8_length_from_utf16_tests)
+target_link_libraries(utf8_length_from_utf16_tests
+    PUBLIC simdutf::tests::helpers)

--- a/tests/convert_utf16le_to_utf8_tests.cpp
+++ b/tests/convert_utf16le_to_utf8_tests.cpp
@@ -37,7 +37,7 @@ TEST(issue_a73) {
       u"\ubcb8\uadd8\uff89\u919b\u8a77\u8bfa\uafad\ub6cf\ub5c6\uf096\ubd8f"
       u"\uceae\ua8ab\u81f0\ub194\ua4c0\ua4c0\ub2f6\ub8a5\u9ff3\u3cbd\u81f4"
       u"\u82ae\u9efc\ufe88\ufabe\u9980\uf9b1\u8e95\u80df\ubdf6\ub4ad";
-  const size_t len = sizeof(utf16) / sizeof(char16_t);
+  const size_t len = sizeof(utf16) / sizeof(char16_t) - 1;
   to_utf16le_inplace(utf16, len);
 
   const size_t expected_length =

--- a/tests/utf8_length_from_utf16_tests.cpp
+++ b/tests/utf8_length_from_utf16_tests.cpp
@@ -1,0 +1,49 @@
+// The goal of these tests is to trigger the case when a low surrogate (the
+// first one) is the last char handled by a vectorized code, and the remaining
+// single one char16_t is passed to scalar code.
+
+#include "simdutf.h"
+
+#include <tests/helpers/test.h>
+
+TEST(utf16le_surrogate_pair) {
+  for (size_t size = 0; size < 512; size++) {
+    std::vector<uint8_t> input(size * 2, 0);
+
+    // low surrogate
+    input.push_back(0x01);
+    input.push_back(0xd8);
+
+    // high surrogate
+    input.push_back(0x01);
+    input.push_back(0xdc);
+
+    const size_t want = size + 4;
+    const size_t got = implementation.utf8_length_from_utf16le(
+        reinterpret_cast<const char16_t *>(input.data()), input.size() / 2);
+
+    ASSERT_EQUAL(want, got);
+  }
+}
+
+TEST(utf16be_surrogate_pair) {
+  for (size_t size = 0; size < 512; size++) {
+    std::vector<uint8_t> input(size * 2, 0);
+
+    // low surrogate
+    input.push_back(0xd8);
+    input.push_back(0x01);
+
+    // high surrogate
+    input.push_back(0xdc);
+    input.push_back(0x01);
+
+    const size_t want = size + 4;
+    const size_t got = implementation.utf8_length_from_utf16be(
+        reinterpret_cast<const char16_t *>(input.data()), input.size() / 2);
+
+    ASSERT_EQUAL(want, got);
+  }
+}
+
+TEST_MAIN


### PR DESCRIPTION
This PR uses similar approach used previously to speed-up UTF-8 length from UTF-32 --- that is, don't convert byte-mask into bit-mask, but use vector counters, that from time-to-time update scalar counter.

Results for `./benchmark -P utf8_length_from_utf16le -F unicode_lipsum/wikipedia_mars/*.utf16.txt`.


### IceLake

|              dataset              | size [B] | iterations | old GB/s | new GB/s | speedup |
| --------------------------------- | -------- | ---------- | -------- | -------- | ------- |
| utf8_length_from_utf16le+haswell                                                          |
| arabic.utf16                      |   849688 |      30000 |     6.59 |    12.74 | 1.93x   |
| chinese.utf16                     |   274416 |      30000 |     6.59 |    12.72 | 1.93x   |
| czech.utf16                       |   287664 |      30000 |     6.59 |    12.72 | 1.93x   |
| english.utf16                     |   775018 |      30000 |     6.59 |    12.74 | 1.93x   |
| esperanto.utf16                   |   168250 |      30000 |     6.58 |    12.66 | 1.93x   |
| french.utf16                      |   869734 |      30000 |     6.58 |    12.72 | 1.94x   |
| german.utf16                      |   402430 |      30000 |     6.59 |    12.72 | 1.93x   |
| greek.utf16                       |   285998 |      30000 |     6.58 |    12.70 | 1.93x   |
| hebrew.utf16                      |   292702 |      30000 |     6.58 |    12.70 | 1.93x   |
| hindi.utf16                       |   547916 |      30000 |     6.59 |    12.73 | 1.93x   |
| japanese.utf16                    |   237782 |      30000 |     6.58 |    12.70 | 1.93x   |
| korean.utf16                      |   145836 |      30000 |     6.57 |    12.64 | 1.92x   |
| persan.utf16                      |   249388 |      30000 |     6.58 |    12.69 | 1.93x   |
| portuguese.utf16                  |   547230 |      30000 |     6.59 |    12.73 | 1.93x   |
| russian.utf16                     |   624074 |      30000 |     6.59 |    12.74 | 1.93x   |
| thai.utf16                        |   809516 |      30000 |     6.58 |    12.74 | 1.94x   |
| turkish.utf16                     |   370884 |      30000 |     6.59 |    12.73 | 1.93x   |
| vietnamese.utf16                  |   564838 |      30000 |     6.59 |    12.74 | 1.93x   |
| utf8_length_from_utf16le+icelake                                                          |
| arabic.utf16                      |   849688 |      30000 |     7.57 |     7.54 | 1.00x   |
| chinese.utf16                     |   274416 |      30000 |     7.57 |     7.56 | 1.00x   |
| czech.utf16                       |   287664 |      30000 |     7.56 |     7.56 | 1.00x   |
| english.utf16                     |   775018 |      30000 |     7.57 |     7.58 | 1.00x   |
| esperanto.utf16                   |   168250 |      30000 |     7.55 |     7.55 | 1.00x   |
| french.utf16                      |   869734 |      30000 |     7.55 |     7.54 | 1.00x   |
| german.utf16                      |   402430 |      30000 |     7.56 |     7.56 | 1.00x   |
| greek.utf16                       |   285998 |      30000 |     7.56 |     7.57 | 1.00x   |
| hebrew.utf16                      |   292702 |      30000 |     7.57 |     7.56 | 1.00x   |
| hindi.utf16                       |   547916 |      30000 |     7.57 |     7.58 | 1.00x   |
| japanese.utf16                    |   237782 |      30000 |     7.56 |     7.56 | 1.00x   |
| korean.utf16                      |   145836 |      30000 |     7.55 |     7.56 | 1.00x   |
| persan.utf16                      |   249388 |      30000 |     7.57 |     7.57 | 1.00x   |
| portuguese.utf16                  |   547230 |      30000 |     7.57 |     7.57 | 1.00x   |
| russian.utf16                     |   624074 |      30000 |     7.58 |     7.58 | 1.00x   |
| thai.utf16                        |   809516 |      30000 |     7.56 |     7.56 | 1.00x   |
| turkish.utf16                     |   370884 |      30000 |     7.58 |     7.58 | 1.00x   |
| vietnamese.utf16                  |   564838 |      30000 |     7.58 |     7.57 | 1.00x   |
| utf8_length_from_utf16le+westmere                                                         |
| arabic.utf16                      |   849688 |      30000 |     3.70 |     8.48 | 2.29x   |
| chinese.utf16                     |   274416 |      30000 |     3.71 |     8.49 | 2.29x   |
| czech.utf16                       |   287664 |      30000 |     3.71 |     8.49 | 2.29x   |
| english.utf16                     |   775018 |      30000 |     3.71 |     8.50 | 2.29x   |
| esperanto.utf16                   |   168250 |      30000 |     3.70 |     8.46 | 2.29x   |
| french.utf16                      |   869734 |      30000 |     3.70 |     8.46 | 2.29x   |
| german.utf16                      |   402430 |      30000 |     3.71 |     8.49 | 2.29x   |
| greek.utf16                       |   285998 |      30000 |     3.70 |     8.48 | 2.29x   |
| hebrew.utf16                      |   292702 |      30000 |     3.71 |     8.48 | 2.29x   |
| hindi.utf16                       |   547916 |      30000 |     3.71 |     8.49 | 2.29x   |
| japanese.utf16                    |   237782 |      30000 |     3.71 |     8.48 | 2.29x   |
| korean.utf16                      |   145836 |      30000 |     3.71 |     8.45 | 2.28x   |
| persan.utf16                      |   249388 |      30000 |     3.70 |     8.47 | 2.29x   |
| portuguese.utf16                  |   547230 |      30000 |     3.70 |     8.49 | 2.29x   |
| russian.utf16                     |   624074 |      30000 |     3.70 |     8.50 | 2.29x   |
| thai.utf16                        |   809516 |      30000 |     3.70 |     8.49 | 2.30x   |
| turkish.utf16                     |   370884 |      30000 |     3.71 |     8.49 | 2.29x   |
| vietnamese.utf16                  |   564838 |      30000 |     3.71 |     8.50 | 2.29x   |


### Skylake-X

|              dataset              | size [B] | iterations | old GB/s | new GB/s | speedup |
| --------------------------------- | -------- | ---------- | -------- | -------- | ------- |
| utf8_length_from_utf16le+fallback                                                         |
| arabic.utf16                      |   849688 |      30000 |     2.82 |     2.82 | 1.00x   |
| chinese.utf16                     |   274416 |      30000 |     2.80 |     2.80 | 1.00x   |
| czech.utf16                       |   287664 |      30000 |     2.81 |     2.81 | 1.00x   |
| english.utf16                     |   775018 |      30000 |     2.82 |     2.83 | 1.00x   |
| esperanto.utf16                   |   168250 |      30000 |     2.78 |     2.78 | 1.00x   |
| french.utf16                      |   869734 |      30000 |     2.83 |     2.82 | 1.00x   |
| german.utf16                      |   402430 |      30000 |     2.81 |     2.81 | 1.00x   |
| greek.utf16                       |   285998 |      30000 |     2.80 |     2.80 | 1.00x   |
| hebrew.utf16                      |   292702 |      30000 |     2.81 |     2.81 | 1.00x   |
| hindi.utf16                       |   547916 |      30000 |     2.82 |     2.82 | 1.00x   |
| japanese.utf16                    |   237782 |      30000 |     2.80 |     2.80 | 1.00x   |
| korean.utf16                      |   145836 |      30000 |     2.77 |     2.77 | 1.00x   |
| persan.utf16                      |   249388 |      30000 |     2.80 |     2.80 | 1.00x   |
| portuguese.utf16                  |   547230 |      30000 |     2.82 |     2.82 | 1.00x   |
| russian.utf16                     |   624074 |      30000 |     2.82 |     2.82 | 1.00x   |
| thai.utf16                        |   809516 |      30000 |     2.82 |     2.82 | 1.00x   |
| turkish.utf16                     |   370884 |      30000 |     2.81 |     2.81 | 1.00x   |
| vietnamese.utf16                  |   564838 |      30000 |     2.82 |     2.82 | 1.00x   |
| utf8_length_from_utf16le+haswell                                                          |
| arabic.utf16                      |   849688 |      30000 |     4.84 |    11.34 | 2.34x   |
| chinese.utf16                     |   274416 |      30000 |     4.81 |    11.38 | 2.37x   |
| czech.utf16                       |   287664 |      30000 |     4.81 |    11.40 | 2.37x   |
| english.utf16                     |   775018 |      30000 |     4.85 |    11.65 | 2.40x   |
| esperanto.utf16                   |   168250 |      30000 |     4.74 |    10.99 | 2.32x   |
| french.utf16                      |   869734 |      30000 |     4.84 |    11.12 | 2.30x   |
| german.utf16                      |   402430 |      30000 |     4.84 |    11.52 | 2.38x   |
| greek.utf16                       |   285998 |      30000 |     4.81 |    11.38 | 2.37x   |
| hebrew.utf16                      |   292702 |      30000 |     4.81 |    11.40 | 2.37x   |
| hindi.utf16                       |   547916 |      30000 |     4.85 |    11.62 | 2.40x   |
| japanese.utf16                    |   237782 |      30000 |     4.79 |    11.28 | 2.35x   |
| korean.utf16                      |   145836 |      30000 |     4.72 |    10.88 | 2.31x   |
| persan.utf16                      |   249388 |      30000 |     4.80 |    11.29 | 2.36x   |
| portuguese.utf16                  |   547230 |      30000 |     4.85 |    11.62 | 2.40x   |
| russian.utf16                     |   624074 |      30000 |     4.83 |    11.64 | 2.41x   |
| thai.utf16                        |   809516 |      30000 |     4.82 |    11.18 | 2.32x   |
| turkish.utf16                     |   370884 |      30000 |     4.83 |    11.51 | 2.38x   |
| vietnamese.utf16                  |   564838 |      30000 |     4.85 |    11.63 | 2.40x   |
| utf8_length_from_utf16le+westmere                                                         |
| arabic.utf16                      |   849688 |      30000 |     3.60 |     5.06 | 1.41x   |
| chinese.utf16                     |   274416 |      30000 |     3.58 |     5.00 | 1.40x   |
| czech.utf16                       |   287664 |      30000 |     3.58 |     5.00 | 1.40x   |
| english.utf16                     |   775018 |      30000 |     3.60 |     5.07 | 1.41x   |
| esperanto.utf16                   |   168250 |      30000 |     3.54 |     4.93 | 1.39x   |
| french.utf16                      |   869734 |      30000 |     3.60 |     5.05 | 1.40x   |
| german.utf16                      |   402430 |      30000 |     3.59 |     5.03 | 1.40x   |
| greek.utf16                       |   285998 |      30000 |     3.58 |     5.00 | 1.40x   |
| hebrew.utf16                      |   292702 |      30000 |     3.58 |     5.00 | 1.40x   |
| hindi.utf16                       |   547916 |      30000 |     3.60 |     5.05 | 1.40x   |
| japanese.utf16                    |   237782 |      30000 |     3.57 |     4.98 | 1.40x   |
| korean.utf16                      |   145836 |      30000 |     3.53 |     4.91 | 1.39x   |
| persan.utf16                      |   249388 |      30000 |     3.57 |     4.98 | 1.40x   |
| portuguese.utf16                  |   547230 |      30000 |     3.60 |     5.05 | 1.40x   |
| russian.utf16                     |   624074 |      30000 |     3.59 |     5.06 | 1.41x   |
| thai.utf16                        |   809516 |      30000 |     3.60 |     5.05 | 1.41x   |
| turkish.utf16                     |   370884 |      30000 |     3.59 |     5.03 | 1.40x   |
| vietnamese.utf16                  |   564838 |      30000 |     3.60 |     5.05 | 1.40x   |


### Ryzen 7

|              dataset              | size [B] | iterations | old GB/s | new GB/s | speedup |
| --------------------------------- | -------- | ---------- | -------- | -------- | ------- |
| utf8_length_from_utf16le+fallback                                                         |
| arabic.utf16                      |   849690 |      30000 |     3.57 |     3.57 | 1.00x   |
| chinese.utf16                     |   274418 |      30000 |     3.59 |     3.60 | 1.00x   |
| czech.utf16                       |   287666 |      30000 |     3.58 |     3.60 | 1.01x   |
| english.utf16                     |   775020 |      30000 |     3.57 |     3.57 | 1.00x   |
| esperanto.utf16                   |   168252 |      30000 |     3.55 |     3.61 | 1.02x   |
| french.utf16                      |   869736 |      30000 |     3.56 |     3.57 | 1.00x   |
| german.utf16                      |   402432 |      30000 |     3.60 |     3.58 | 1.00x   |
| greek.utf16                       |   286000 |      30000 |     3.58 |     3.59 | 1.00x   |
| hebrew.utf16                      |   292704 |      30000 |     3.59 |     3.61 | 1.01x   |
| hindi.utf16                       |   547918 |      30000 |     3.59 |     3.59 | 1.00x   |
| japanese.utf16                    |   237784 |      30000 |     3.55 |     3.62 | 1.02x   |
| korean.utf16                      |   145838 |      30000 |     3.55 |     3.55 | 1.00x   |
| persan.utf16                      |   249390 |      30000 |     3.60 |     3.58 | 1.00x   |
| portuguese.utf16                  |   547232 |      30000 |     3.56 |     3.58 | 1.01x   |
| russian.utf16                     |   624076 |      30000 |     3.58 |     3.57 | 1.00x   |
| thai.utf16                        |   809518 |      30000 |     3.55 |     3.56 | 1.01x   |
| turkish.utf16                     |   370886 |      30000 |     3.58 |     3.55 | 0.99x   |
| vietnamese.utf16                  |   564840 |      30000 |     3.58 |     3.55 | 0.99x   |
| utf8_length_from_utf16le+haswell                                                          |
| arabic.utf16                      |   849690 |      30000 |    12.95 |    32.80 | 2.53x   |
| chinese.utf16                     |   274418 |      30000 |    12.92 |    32.38 | 2.51x   |
| czech.utf16                       |   287666 |      30000 |    12.92 |    32.85 | 2.54x   |
| english.utf16                     |   775020 |      30000 |    12.95 |    32.45 | 2.51x   |
| esperanto.utf16                   |   168252 |      30000 |    12.90 |    32.80 | 2.54x   |
| french.utf16                      |   869736 |      30000 |    12.94 |    32.66 | 2.52x   |
| german.utf16                      |   402432 |      30000 |    12.95 |    32.03 | 2.47x   |
| greek.utf16                       |   286000 |      30000 |    12.93 |    32.51 | 2.51x   |
| hebrew.utf16                      |   292704 |      30000 |    12.93 |    32.54 | 2.52x   |
| hindi.utf16                       |   547918 |      30000 |    12.94 |    32.02 | 2.47x   |
| japanese.utf16                    |   237784 |      30000 |    12.93 |    32.83 | 2.54x   |
| korean.utf16                      |   145838 |      30000 |    12.91 |    32.71 | 2.53x   |
| persan.utf16                      |   249390 |      30000 |    12.93 |    32.32 | 2.50x   |
| portuguese.utf16                  |   547232 |      30000 |    12.95 |    32.24 | 2.49x   |
| russian.utf16                     |   624076 |      30000 |    12.94 |    32.47 | 2.51x   |
| thai.utf16                        |   809518 |      30000 |    12.94 |    32.55 | 2.52x   |
| turkish.utf16                     |   370886 |      30000 |    12.93 |    32.08 | 2.48x   |
| vietnamese.utf16                  |   564840 |      30000 |    12.93 |    32.18 | 2.49x   |
| utf8_length_from_utf16le+westmere                                                         |
| arabic.utf16                      |   849690 |      30000 |     6.40 |    14.47 | 2.26x   |
| chinese.utf16                     |   274418 |      30000 |     6.42 |    14.48 | 2.25x   |
| czech.utf16                       |   287666 |      30000 |     6.43 |    14.47 | 2.25x   |
| english.utf16                     |   775020 |      30000 |     6.41 |    14.46 | 2.26x   |
| esperanto.utf16                   |   168252 |      30000 |     6.43 |    14.46 | 2.25x   |
| french.utf16                      |   869736 |      30000 |     6.40 |    14.47 | 2.26x   |
| german.utf16                      |   402432 |      30000 |     6.42 |    14.49 | 2.26x   |
| greek.utf16                       |   286000 |      30000 |     6.42 |    14.47 | 2.25x   |
| hebrew.utf16                      |   292704 |      30000 |     6.42 |    14.48 | 2.25x   |
| hindi.utf16                       |   547918 |      30000 |     6.41 |    14.47 | 2.26x   |
| japanese.utf16                    |   237784 |      30000 |     6.43 |    14.45 | 2.25x   |
| korean.utf16                      |   145838 |      30000 |     6.42 |    14.41 | 2.24x   |
| persan.utf16                      |   249390 |      30000 |     6.42 |    14.46 | 2.25x   |
| portuguese.utf16                  |   547232 |      30000 |     6.42 |    14.48 | 2.26x   |
| russian.utf16                     |   624076 |      30000 |     6.41 |    14.47 | 2.26x   |
| thai.utf16                        |   809518 |      30000 |     6.41 |    14.46 | 2.26x   |
| turkish.utf16                     |   370886 |      30000 |     6.42 |    14.47 | 2.26x   |
| vietnamese.utf16                  |   564840 |      30000 |     6.41 |    14.47 | 2.26x   |