### PR TITLE
icelake: faster UTF-8 length from UTF-16

### DIFF
--- a/src/icelake/icelake_utf8_length_from_utf16.inl.cpp
+++ b/src/icelake/icelake_utf8_length_from_utf16.inl.cpp
@@ -1,0 +1,84 @@
+// This is translation of `utf8_length_from_utf16_bytemask` from
+// `generic/utf16.h`
+template <endianness big_endian>
+simdutf_really_inline size_t icelake_utf8_length_from_utf16(const char16_t *in,
+                                                            size_t size) {
+  size_t pos = 0;
+
+  using vector_u16 = simd16<uint16_t>;
+  constexpr size_t N = vector_u16::ELEMENTS;
+
+  const auto one = vector_u16::splat(1);
+
+  auto v_count = vector_u16::zero();
+
+  // each char16 yields at least one byte
+  size_t count = size / N * N;
+
+  // in a single iteration the increment is 0, 1 or 2, despite we have
+  // three additions
+  constexpr size_t max_iterations = 65535 / 2;
+  size_t iteration = max_iterations;
+
+  for (; pos < size / N * N; pos += N) {
+    auto input = vector_u16::load(reinterpret_cast<const uint16_t *>(in + pos));
+    if (!match_system(big_endian)) {
+      input = input.swap_bytes();
+    }
+
+    // not_surrogate[i] = non-zero if i-th element is not a surrogate word
+    const auto not_surrogate = (input & uint16_t(0xf800)) ^ uint16_t(0xd800);
+
+    // not_surrogate[i] = 1 if surrogate word, 0 otherwise
+    const auto is_surrogate = min(not_surrogate, one) ^ one;
+
+    // c0 - chars that yield 2- or 3-byte UTF-8 codes
+    const auto c0 = min(input & uint16_t(0xff80), one);
+
+    // c1 - chars that yield 3-byte UTF-8 codes (including surrogates)
+    const auto c1 = min(input & uint16_t(0xf800), one);
+
+    /*
+        Explanation how the counting works.
+
+        In the case of a non-surrogate character we count:
+        * always 1 -- see how `count` is initialized above;
+        * c0 = 1 if the current char yields 2 or 3 bytes;
+        * c1 = 1 if the current char yields 3 bytes.
+
+        Thus, we always have correct count for the current char:
+        from 1, 2 or 3 bytes.
+
+        A trickier part is how we count surrogate pairs. Whether
+        we encounter a surrogate (low or high), we count it as
+        3 chars and then minus 1 (`is_surrogate` is -1 or 0).
+        Each surrogate char yields 2. A surrogate pair, that
+        is a low surrogate followed by a high one, yields
+        the expected 4 bytes.
+
+        It also correctly handles cases when low surrogate is
+        processed by the this loop, but high surrogate is counted
+        by the scalar procedure. The scalar procedure uses exactly
+        the described approach, thanks to that for valid UTF-16
+        strings it always count correctly.
+    */
+    v_count += c0;
+    v_count += c1;
+    v_count -= is_surrogate;
+
+    iteration -= 1;
+    if (iteration == 0) {
+      count += v_count.sum();
+      v_count = vector_u16::zero();
+
+      iteration = max_iterations;
+    }
+  }
+
+  if (iteration > 0) {
+    count += v_count.sum();
+  }
+
+  return count + scalar::utf16::utf8_length_from_utf16<big_endian>(in + pos,
+                                                                   size - pos);
+}

--- a/src/simdutf/icelake/simd.h
+++ b/src/simdutf/icelake/simd.h
@@ -6,6 +6,7 @@ namespace SIMDUTF_IMPLEMENTATION {
 namespace {
 namespace simd {
 
+#include "simdutf/icelake/simd16-inl.h"
 #include "simdutf/icelake/simd32-inl.h"
 
 } // namespace simd

--- a/src/simdutf/icelake/simd16-inl.h
+++ b/src/simdutf/icelake/simd16-inl.h
@@ -1,0 +1,90 @@
+template <typename T> struct simd16;
+
+template <> struct simd16<uint16_t> {
+  static const size_t SIZE = sizeof(__m512i);
+  static const size_t ELEMENTS = SIZE / sizeof(uint16_t);
+
+  template <typename Pointer>
+  static simdutf_really_inline simd16<uint16_t> load(const Pointer *ptr) {
+    return simd16<uint16_t>(ptr);
+  }
+
+  __m512i value;
+
+  simdutf_really_inline simd16(const __m512i v) : value(v) {}
+
+  template <typename Pointer>
+  simdutf_really_inline simd16(const Pointer *ptr)
+      : value(_mm512_loadu_si512(reinterpret_cast<const __m512i *>(ptr))) {}
+
+  // operators
+  simdutf_really_inline simd16 &operator+=(const simd16 other) {
+    value = _mm512_add_epi32(value, other.value);
+    return *this;
+  }
+
+  simdutf_really_inline simd16 &operator-=(const simd16 other) {
+    value = _mm512_sub_epi32(value, other.value);
+    return *this;
+  }
+
+  // methods
+  simdutf_really_inline simd16 swap_bytes() const {
+    const __m512i byteflip = _mm512_setr_epi64(
+        0x0607040502030001, 0x0e0f0c0d0a0b0809, 0x0607040502030001,
+        0x0e0f0c0d0a0b0809, 0x0607040502030001, 0x0e0f0c0d0a0b0809,
+        0x0607040502030001, 0x0e0f0c0d0a0b0809);
+
+    return _mm512_shuffle_epi8(value, byteflip);
+  }
+
+  simdutf_really_inline uint64_t sum() const {
+    const auto lo = _mm512_and_si512(value, _mm512_set1_epi32(0xffff));
+    const auto hi = _mm512_srli_epi32(value, 16);
+    const auto sum32 = _mm512_add_epi32(lo, hi);
+
+    return _mm512_reduce_add_epi32(sum32);
+  }
+
+  // static members
+  simdutf_really_inline static simd16<uint16_t> zero() {
+    return _mm512_setzero_si512();
+  }
+
+  simdutf_really_inline static simd16<uint16_t> splat(uint16_t v) {
+    return _mm512_set1_epi16(v);
+  }
+};
+
+template <> struct simd16<bool> {
+  __mmask32 value;
+
+  simdutf_really_inline simd16(const __mmask32 v) : value(v) {}
+};
+
+// ------------------------------------------------------------
+
+simdutf_really_inline simd16<uint16_t> min(const simd16<uint16_t> b,
+                                           const simd16<uint16_t> a) {
+  return _mm512_min_epu16(a.value, b.value);
+}
+
+simdutf_really_inline simd16<uint16_t> operator&(const simd16<uint16_t> a,
+                                                 uint16_t b) {
+  return _mm512_and_si512(a.value, _mm512_set1_epi16(b));
+}
+
+simdutf_really_inline simd16<uint16_t> operator^(const simd16<uint16_t> a,
+                                                 uint16_t b) {
+  return _mm512_xor_si512(a.value, _mm512_set1_epi16(b));
+}
+
+simdutf_really_inline simd16<uint16_t> operator^(const simd16<uint16_t> a,
+                                                 const simd16<uint16_t> b) {
+  return _mm512_xor_si512(a.value, b.value);
+}
+
+simdutf_really_inline simd16<bool> operator==(const simd16<uint16_t> a,
+                                              uint16_t b) {
+  return _mm512_cmpeq_epi16_mask(a.value, _mm512_set1_epi16(b));
+}


### PR DESCRIPTION
Use a similar approach as the generic implementation, that is keep counters in vector registers.

Benchmark results for `./build/benchmarks/benchmark -P utf8_length_from_utf16le+icelake -F ~/unicode_lipsum/wikipedia_mars/*.utf16.txt -I 10000`

### Icelake

|             dataset              | size [B] | iterations | old GB/s | new GB/s | speedup |
| -------------------------------- | -------- | ---------- | -------- | -------- | ------- |
| utf8_length_from_utf16le+icelake                                                         |
| arabic.utf16                     |   849688 |      10000 |     7.65 |    12.19 | 1.59x   |
| chinese.utf16                    |   274416 |      10000 |     7.64 |    12.21 | 1.60x   |
| czech.utf16                      |   287664 |      10000 |     7.63 |    12.21 | 1.60x   |
| english.utf16                    |   775018 |      10000 |     7.65 |    12.23 | 1.60x   |
| esperanto.utf16                  |   168250 |      10000 |     7.61 |    12.16 | 1.60x   |
| french.utf16                     |   869734 |      10000 |     7.65 |    12.14 | 1.59x   |
| german.utf16                     |   402430 |      10000 |     7.64 |    12.20 | 1.60x   |
| greek.utf16                      |   285998 |      10000 |     7.64 |    12.20 | 1.60x   |
| hebrew.utf16                     |   292702 |      10000 |     7.63 |    12.20 | 1.60x   |
| hindi.utf16                      |   547916 |      10000 |     7.65 |    12.22 | 1.60x   |
| japanese.utf16                   |   237782 |      10000 |     7.63 |    12.18 | 1.60x   |
| korean.utf16                     |   145836 |      10000 |     7.62 |    12.22 | 1.60x   |
| persan.utf16                     |   249388 |      10000 |     7.63 |    12.21 | 1.60x   |
| portuguese.utf16                 |   547230 |      10000 |     7.64 |    12.21 | 1.60x   |
| russian.utf16                    |   624074 |      10000 |     7.65 |    12.22 | 1.60x   |
| thai.utf16                       |   809516 |      10000 |     7.65 |    12.19 | 1.59x   |
| turkish.utf16                    |   370884 |      10000 |     7.65 |    12.23 | 1.60x   |
| vietnamese.utf16                 |   564838 |      10000 |     7.65 |    12.22 | 1.60x   |