### PR TITLE
lsx & lasx: add splat intrinsics

### DIFF
--- a/src/lasx/implementation.cpp
+++ b/src/lasx/implementation.cpp
@@ -108,7 +108,7 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
   __m128i ascii = __lsx_vand_v(perm, __lsx_vrepli_h(0x7f)); // 6 or 7 bits
   // 1 byte: 00000000 00000000
   // 2 byte: 00000aaa aa000000
-  __m128i v1f00 = __lsx_vldi(-2785); // -2785(13bit) => 151f
+  __m128i v1f00 = lsx_splat_u16(0x1f00);
   __m128i composed = __lsx_vsrli_h(__lsx_vand_v(perm, v1f00), 2); // 5 bits
   // Combine with a shift right accumulate
   // 1 byte: 00000000 0bbbbbbb
@@ -1269,9 +1269,10 @@ simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::utf8_length_from_utf32(
     const char32_t *input, size_t length) const noexcept {
-  __m256i v_80 = __lasx_xvrepli_w(0x80); /*0x00000080*/
-  __m256i v_800 = __lasx_xvldi(-3832);   /*0x00000800*/
-  __m256i v_10000 = __lasx_xvldi(-3583); /*0x00010000*/
+  const __m256i v_80 = lasx_splat_u32(0x00000080);
+  const __m256i v_800 = lasx_splat_u32(0x00000800);
+  const __m256i v_10000 = lasx_splat_u32(0x00010000);
+
   size_t pos = 0;
   size_t count = 0;
   for (; pos + 8 <= length; pos += 8) {
@@ -1307,7 +1308,7 @@ simdutf_warn_unused size_t implementation::utf8_length_from_utf32(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::utf16_length_from_utf32(
     const char32_t *input, size_t length) const noexcept {
-  __m128i v_ffff = __lsx_vldi(-2304); /*0x0000ffff*/
+  __m128i v_ffff = lsx_splat_u32(0x0000ffff);
   size_t pos = 0;
   size_t count = 0;
   for (; pos + 4 <= length; pos += 4) {

--- a/src/lasx/lasx_base64.cpp
+++ b/src/lasx/lasx_base64.cpp
@@ -365,10 +365,9 @@ static inline void load_block(block64 *b, const char16_t *src) {
 static inline void base64_decode(char *out, __m256i str) {
   __m256i t0 = __lasx_xvor_v(
       __lasx_xvslli_w(str, 26),
-      __lasx_xvslli_w(__lasx_xvand_v(str, __lasx_xvldi(-1758 /*0x0000FF00*/)),
-                      12));
-  __m256i t1 = __lasx_xvsrli_w(
-      __lasx_xvand_v(str, __lasx_xvldi(-3521 /*0x003F0000*/)), 2);
+      __lasx_xvslli_w(__lasx_xvand_v(str, lasx_splat_u32(0x0000ff00)), 12));
+  __m256i t1 =
+      __lasx_xvsrli_w(__lasx_xvand_v(str, lasx_splat_u32(0x003f0000)), 2);
   __m256i t2 = __lasx_xvor_v(t0, t1);
   __m256i t3 = __lasx_xvor_v(t2, __lasx_xvsrli_w(str, 16));
   __m256i pack_shuffle = ____m256i(

--- a/src/lasx/lasx_convert_latin1_to_utf8.cpp
+++ b/src/lasx/lasx_convert_latin1_to_utf8.cpp
@@ -30,7 +30,7 @@ lasx_convert_latin1_to_utf8(const char *latin1_input, size_t len,
     // t0 = [0000|00aa|bbbb|bb00]
     __m256i t0 = __lasx_xvslli_h(in16, 2);
     // t1 = [0000|00aa|0000|0000]
-    __m256i t1 = __lasx_xvand_v(t0, __lasx_xvldi(-2785));
+    __m256i t1 = __lasx_xvand_v(t0, lasx_splat_u16(0x300));
     // t3 = [0000|00aa|00bb|bbbb]
     __m256i t2 = __lasx_xvbitsel_v(t1, in16, __lasx_xvrepli_h(0x3f));
     // t4 = [1100|00aa|10bb|bbbb]

--- a/src/lasx/lasx_convert_utf16_to_utf32.cpp
+++ b/src/lasx/lasx_convert_utf16_to_utf32.cpp
@@ -32,8 +32,8 @@ lasx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
     }
   }
 
-  __m256i v_f800 = __lasx_xvldi(-2568); /*0xF800*/
-  __m256i v_d800 = __lasx_xvldi(-2600); /*0xD800*/
+  __m256i v_f800 = lasx_splat_u16(0xf800);
+  __m256i v_d800 = lasx_splat_u16(0xd800);
 
   while (end - buf >= 16) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint16_t *>(buf), 0);
@@ -131,8 +131,8 @@ lasx_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
     }
   }
 
-  __m256i v_f800 = __lasx_xvldi(-2568); /*0xF800*/
-  __m256i v_d800 = __lasx_xvldi(-2600); /*0xD800*/
+  __m256i v_f800 = lasx_splat_u16(0xf800);
+  __m256i v_d800 = lasx_splat_u16(0xd800);
   while (end - buf >= 16) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint16_t *>(buf), 0);
     if (!match_system(big_endian)) {

--- a/src/lasx/lasx_convert_utf16_to_utf8.cpp
+++ b/src/lasx/lasx_convert_utf16_to_utf8.cpp
@@ -89,7 +89,7 @@ lasx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
       // t0 = [000a|aaaa|bbbb|bb00]
       __m256i t0 = __lasx_xvslli_h(in, 2);
       // t1 = [000a|aaaa|0000|0000]
-      __m256i t1 = __lasx_xvand_v(t0, __lasx_xvldi(-2785 /*0x1f00*/));
+      __m256i t1 = __lasx_xvand_v(t0, lasx_splat_u16(0x1f00));
       // t2 = [0000|0000|00bb|bbbb]
       __m256i t2 = __lasx_xvand_v(in, __lasx_xvrepli_h(0x3f));
       // t3 = [000a|aaaa|00bb|bbbb]
@@ -127,9 +127,8 @@ lasx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
       buf += 16;
       continue;
     }
-    __m256i surrogates_bytemask =
-        __lasx_xvseq_h(__lasx_xvand_v(in, __lasx_xvldi(-2568 /*0xF800*/)),
-                       __lasx_xvldi(-2600 /*0xD800*/));
+    __m256i surrogates_bytemask = __lasx_xvseq_h(
+        __lasx_xvand_v(in, lasx_splat_u16(0xf800)), lasx_splat_u16(0xd800));
     // It might seem like checking for surrogates_bitmask == 0xc000 could help.
     // However, it is likely an uncommon occurrence.
     if (__lasx_xbz_v(surrogates_bytemask)) {
@@ -169,14 +168,14 @@ lasx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
       __m256i v_3f7f = __lasx_xvreplgr2vr_h(uint16_t(0x3F7F));
       __m256i t1 = __lasx_xvand_v(t0, v_3f7f);
       // [00cc|cccc|0bcc|cccc] => [10cc|cccc|0bcc|cccc]
-      __m256i t2 = __lasx_xvor_v(t1, __lasx_xvldi(-2688));
+      __m256i t2 = __lasx_xvor_v(t1, lasx_splat_u16(0x8000));
 
       // s0: [aaaa|bbbb|bbcc|cccc] => [0000|0000|0000|aaaa]
       __m256i s0 = __lasx_xvsrli_h(in, 12);
       // s1: [aaaa|bbbb|bbcc|cccc] => [0000|bbbb|bb00|0000]
       __m256i s1 = __lasx_xvslli_h(in, 2);
       // s1: [aabb|bbbb|cccc|cc00] => [00bb|bbbb|0000|0000]
-      s1 = __lasx_xvand_v(s1, __lasx_xvldi(-2753 /*0x3F00*/));
+      s1 = __lasx_xvand_v(s1, lasx_splat_u16(0x3f00));
 
       // [00bb|bbbb|0000|aaaa]
       __m256i s2 = __lasx_xvor_v(s0, s1);
@@ -184,8 +183,8 @@ lasx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
       __m256i v_c0e0 = __lasx_xvreplgr2vr_h(uint16_t(0xC0E0));
       __m256i s3 = __lasx_xvor_v(s2, v_c0e0);
       __m256i one_or_two_bytes_bytemask = __lasx_xvsle_hu(in, v_07ff);
-      __m256i m0 = __lasx_xvandn_v(one_or_two_bytes_bytemask,
-                                   __lasx_xvldi(-2752 /*0x4000*/));
+      __m256i m0 =
+          __lasx_xvandn_v(one_or_two_bytes_bytemask, lasx_splat_u16(0x4000));
       __m256i s4 = __lasx_xvxor_v(s3, m0);
 
       // 4. expand code units 16-bit => 32-bit
@@ -344,7 +343,7 @@ lasx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
       // t0 = [000a|aaaa|bbbb|bb00]
       __m256i t0 = __lasx_xvslli_h(in, 2);
       // t1 = [000a|aaaa|0000|0000]
-      __m256i t1 = __lasx_xvand_v(t0, __lasx_xvldi(-2785 /*0x1f00*/));
+      __m256i t1 = __lasx_xvand_v(t0, lasx_splat_u16(0x1f00));
       // t2 = [0000|0000|00bb|bbbb]
       __m256i t2 = __lasx_xvand_v(in, __lasx_xvrepli_h(0x3f));
       // t3 = [000a|aaaa|00bb|bbbb]
@@ -382,9 +381,8 @@ lasx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
       buf += 16;
       continue;
     }
-    __m256i surrogates_bytemask =
-        __lasx_xvseq_h(__lasx_xvand_v(in, __lasx_xvldi(-2568 /*0xF800*/)),
-                       __lasx_xvldi(-2600 /*0xD800*/));
+    __m256i surrogates_bytemask = __lasx_xvseq_h(
+        __lasx_xvand_v(in, lasx_splat_u16(0xf800)), lasx_splat_u16(0xd800));
     // It might seem like checking for surrogates_bitmask == 0xc000 could help.
     // However, it is likely an uncommon occurrence.
     if (__lasx_xbz_v(surrogates_bytemask)) {
@@ -424,14 +422,14 @@ lasx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
       __m256i v_3f7f = __lasx_xvreplgr2vr_h(uint16_t(0x3F7F));
       __m256i t1 = __lasx_xvand_v(t0, v_3f7f);
       // [00cc|cccc|0bcc|cccc] => [10cc|cccc|0bcc|cccc]
-      __m256i t2 = __lasx_xvor_v(t1, __lasx_xvldi(-2688));
+      __m256i t2 = __lasx_xvor_v(t1, lasx_splat_u16(0x8000));
 
       // s0: [aaaa|bbbb|bbcc|cccc] => [0000|0000|0000|aaaa]
       __m256i s0 = __lasx_xvsrli_h(in, 12);
       // s1: [aaaa|bbbb|bbcc|cccc] => [0000|bbbb|bb00|0000]
       __m256i s1 = __lasx_xvslli_h(in, 2);
       // s1: [aabb|bbbb|cccc|cc00] => [00bb|bbbb|0000|0000]
-      s1 = __lasx_xvand_v(s1, __lasx_xvldi(-2753 /*0x3F00*/));
+      s1 = __lasx_xvand_v(s1, lasx_splat_u16(0x3f00));
 
       // [00bb|bbbb|0000|aaaa]
       __m256i s2 = __lasx_xvor_v(s0, s1);
@@ -439,8 +437,8 @@ lasx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
       __m256i v_c0e0 = __lasx_xvreplgr2vr_h(uint16_t(0xC0E0));
       __m256i s3 = __lasx_xvor_v(s2, v_c0e0);
       __m256i one_or_two_bytes_bytemask = __lasx_xvsle_hu(in, v_07ff);
-      __m256i m0 = __lasx_xvandn_v(one_or_two_bytes_bytemask,
-                                   __lasx_xvldi(-2752 /*0x4000*/));
+      __m256i m0 =
+          __lasx_xvandn_v(one_or_two_bytes_bytemask, lasx_splat_u16(0x4000));
       __m256i s4 = __lasx_xvxor_v(s3, m0);
 
       // 4. expand code units 16-bit => 32-bit

--- a/src/lasx/lasx_convert_utf32_to_utf16.cpp
+++ b/src/lasx/lasx_convert_utf32_to_utf16.cpp
@@ -38,8 +38,8 @@ lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
   }
 
   __m256i forbidden_bytemask = __lasx_xvrepli_h(0);
-  __m256i v_d800 = __lasx_xvldi(-2600); /*0xD800*/
-  __m256i v_dfff = __lasx_xvreplgr2vr_h(uint16_t(0xdfff));
+  __m256i v_d800 = lasx_splat_u16(0xd800);
+  __m256i v_dfff = lasx_splat_u16(0xdfff);
   while (end - buf >= 16) {
     __m256i in0 = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m256i in1 = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 32);
@@ -145,8 +145,8 @@ lasx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
   }
 
   __m256i forbidden_bytemask = __lasx_xvrepli_h(0);
-  __m256i v_d800 = __lasx_xvldi(-2600); /*0xD800*/
-  __m256i v_dfff = __lasx_xvreplgr2vr_h(uint16_t(0xdfff));
+  __m256i v_d800 = lasx_splat_u16(0xd800);
+  __m256i v_dfff = lasx_splat_u16(0xdfff);
   while (end - buf >= 16) {
     __m256i in0 = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m256i in1 = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 32);

--- a/src/lasx/lasx_convert_utf32_to_utf8.cpp
+++ b/src/lasx/lasx_convert_utf32_to_utf8.cpp
@@ -30,10 +30,10 @@ lasx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
     buf++;
   }
 
-  __m256i v_c080 = __lasx_xvreplgr2vr_h(uint16_t(0xC080));
-  __m256i v_07ff = __lasx_xvreplgr2vr_h(uint16_t(0x7FF));
-  __m256i v_dfff = __lasx_xvreplgr2vr_h(uint16_t(0xDFFF));
-  __m256i v_d800 = __lasx_xvldi(-2600); /*0xD800*/
+  __m256i v_c080 = lasx_splat_u16(0xc080);
+  __m256i v_07ff = lasx_splat_u16(0x07ff);
+  __m256i v_dfff = lasx_splat_u16(0xdfff);
+  __m256i v_d800 = lasx_splat_u16(0xd800);
   __m256i zero = __lasx_xvldi(0);
   __m128i zero_128 = __lsx_vldi(0);
   __m256i forbidden_bytemask = __lasx_xvldi(0x0);
@@ -75,7 +75,7 @@ lasx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
         // t0 = [000a|aaaa|bbbb|bb00]
         const __m256i t0 = __lasx_xvslli_h(utf16_packed, 2);
         // t1 = [000a|aaaa|0000|0000]
-        const __m256i t1 = __lasx_xvand_v(t0, __lasx_xvldi(-2785 /*0x1f00*/));
+        const __m256i t1 = __lasx_xvand_v(t0, lasx_splat_u16(0x1f00));
         // t2 = [0000|0000|00bb|bbbb]
         const __m256i t2 = __lasx_xvand_v(utf16_packed, __lasx_xvrepli_h(0x3f));
         // t3 = [000a|aaaa|00bb|bbbb]
@@ -155,14 +155,14 @@ lasx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
         __m256i v_3f7f = __lasx_xvreplgr2vr_h(uint16_t(0x3F7F));
         __m256i t1 = __lasx_xvand_v(t0, v_3f7f);
         // [00cc|cccc|0bcc|cccc] => [10cc|cccc|0bcc|cccc]
-        __m256i t2 = __lasx_xvor_v(t1, __lasx_xvldi(-2688 /*0x8000*/));
+        __m256i t2 = __lasx_xvor_v(t1, lasx_splat_u16(0x8000));
 
         // s0: [aaaa|bbbb|bbcc|cccc] => [0000|0000|0000|aaaa]
         __m256i s0 = __lasx_xvsrli_h(utf16_packed, 12);
         // s1: [aaaa|bbbb|bbcc|cccc] => [0000|bbbb|bb00|0000]
         __m256i s1 = __lasx_xvslli_h(utf16_packed, 2);
         // [0000|bbbb|bb00|0000] => [00bb|bbbb|0000|0000]
-        s1 = __lasx_xvand_v(s1, __lasx_xvldi(-2753 /*0x3F00*/));
+        s1 = __lasx_xvand_v(s1, lasx_splat_u16(0x3f00));
         // [00bb|bbbb|0000|aaaa]
         __m256i s2 = __lasx_xvor_v(s0, s1);
         // s3: [00bb|bbbb|0000|aaaa] => [11bb|bbbb|1110|aaaa]
@@ -171,8 +171,8 @@ lasx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
         // __m256i v_07ff = vmovq_n_u16((uint16_t)0x07FF);
         __m256i one_or_two_bytes_bytemask =
             __lasx_xvsle_hu(utf16_packed, v_07ff);
-        __m256i m0 = __lasx_xvandn_v(one_or_two_bytes_bytemask,
-                                     __lasx_xvldi(-2752 /*0x4000*/));
+        __m256i m0 =
+            __lasx_xvandn_v(one_or_two_bytes_bytemask, lasx_splat_u16(0x4000));
         __m256i s4 = __lasx_xvxor_v(s3, m0);
 
         // 4. expand code units 16-bit => 32-bit
@@ -326,10 +326,10 @@ lasx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
     buf++;
   }
 
-  __m256i v_c080 = __lasx_xvreplgr2vr_h(uint16_t(0xC080));
-  __m256i v_07ff = __lasx_xvreplgr2vr_h(uint16_t(0x7FF));
-  __m256i v_dfff = __lasx_xvreplgr2vr_h(uint16_t(0xDFFF));
-  __m256i v_d800 = __lasx_xvldi(-2600); /*0xD800*/
+  __m256i v_c080 = lasx_splat_u16(0xc080);
+  __m256i v_07ff = lasx_splat_u16(0x07ff);
+  __m256i v_dfff = lasx_splat_u16(0xdfff);
+  __m256i v_d800 = lasx_splat_u16(0xd800);
   __m256i zero = __lasx_xvldi(0);
   __m128i zero_128 = __lsx_vldi(0);
   __m256i forbidden_bytemask = __lasx_xvldi(0x0);
@@ -370,7 +370,7 @@ lasx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
         // t0 = [000a|aaaa|bbbb|bb00]
         const __m256i t0 = __lasx_xvslli_h(utf16_packed, 2);
         // t1 = [000a|aaaa|0000|0000]
-        const __m256i t1 = __lasx_xvand_v(t0, __lasx_xvldi(-2785 /*0x1f00*/));
+        const __m256i t1 = __lasx_xvand_v(t0, lasx_splat_u16(0x1f00));
         // t2 = [0000|0000|00bb|bbbb]
         const __m256i t2 = __lasx_xvand_v(utf16_packed, __lasx_xvrepli_h(0x3f));
         // t3 = [000a|aaaa|00bb|bbbb]
@@ -454,14 +454,14 @@ lasx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
         __m256i v_3f7f = __lasx_xvreplgr2vr_h(uint16_t(0x3F7F));
         __m256i t1 = __lasx_xvand_v(t0, v_3f7f);
         // [00cc|cccc|0bcc|cccc] => [10cc|cccc|0bcc|cccc]
-        __m256i t2 = __lasx_xvor_v(t1, __lasx_xvldi(-2688 /*0x8000*/));
+        __m256i t2 = __lasx_xvor_v(t1, lasx_splat_u16(0x8000));
 
         // s0: [aaaa|bbbb|bbcc|cccc] => [0000|0000|0000|aaaa]
         __m256i s0 = __lasx_xvsrli_h(utf16_packed, 12);
         // s1: [aaaa|bbbb|bbcc|cccc] => [0000|bbbb|bb00|0000]
         __m256i s1 = __lasx_xvslli_h(utf16_packed, 2);
         // [0000|bbbb|bb00|0000] => [00bb|bbbb|0000|0000]
-        s1 = __lasx_xvand_v(s1, __lasx_xvldi(-2753 /*0x3F00*/));
+        s1 = __lasx_xvand_v(s1, lasx_splat_u16(0x3F00));
         // [00bb|bbbb|0000|aaaa]
         __m256i s2 = __lasx_xvor_v(s0, s1);
         // s3: [00bb|bbbb|0000|aaaa] => [11bb|bbbb|1110|aaaa]
@@ -470,8 +470,8 @@ lasx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
         // __m256i v_07ff = vmovq_n_u16((uint16_t)0x07FF);
         __m256i one_or_two_bytes_bytemask =
             __lasx_xvsle_hu(utf16_packed, v_07ff);
-        __m256i m0 = __lasx_xvandn_v(one_or_two_bytes_bytemask,
-                                     __lasx_xvldi(-2752 /*0x4000*/));
+        __m256i m0 =
+            __lasx_xvandn_v(one_or_two_bytes_bytemask, lasx_splat_u16(0x4000));
         __m256i s4 = __lasx_xvxor_v(s3, m0);
 
         // 4. expand code units 16-bit => 32-bit

--- a/src/lasx/lasx_convert_utf8_to_utf16.cpp
+++ b/src/lasx/lasx_convert_utf8_to_utf16.cpp
@@ -118,7 +118,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // 1 byte: 00000000 00000000
     // 2 byte: xx0bbbbb 00000000
     // 3 byte: xxbbbbbb 00000000
-    __m128i middlebyte = __lsx_vand_v(lowperm, __lsx_vldi(-2561) /*0xFF00*/);
+    __m128i middlebyte = __lsx_vand_v(lowperm, lsx_splat_u16(0xFF00));
     // 1 byte: 00000000 0ccccccc
     // 2 byte: 0010bbbb bbcccccc
     // 3 byte: 0010bbbb bbcccccc
@@ -170,10 +170,8 @@ size_t convert_masked_utf8_to_utf16(const char *input,
       //                   = +0xDC00|0xE7C0
       __m128i magic = __lsx_vreplgr2vr_w(uint32_t(0xDC00E7C0));
       // Generate unadjusted trail surrogate minus lowest 2 bits
-      // vec(0000FF00) = __lsx_vldi(-1758)
       // xxxxxxxx xxxxxxxx|11110aaa bbbbbb00
-      __m128i trail =
-          __lsx_vbitsel_v(shift, swap, __lsx_vldi(-1758 /*0000FF00*/));
+      __m128i trail = __lsx_vbitsel_v(shift, swap, lsx_splat_u32(0x0000FF00));
       // Insert low 2 bits of trail surrogate to magic number for later
       // 11011100 00000000 11100111 110000cc
       __m128i magic_with_low_2 = __lsx_vor_v(__lsx_vsrli_w(shift, 30), magic);
@@ -186,10 +184,8 @@ size_t convert_masked_utf8_to_utf16(const char *input,
           __lsx_vrepli_h(0x3f /* 0x003f*/));
 
       // Blend pairs
-      // __lsx_vldi(-1741) => vec(0x0000FFFF)
       // 000000cc ccdddddd|11110aaa bbbbbb00
-      __m128i blend =
-          __lsx_vbitsel_v(lead, trail, __lsx_vldi(-1741) /* (0x0000FFFF)*4 */);
+      __m128i blend = __lsx_vbitsel_v(lead, trail, lsx_splat_u32(0x0000FFFF));
 
       // Add magic number to finish the result
       // 110111CC CCDDDDDD|110110AA BBBBBBCC
@@ -226,13 +222,12 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // first.
     __m128i middlehigh = __lsx_vslli_w(perm, 2);
     // 00000000 00000000 00cccccc 00000000
-    __m128i middlebyte = __lsx_vand_v(perm, __lsx_vldi(-3777) /* 0x00003F00 */);
+    __m128i middlebyte = __lsx_vand_v(perm, lsx_splat_u32(0x00003F00));
     // Start assembling the sequence. Since the 4th byte is in the same position
     // as it would be in a surrogate and there is no dependency, shift left
     // instead of right. 3 byte: 00000000 10bbbbxx xxxxxxxx xxxxxxxx 4 byte:
     // 11110aaa bbbbbbxx xxxxxxxx xxxxxxxx
-    __m128i ab =
-        __lsx_vbitsel_v(middlehigh, perm, __lsx_vldi(-1656) /*0xFF000000*/);
+    __m128i ab = __lsx_vbitsel_v(middlehigh, perm, lsx_splat_u32(0xFF000000));
     // Top 16 bits contains the high ten bits of the surrogate pair before
     // correction 3 byte: 00000000 10bbbbcc|cccc0000 00000000 4 byte: 11110aaa
     // bbbbbbcc|cccc0000 00000000 - high 10 bits correct w/o correction
@@ -246,8 +241,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // After this is for surrogates
     // Blend the low and high surrogates
     // 4 byte: 11110aaa bbbbbbcc|bbbbcccc ccdddddd
-    __m128i mixed =
-        __lsx_vbitsel_v(abc, composed, __lsx_vldi(-1741) /*0x0000FFFF*/);
+    __m128i mixed = __lsx_vbitsel_v(abc, composed, lsx_splat_u32(0x0000FFFF));
     // Clear the upper 6 bits of the low surrogate. Don't clear the upper bits
     // yet as 0x10000 was not subtracted from the codepoint yet. 4 byte:
     // 11110aaa bbbbbbcc|000000cc ccdddddd

--- a/src/lasx/lasx_convert_utf8_to_utf32.cpp
+++ b/src/lasx/lasx_convert_utf8_to_utf32.cpp
@@ -106,14 +106,13 @@ size_t convert_masked_utf8_to_utf32(const char *input,
     // The top bits will be corrected later in the bsl
     // 00000000 10bbbbbb 00000000
     __m128i middle =
-        __lsx_vand_v(perm, __lsx_vldi(-1758 /*0x0000FF00*/)); // 5 or 6 bits
+        __lsx_vand_v(perm, lsx_splat_u32(0x0000FF00)); // 5 or 6 bits
     // Combine low and middle with shift right accumulate
     // 00000000 00xxbbbb bbcccccc
     __m128i lowmid = __lsx_vor_v(ascii, __lsx_vsrli_w(middle, 2));
     // Insert top 4 bits from high byte with bitwise select
     // 00000000 aaaabbbb bbcccccc
-    __m128i composed =
-        __lsx_vbitsel_v(lowmid, high, __lsx_vldi(-3600 /*0x0000F000*/));
+    __m128i composed = __lsx_vbitsel_v(lowmid, high, lsx_splat_u32(0x0000F000));
     __lsx_vst(composed, utf32_output, 0);
     utf32_output += 4; // We wrote 4 32-bit characters.
     return consumed;
@@ -142,10 +141,10 @@ size_t convert_masked_utf8_to_utf32(const char *input,
       __m128i merge2 =
           __lsx_vbitsel_v(__lsx_vslli_w(merge1, 12), /* merge1 << 12 */
                           __lsx_vsrli_w(merge1, 16), /* merge1 >> 16 */
-                          __lsx_vldi(-2545));        /*0x00000FFF*/
+                          lsx_splat_u32(0x00000FFF));
       // Clear the garbage
       // 00000000 000aaabb bbbbcccc ccdddddd
-      __m128i composed = __lsx_vand_v(merge2, __lsx_vldi(-2273 /*0x1FFFFF*/));
+      __m128i composed = __lsx_vand_v(merge2, lsx_splat_u32(0x1FFFFF));
       // Store
       __lsx_vst(composed, utf32_output, 0);
       utf32_output += 3; // We wrote 3 32-bit characters.
@@ -165,11 +164,11 @@ size_t convert_masked_utf8_to_utf32(const char *input,
 
     // Ascii
     __m128i ascii = __lsx_vand_v(perm, __lsx_vrepli_w(0x7F));
-    __m128i middle = __lsx_vand_v(perm, __lsx_vldi(-3777 /*0x00003f00*/));
+    __m128i middle = __lsx_vand_v(perm, lsx_splat_u32(0x00003f00));
     // 00000000 00000000 0000cccc ccdddddd
     __m128i cd = __lsx_vor_v(__lsx_vsrli_w(middle, 2), ascii);
 
-    __m128i correction = __lsx_vand_v(perm, __lsx_vldi(-3520 /*0x00400000*/));
+    __m128i correction = __lsx_vand_v(perm, lsx_splat_u32(0x00400000));
     __m128i corrected = __lsx_vadd_b(perm, __lsx_vsrli_w(correction, 1));
     // Insert twice
     // 00000000 000aaabb bbbbxxxx xxxxxxxx
@@ -179,8 +178,7 @@ size_t convert_masked_utf8_to_utf32(const char *input,
         __lsx_vbitsel_v(corrected_srli2, corrected, __lsx_vrepli_h(0x3f));
     ab = __lsx_vsrli_w(ab, 4);
     // 00000000 000aaabb bbbbcccc ccdddddd
-    __m128i composed =
-        __lsx_vbitsel_v(ab, cd, __lsx_vldi(-2545 /*0x00000FFF*/));
+    __m128i composed = __lsx_vbitsel_v(ab, cd, lsx_splat_u32(0x00000FFF));
     // Store
     __lsx_vst(composed, utf32_output, 0);
     utf32_output += 3; // We wrote 3 32-bit characters.

--- a/src/lasx/lasx_validate_utf32le.cpp
+++ b/src/lasx/lasx_validate_utf32le.cpp
@@ -1,4 +1,3 @@
-
 const char32_t *lasx_validate_utf32le(const char32_t *input, size_t size) {
   const char32_t *end = input + size;
 
@@ -10,9 +9,9 @@ const char32_t *lasx_validate_utf32le(const char32_t *input, size_t size) {
     }
   }
 
-  __m256i offset = __lasx_xvreplgr2vr_w(uint32_t(0xffff2000));
-  __m256i standardoffsetmax = __lasx_xvreplgr2vr_w(uint32_t(0xfffff7ff));
-  __m256i standardmax = __lasx_xvldi(-2288); /*0x10ffff*/
+  __m256i offset = lasx_splat_u32(0xffff2000);
+  __m256i standardoffsetmax = lasx_splat_u32(0xfffff7ff);
+  __m256i standardmax = lasx_splat_u32(0x10ffff);
   __m256i currentmax = __lasx_xvldi(0x0);
   __m256i currentoffsetmax = __lasx_xvldi(0x0);
 
@@ -55,9 +54,9 @@ const result lasx_validate_utf32le_with_errors(const char32_t *input,
     input++;
   }
 
-  __m256i offset = __lasx_xvreplgr2vr_w(uint32_t(0xffff2000));
-  __m256i standardoffsetmax = __lasx_xvreplgr2vr_w(uint32_t(0xfffff7ff));
-  __m256i standardmax = __lasx_xvldi(-2288); /*0x10ffff*/
+  __m256i offset = lasx_splat_u32(0xffff2000);
+  __m256i standardoffsetmax = lasx_splat_u32(0xfffff7ff);
+  __m256i standardmax = lasx_splat_u32(0x10ffff);
   __m256i currentmax = __lasx_xvldi(0x0);
   __m256i currentoffsetmax = __lasx_xvldi(0x0);
 

--- a/src/lsx/implementation.cpp
+++ b/src/lsx/implementation.cpp
@@ -33,10 +33,7 @@ const uint8_t lsx_1_2_utf8_bytes_mask[] = {
 
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_UTF32
 simdutf_really_inline __m128i lsx_swap_bytes(__m128i vec) {
-  // const v16u8 shuf = {1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14};
-  // return __lsx_vshuf_b(__lsx_vldi(0), vec, shuf);
   return __lsx_vshuf4i_b(vec, 0b10110001);
-  // return __lsx_vor_v(__lsx_vslli_h(vec, 8), __lsx_vsrli_h(vec, 8));
 }
 #endif // SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_UTF32
 
@@ -108,7 +105,7 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
   __m128i ascii = __lsx_vand_v(perm, __lsx_vrepli_h(0x7f)); // 6 or 7 bits
   // 1 byte: 00000000 00000000
   // 2 byte: 00000aaa aa000000
-  const __m128i v1f00 = __lsx_vldi(-2785); // -2785(13bit) => 151f
+  const __m128i v1f00 = lsx_splat_u16(0x1f00);
   __m128i composed = __lsx_vsrli_h(__lsx_vand_v(perm, v1f00), 2); // 5 bits
   // Combine with a shift right accumulate
   // 1 byte: 00000000 0bbbbbbb
@@ -1158,9 +1155,10 @@ simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::utf8_length_from_utf32(
     const char32_t *input, size_t length) const noexcept {
-  const __m128i v_80 = __lsx_vrepli_w(0x80); /*0x00000080*/
-  const __m128i v_800 = __lsx_vldi(-3832);   /*0x00000800*/
-  const __m128i v_10000 = __lsx_vldi(-3583); /*0x00010000*/
+  const __m128i v_80 = lsx_splat_u32(0x00000080);
+  const __m128i v_800 = lsx_splat_u32(0x00000800);
+  const __m128i v_10000 = lsx_splat_u32(0x00010000);
+
   size_t pos = 0;
   size_t count = 0;
   for (; pos + 4 <= length; pos += 4) {
@@ -1190,7 +1188,7 @@ simdutf_warn_unused size_t implementation::utf8_length_from_utf32(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::utf16_length_from_utf32(
     const char32_t *input, size_t length) const noexcept {
-  const __m128i v_ffff = __lsx_vldi(-2304); /*0x0000ffff*/
+  const __m128i v_ffff = lsx_splat_u32(0x0000ffff);
   size_t pos = 0;
   size_t count = 0;
   for (; pos + 4 <= length; pos += 4) {

--- a/src/lsx/lsx_base64.cpp
+++ b/src/lsx/lsx_base64.cpp
@@ -367,9 +367,8 @@ static inline void load_block(block64 *b, const char16_t *src) {
 static inline void base64_decode(char *out, __m128i str) {
   __m128i t0 = __lsx_vor_v(
       __lsx_vslli_w(str, 26),
-      __lsx_vslli_w(__lsx_vand_v(str, __lsx_vldi(-1758 /*0x0000FF00*/)), 12));
-  __m128i t1 =
-      __lsx_vsrli_w(__lsx_vand_v(str, __lsx_vldi(-3521 /*0x003F0000*/)), 2);
+      __lsx_vslli_w(__lsx_vand_v(str, lsx_splat_u32(0x0000FF00)), 12));
+  __m128i t1 = __lsx_vsrli_w(__lsx_vand_v(str, lsx_splat_u32(0x003F0000)), 2);
   __m128i t2 = __lsx_vor_v(t0, t1);
   __m128i t3 = __lsx_vor_v(t2, __lsx_vsrli_w(str, 16));
   const v16u8 pack_shuffle = {3, 2,  1,  7,  6, 5, 11, 10,

--- a/src/lsx/lsx_convert_latin1_to_utf8.cpp
+++ b/src/lsx/lsx_convert_latin1_to_utf8.cpp
@@ -30,7 +30,7 @@ lsx_convert_latin1_to_utf8(const char *latin1_input, size_t len,
     // t0 = [0000|00aa|bbbb|bb00]
     __m128i t0 = __lsx_vslli_h(in16, 2);
     // t1 = [0000|00aa|0000|0000]
-    __m128i t1 = __lsx_vand_v(t0, __lsx_vldi(-2785));
+    __m128i t1 = __lsx_vand_v(t0, lsx_splat_u16(0x300));
     // t3 = [0000|00aa|00bb|bbbb]
     __m128i t2 = __lsx_vbitsel_v(t1, in16, __lsx_vrepli_h(0x3f));
     // t4 = [1100|00aa|10bb|bbbb]

--- a/src/lsx/lsx_convert_utf16_to_utf32.cpp
+++ b/src/lsx/lsx_convert_utf16_to_utf32.cpp
@@ -6,8 +6,8 @@ lsx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
   const char16_t *end = buf + len;
 
   __m128i zero = __lsx_vldi(0);
-  __m128i v_f800 = __lsx_vldi(-2568); /*0xF800*/
-  __m128i v_d800 = __lsx_vldi(-2600); /*0xD800*/
+  __m128i v_f800 = lsx_splat_u16(0xf800);
+  __m128i v_d800 = lsx_splat_u16(0xd800);
 
   while (end - buf >= 8) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
@@ -79,8 +79,8 @@ lsx_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
   const char16_t *end = buf + len;
 
   __m128i zero = __lsx_vldi(0);
-  __m128i v_f800 = __lsx_vldi(-2568); /*0xF800*/
-  __m128i v_d800 = __lsx_vldi(-2600); /*0xD800*/
+  __m128i v_f800 = lsx_splat_u16(0xf800);
+  __m128i v_d800 = lsx_splat_u16(0xd800);
 
   while (end - buf >= 8) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);

--- a/src/lsx/lsx_convert_utf16_to_utf8.cpp
+++ b/src/lsx/lsx_convert_utf16_to_utf8.cpp
@@ -105,7 +105,7 @@ lsx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
       // t0 = [000a|aaaa|bbbb|bb00]
       __m128i t0 = __lsx_vslli_h(in, 2);
       // t1 = [000a|aaaa|0000|0000]
-      __m128i t1 = __lsx_vand_v(t0, __lsx_vldi(-2785 /*0x1f00*/));
+      __m128i t1 = __lsx_vand_v(t0, lsx_splat_u16(0x1f00));
       // t2 = [0000|0000|00bb|bbbb]
       __m128i t2 = __lsx_vand_v(in, __lsx_vrepli_h(0x3f));
       // t3 = [000a|aaaa|00bb|bbbb]
@@ -131,9 +131,8 @@ lsx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
       utf8_output += row[0];
       continue;
     }
-    __m128i surrogates_bytemask =
-        __lsx_vseq_h(__lsx_vand_v(in, __lsx_vldi(-2568 /*0xF800*/)),
-                     __lsx_vldi(-2600 /*0xD800*/));
+    __m128i surrogates_bytemask = __lsx_vseq_h(
+        __lsx_vand_v(in, lsx_splat_u16(0xf800)), lsx_splat_u16(0xd800));
     // It might seem like checking for surrogates_bitmask == 0xc000 could help.
     // However, it is likely an uncommon occurrence.
     if (__lsx_bz_v(surrogates_bytemask)) {
@@ -173,14 +172,14 @@ lsx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
       __m128i v_3f7f = __lsx_vreplgr2vr_h(uint16_t(0x3F7F));
       __m128i t1 = __lsx_vand_v(t0, v_3f7f);
       // [00cc|cccc|0bcc|cccc] => [10cc|cccc|0bcc|cccc]
-      __m128i t2 = __lsx_vor_v(t1, __lsx_vldi(-2688 /*0x8000*/));
+      __m128i t2 = __lsx_vor_v(t1, lsx_splat_u16(0x8000));
 
       // s0: [aaaa|bbbb|bbcc|cccc] => [0000|0000|0000|aaaa]
       __m128i s0 = __lsx_vsrli_h(in, 12);
       // s1: [aaaa|bbbb|bbcc|cccc] => [0000|bbbb|bb00|0000]
       __m128i s1 = __lsx_vslli_h(in, 2);
       // s1: [aabb|bbbb|cccc|cc00] => [00bb|bbbb|0000|0000]
-      s1 = __lsx_vand_v(s1, __lsx_vldi(-2753 /*0x3F00*/));
+      s1 = __lsx_vand_v(s1, lsx_splat_u16(0x3f00));
 
       // [00bb|bbbb|0000|aaaa]
       __m128i s2 = __lsx_vor_v(s0, s1);
@@ -188,8 +187,8 @@ lsx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
       __m128i v_c0e0 = __lsx_vreplgr2vr_h(uint16_t(0xC0E0));
       __m128i s3 = __lsx_vor_v(s2, v_c0e0);
       __m128i one_or_two_bytes_bytemask = __lsx_vsle_hu(in, v_07ff);
-      __m128i m0 = __lsx_vandn_v(one_or_two_bytes_bytemask,
-                                 __lsx_vldi(-2752 /*0x4000*/));
+      __m128i m0 =
+          __lsx_vandn_v(one_or_two_bytes_bytemask, lsx_splat_u16(0x4000));
       __m128i s4 = __lsx_vxor_v(s3, m0);
 
       // 4. expand code units 16-bit => 32-bit
@@ -344,7 +343,7 @@ lsx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
       // t0 = [000a|aaaa|bbbb|bb00]
       __m128i t0 = __lsx_vslli_h(in, 2);
       // t1 = [000a|aaaa|0000|0000]
-      __m128i t1 = __lsx_vand_v(t0, __lsx_vldi(-2785 /*0x1f00*/));
+      __m128i t1 = __lsx_vand_v(t0, lsx_splat_u16(0x1f00));
       // t2 = [0000|0000|00bb|bbbb]
       __m128i t2 = __lsx_vand_v(in, __lsx_vrepli_h(0x3f));
       // t3 = [000a|aaaa|00bb|bbbb]
@@ -370,9 +369,8 @@ lsx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
       utf8_output += row[0];
       continue;
     }
-    __m128i surrogates_bytemask =
-        __lsx_vseq_h(__lsx_vand_v(in, __lsx_vldi(-2568 /*0xF800*/)),
-                     __lsx_vldi(-2600 /*0xD800*/));
+    __m128i surrogates_bytemask = __lsx_vseq_h(
+        __lsx_vand_v(in, lsx_splat_u16(0xf800)), lsx_splat_u16(0xd800));
     // It might seem like checking for surrogates_bitmask == 0xc000 could help.
     // However, it is likely an uncommon occurrence.
     if (__lsx_bz_v(surrogates_bytemask)) {
@@ -412,14 +410,14 @@ lsx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
       __m128i v_3f7f = __lsx_vreplgr2vr_h(uint16_t(0x3F7F));
       __m128i t1 = __lsx_vand_v(t0, v_3f7f);
       // [00cc|cccc|0bcc|cccc] => [10cc|cccc|0bcc|cccc]
-      __m128i t2 = __lsx_vor_v(t1, __lsx_vldi(-2688));
+      __m128i t2 = __lsx_vor_v(t1, lsx_splat_u16(0x8000));
 
       // s0: [aaaa|bbbb|bbcc|cccc] => [0000|0000|0000|aaaa]
       __m128i s0 = __lsx_vsrli_h(in, 12);
       // s1: [aaaa|bbbb|bbcc|cccc] => [0000|bbbb|bb00|0000]
       __m128i s1 = __lsx_vslli_h(in, 2);
       // s1: [aabb|bbbb|cccc|cc00] => [00bb|bbbb|0000|0000]
-      s1 = __lsx_vand_v(s1, __lsx_vldi(-2753 /*0x3F00*/));
+      s1 = __lsx_vand_v(s1, lsx_splat_u16(0x3f00));
 
       // [00bb|bbbb|0000|aaaa]
       __m128i s2 = __lsx_vor_v(s0, s1);
@@ -427,8 +425,8 @@ lsx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
       __m128i v_c0e0 = __lsx_vreplgr2vr_h(uint16_t(0xC0E0));
       __m128i s3 = __lsx_vor_v(s2, v_c0e0);
       __m128i one_or_two_bytes_bytemask = __lsx_vsle_hu(in, v_07ff);
-      __m128i m0 = __lsx_vandn_v(one_or_two_bytes_bytemask,
-                                 __lsx_vldi(-2752 /*0x4000*/));
+      __m128i m0 =
+          __lsx_vandn_v(one_or_two_bytes_bytemask, lsx_splat_u16(0x4000));
       __m128i s4 = __lsx_vxor_v(s3, m0);
 
       // 4. expand code units 16-bit => 32-bit

--- a/src/lsx/lsx_convert_utf32_to_utf16.cpp
+++ b/src/lsx/lsx_convert_utf32_to_utf16.cpp
@@ -6,8 +6,8 @@ lsx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
   const char32_t *end = buf + len;
 
   __m128i forbidden_bytemask = __lsx_vrepli_h(0);
-  __m128i v_d800 = __lsx_vldi(-2600); /*0xD800*/
-  __m128i v_dfff = __lsx_vreplgr2vr_h(uint16_t(0xdfff));
+  __m128i v_d800 = lsx_splat_u16(0xd800);
+  __m128i v_dfff = lsx_splat_u16(0xdfff);
   while (end - buf >= 8) {
     __m128i in0 = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m128i in1 = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 16);
@@ -82,8 +82,8 @@ lsx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
   const char32_t *end = buf + len;
 
   __m128i forbidden_bytemask = __lsx_vrepli_h(0);
-  __m128i v_d800 = __lsx_vldi(-2600); /*0xD800*/
-  __m128i v_dfff = __lsx_vreplgr2vr_h(uint16_t(0xdfff));
+  __m128i v_d800 = lsx_splat_u16(0xd800);
+  __m128i v_dfff = lsx_splat_u16(0xdfff);
 
   while (end - buf >= 8) {
     __m128i in0 = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 0);

--- a/src/lsx/lsx_validate_utf32le.cpp
+++ b/src/lsx/lsx_validate_utf32le.cpp
@@ -1,12 +1,11 @@
-
 const char32_t *lsx_validate_utf32le(const char32_t *input, size_t size) {
   const char32_t *end = input + size;
 
-  __m128i offset = __lsx_vreplgr2vr_w(uint32_t(0xffff2000));
-  __m128i standardoffsetmax = __lsx_vreplgr2vr_w(uint32_t(0xfffff7ff));
-  __m128i standardmax = __lsx_vldi(-2288); /*0x10ffff*/
-  __m128i currentmax = __lsx_vldi(0x0);
-  __m128i currentoffsetmax = __lsx_vldi(0x0);
+  __m128i offset = lsx_splat_u32(0xffff2000);
+  __m128i standardoffsetmax = lsx_splat_u32(0xfffff7ff);
+  __m128i standardmax = lsx_splat_u32(0x10ffff);
+  __m128i currentmax = lsx_splat_u32(0);
+  __m128i currentoffsetmax = lsx_splat_u32(0);
 
   while (input + 4 < end) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint32_t *>(input), 0);
@@ -38,11 +37,11 @@ const result lsx_validate_utf32le_with_errors(const char32_t *input,
   const char32_t *start = input;
   const char32_t *end = input + size;
 
-  __m128i offset = __lsx_vreplgr2vr_w(uint32_t(0xffff2000));
-  __m128i standardoffsetmax = __lsx_vreplgr2vr_w(uint32_t(0xfffff7ff));
-  __m128i standardmax = __lsx_vldi(-2288); /*0x10ffff*/
-  __m128i currentmax = __lsx_vldi(0x0);
-  __m128i currentoffsetmax = __lsx_vldi(0x0);
+  __m128i offset = lsx_splat_u32(0xffff2000);
+  __m128i standardoffsetmax = lsx_splat_u32(0xfffff7ff);
+  __m128i standardmax = lsx_splat_u32(0x10ffff);
+  __m128i currentmax = lsx_splat_u32(0);
+  __m128i currentoffsetmax = lsx_splat_u32(0);
 
   while (input + 4 < end) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint32_t *>(input), 0);

--- a/src/simdutf/lasx/intrinsics.h
+++ b/src/simdutf/lasx/intrinsics.h
@@ -98,4 +98,185 @@ static inline __m128i lasx_extracti128_hi(__m256i in) {
 }
 #endif
 
+/*
+Encoding of argument for LoongArch64 xvldi instruction.  See:
+https://jia.je/unofficial-loongarch-intrinsics-guide/lasx/misc/#__m256i-__lasx_xvldi-imm_n1024_1023-imm
+
+1: imm[12:8]=0b10000: broadcast imm[7:0] as 32-bit elements to all lanes
+
+2: imm[12:8]=0b10001: broadcast imm[7:0] << 8 as 32-bit elements to all lanes
+
+3: imm[12:8]=0b10010: broadcast imm[7:0] << 16 as 32-bit elements to all lanes
+
+4: imm[12:8]=0b10011: broadcast imm[7:0] << 24 as 32-bit elements to all lanes
+
+5: imm[12:8]=0b10100: broadcast imm[7:0] as 16-bit elements to all lanes
+
+6: imm[12:8]=0b10101: broadcast imm[7:0] << 8 as 16-bit elements to all lanes
+
+7: imm[12:8]=0b10110: broadcast (imm[7:0] << 8) | 0xFF as 32-bit elements to all
+lanes
+
+8: imm[12:8]=0b10111: broadcast (imm[7:0] << 16) | 0xFFFF as 32-bit elements to
+all lanes
+
+9: imm[12:8]=0b11000: broadcast imm[7:0] as 8-bit elements to all lanes
+
+10: imm[12:8]=0b11001: repeat each bit of imm[7:0] eight times, and broadcast
+the result as 64-bit elements to all lanes
+*/
+
+namespace lasx_vldi {
+
+template <uint16_t v> class const_u16 {
+  constexpr static const uint8_t b0 = ((v >> 0 * 8) & 0xff);
+  constexpr static const uint8_t b1 = ((v >> 1 * 8) & 0xff);
+
+  constexpr static bool is_case5 = uint16_t(b0) == v;
+  constexpr static bool is_case6 = (uint16_t(b1) << 8) == v;
+  constexpr static bool is_case9 = (b0 == b1);
+  constexpr static bool is_case10 =
+      ((b0 == 0xff) || (b0 == 0x00)) && ((b1 == 0xff) || (b1 == 0x00));
+
+public:
+  constexpr static uint16_t operation = is_case5    ? 0b10100
+                                        : is_case6  ? 0b10101
+                                        : is_case9  ? 0b11000
+                                        : is_case10 ? 0x11001
+                                                    : 0xffff;
+
+  constexpr static uint16_t byte =
+      is_case5    ? b0
+      : is_case6  ? b1
+      : is_case9  ? b0
+      : is_case10 ? ((b0 ? 0x55 : 0x00) | (b1 ? 0xaa : 0x00))
+                  : 0xffff;
+
+  constexpr static int value = int((operation << 8) | byte) - 8192;
+  constexpr static bool valid = operation != 0xffff;
+};
+
+template <uint32_t v> class const_u32 {
+  constexpr static const uint8_t b0 = (v & 0xff);
+  constexpr static const uint8_t b1 = ((v >> 8) & 0xff);
+  constexpr static const uint8_t b2 = ((v >> 16) & 0xff);
+  constexpr static const uint8_t b3 = ((v >> 24) & 0xff);
+
+  constexpr static bool is_case1 = (uint32_t(b0) == v);
+  constexpr static bool is_case2 = ((uint32_t(b1) << 8) == v);
+  constexpr static bool is_case3 = ((uint32_t(b2) << 16) == v);
+  constexpr static bool is_case4 = ((uint32_t(b3) << 24) == v);
+  constexpr static bool is_case5 = (b0 == b2) && (b1 == 0) && (b3 == 0);
+  constexpr static bool is_case6 = (b1 == b3) && (b0 == 0) && (b2 == 0);
+  constexpr static bool is_case7 = (b3 == 0) && (b2 == 0) && (b0 == 0xff);
+  constexpr static bool is_case8 = (b3 == 0) && (b1 == 0xff) && (b0 == 0xff);
+  constexpr static bool is_case9 = (b0 == b1) && (b0 == b2) && (b0 == b3);
+  constexpr static bool is_case10 =
+      ((b0 == 0xff) || (b0 == 0x00)) && ((b1 == 0xff) || (b1 == 0x00)) &&
+      ((b2 == 0xff) || (b2 == 0x00)) && ((b3 == 0xff) || (b3 == 0x00));
+
+public:
+  constexpr static uint16_t operation = is_case1    ? 0b10000
+                                        : is_case2  ? 0b10001
+                                        : is_case3  ? 0b10010
+                                        : is_case4  ? 0b10011
+                                        : is_case5  ? 0b10100
+                                        : is_case6  ? 0b10101
+                                        : is_case7  ? 0b10110
+                                        : is_case8  ? 0b10111
+                                        : is_case9  ? 0b11000
+                                        : is_case10 ? 0b11001
+                                                    : 0xffff;
+
+  constexpr static uint16_t byte =
+      is_case1    ? b0
+      : is_case2  ? b1
+      : is_case3  ? b2
+      : is_case4  ? b3
+      : is_case5  ? b0
+      : is_case6  ? b1
+      : is_case7  ? b1
+      : is_case8  ? b2
+      : is_case9  ? b0
+      : is_case10 ? ((b0 ? 0x11 : 0x00) | (b1 ? 0x22 : 0x00) |
+                     (b2 ? 0x44 : 0x00) | (b3 ? 0x88 : 0x00))
+                  : 0xffff;
+
+  constexpr static int value = int((operation << 8) | byte) - 8192;
+  constexpr static bool valid = operation != 0xffff;
+};
+
+template <uint64_t v> class const_u64 {
+  constexpr static const uint8_t b0 = ((v >> 0 * 8) & 0xff);
+  constexpr static const uint8_t b1 = ((v >> 1 * 8) & 0xff);
+  constexpr static const uint8_t b2 = ((v >> 2 * 8) & 0xff);
+  constexpr static const uint8_t b3 = ((v >> 3 * 8) & 0xff);
+  constexpr static const uint8_t b4 = ((v >> 4 * 8) & 0xff);
+  constexpr static const uint8_t b5 = ((v >> 5 * 8) & 0xff);
+  constexpr static const uint8_t b6 = ((v >> 6 * 8) & 0xff);
+  constexpr static const uint8_t b7 = ((v >> 7 * 8) & 0xff);
+
+  constexpr static bool is_case10 =
+      ((b0 == 0xff) || (b0 == 0x00)) && ((b1 == 0xff) || (b1 == 0x00)) &&
+      ((b2 == 0xff) || (b2 == 0x00)) && ((b3 == 0xff) || (b3 == 0x00)) &&
+      ((b4 == 0xff) || (b4 == 0x00)) && ((b5 == 0xff) || (b5 == 0x00)) &&
+      ((b6 == 0xff) || (b6 == 0x00)) && ((b7 == 0xff) || (b7 == 0x00));
+
+public:
+  constexpr static bool is_32bit =
+      ((v & 0xffffffff) == (v >> 32)) && const_u32<(v >> 32)>::value;
+  constexpr static uint8_t op_32bit = const_u32<(v >> 32)>::operation;
+  constexpr static uint8_t byte_32bit = const_u32<(v >> 32)>::byte;
+
+  constexpr static uint16_t operation = is_32bit    ? op_32bit
+                                        : is_case10 ? 0x11001
+                                                    : 0xffff;
+
+  constexpr static uint16_t byte =
+      is_32bit ? byte_32bit
+      : is_case10
+          ? ((b0 ? 0x01 : 0x00) | (b1 ? 0x02 : 0x00) | (b2 ? 0x04 : 0x00) |
+             (b3 ? 0x08 : 0x00) | (b4 ? 0x10 : 0x00) | (b5 ? 0x20 : 0x00) |
+             (b6 ? 0x40 : 0x00) | (b7 ? 0x80 : 0x00))
+          : 0xffff;
+
+  constexpr static int value = int((operation << 8) | byte) - 8192;
+  constexpr static bool valid = operation != 0xffff;
+};
+
+} // namespace lasx_vldi
+
+// Uncomment when running under QEMU affected
+// by bug https://gitlab.com/qemu-project/qemu/-/issues/2865
+// Versions <= 9.2.2 are affected, likely anything newer is correct.
+#ifndef QEMU_VLDI_BUG
+// #define QEMU_VLDI_BUG 1
+#endif
+
+#ifdef QEMU_VLDI_BUG
+  #define lasx_splat_u16(v) __lasx_xvreplgr2vr_h(v)
+  #define lasx_splat_u32(v) __lasx_xvreplgr2vr_w(v)
+#else
+template <uint16_t x> constexpr __m256i lasx_splat_u16_aux() {
+  constexpr bool is_imm10 = (int16_t(x) < 512) && (int16_t(x) > -512);
+  constexpr bool is_vldi = lasx_vldi::const_u16<x>::valid;
+
+  return is_imm10  ? __lasx_xvrepli_h(int16_t(x))
+         : is_vldi ? __lasx_xvldi(lasx_vldi::const_u16<x>::value)
+                   : __lasx_xvreplgr2vr_h(x);
+}
+
+template <uint32_t x> constexpr __m256i lasx_splat_u32_aux() {
+  constexpr bool is_imm10 = (int32_t(x) < 512) && (int32_t(x) > -512);
+  constexpr bool is_vldi = lasx_vldi::const_u32<x>::valid;
+
+  return is_imm10  ? __lasx_xvrepli_w(int32_t(x))
+         : is_vldi ? __lasx_xvldi(lasx_vldi::const_u32<x>::value)
+                   : __lasx_xvreplgr2vr_w(x);
+}
+
+  #define lasx_splat_u16(v) lasx_splat_u16_aux<(v)>()
+  #define lasx_splat_u32(v) lasx_splat_u32_aux<(v)>()
+#endif // QEMU_VLDI_BUG
+
 #endif //  SIMDUTF_LASX_INTRINSICS_H

--- a/src/simdutf/lsx/intrinsics.h
+++ b/src/simdutf/lsx/intrinsics.h
@@ -158,7 +158,7 @@ public:
 // by bug https://gitlab.com/qemu-project/qemu/-/issues/2865
 // Versions <= 9.2.2 are affected, likely anything newer is correct.
 #ifndef QEMU_VLDI_BUG
- #define QEMU_VLDI_BUG 1
+// #define QEMU_VLDI_BUG 1
 #endif
 
 #ifdef QEMU_VLDI_BUG

--- a/src/simdutf/lsx/intrinsics.h
+++ b/src/simdutf/lsx/intrinsics.h
@@ -7,4 +7,184 @@
 // you use visual studio or other compilers.
 #include <lsxintrin.h>
 
+/*
+Encoding of argument for LoongArch64 xvldi instruction.  See:
+https://jia.je/unofficial-loongarch-intrinsics-guide/lasx/misc/#__m256i-__lasx_xvldi-imm_n1024_1023-imm
+
+1: imm[12:8]=0b10000: broadcast imm[7:0] as 32-bit elements to all lanes
+
+2: imm[12:8]=0b10001: broadcast imm[7:0] << 8 as 32-bit elements to all lanes
+
+3: imm[12:8]=0b10010: broadcast imm[7:0] << 16 as 32-bit elements to all lanes
+
+4: imm[12:8]=0b10011: broadcast imm[7:0] << 24 as 32-bit elements to all lanes
+
+5: imm[12:8]=0b10100: broadcast imm[7:0] as 16-bit elements to all lanes
+
+6: imm[12:8]=0b10101: broadcast imm[7:0] << 8 as 16-bit elements to all lanes
+
+7: imm[12:8]=0b10110: broadcast (imm[7:0] << 8) | 0xFF as 32-bit elements to all
+lanes
+
+8: imm[12:8]=0b10111: broadcast (imm[7:0] << 16) | 0xFFFF as 32-bit elements to
+all lanes
+
+9: imm[12:8]=0b11000: broadcast imm[7:0] as 8-bit elements to all lanes
+
+10: imm[12:8]=0b11001: repeat each bit of imm[7:0] eight times, and broadcast
+the result as 64-bit elements to all lanes
+*/
+
+namespace vldi {
+
+template <uint16_t v> class const_u16 {
+  constexpr static const uint8_t b0 = ((v >> 0 * 8) & 0xff);
+  constexpr static const uint8_t b1 = ((v >> 1 * 8) & 0xff);
+
+  constexpr static bool is_case5 = uint16_t(b0) == v;
+  constexpr static bool is_case6 = (uint16_t(b1) << 8) == v;
+  constexpr static bool is_case9 = (b0 == b1);
+  constexpr static bool is_case10 =
+      ((b0 == 0xff) || (b0 == 0x00)) && ((b1 == 0xff) || (b1 == 0x00));
+
+public:
+  constexpr static uint16_t operation = is_case5    ? 0b10100
+                                        : is_case6  ? 0b10101
+                                        : is_case9  ? 0b11000
+                                        : is_case10 ? 0x11001
+                                                    : 0xffff;
+
+  constexpr static uint16_t byte =
+      is_case5    ? b0
+      : is_case6  ? b1
+      : is_case9  ? b0
+      : is_case10 ? ((b0 ? 0x55 : 0x00) | (b1 ? 0xaa : 0x00))
+                  : 0xffff;
+
+  constexpr static int value = int((operation << 8) | byte) - 8192;
+  constexpr static bool valid = operation != 0xffff;
+};
+
+template <uint32_t v> class const_u32 {
+  constexpr static const uint8_t b0 = (v & 0xff);
+  constexpr static const uint8_t b1 = ((v >> 8) & 0xff);
+  constexpr static const uint8_t b2 = ((v >> 16) & 0xff);
+  constexpr static const uint8_t b3 = ((v >> 24) & 0xff);
+
+  constexpr static bool is_case1 = (uint32_t(b0) == v);
+  constexpr static bool is_case2 = ((uint32_t(b1) << 8) == v);
+  constexpr static bool is_case3 = ((uint32_t(b2) << 16) == v);
+  constexpr static bool is_case4 = ((uint32_t(b3) << 24) == v);
+  constexpr static bool is_case5 = (b0 == b2) && (b1 == 0) && (b3 == 0);
+  constexpr static bool is_case6 = (b1 == b3) && (b0 == 0) && (b2 == 0);
+  constexpr static bool is_case7 = (b3 == 0) && (b2 == 0) && (b0 == 0xff);
+  constexpr static bool is_case8 = (b3 == 0) && (b1 == 0xff) && (b0 == 0xff);
+  constexpr static bool is_case9 = (b0 == b1) && (b0 == b2) && (b0 == b3);
+  constexpr static bool is_case10 =
+      ((b0 == 0xff) || (b0 == 0x00)) && ((b1 == 0xff) || (b1 == 0x00)) &&
+      ((b2 == 0xff) || (b2 == 0x00)) && ((b3 == 0xff) || (b3 == 0x00));
+
+public:
+  constexpr static uint16_t operation = is_case1    ? 0b10000
+                                        : is_case2  ? 0b10001
+                                        : is_case3  ? 0b10010
+                                        : is_case4  ? 0b10011
+                                        : is_case5  ? 0b10100
+                                        : is_case6  ? 0b10101
+                                        : is_case7  ? 0b10110
+                                        : is_case8  ? 0b10111
+                                        : is_case9  ? 0b11000
+                                        : is_case10 ? 0b11001
+                                                    : 0xffff;
+
+  constexpr static uint16_t byte =
+      is_case1    ? b0
+      : is_case2  ? b1
+      : is_case3  ? b2
+      : is_case4  ? b3
+      : is_case5  ? b0
+      : is_case6  ? b1
+      : is_case7  ? b1
+      : is_case8  ? b2
+      : is_case9  ? b0
+      : is_case10 ? ((b0 ? 0x11 : 0x00) | (b1 ? 0x22 : 0x00) |
+                     (b2 ? 0x44 : 0x00) | (b3 ? 0x88 : 0x00))
+                  : 0xffff;
+
+  constexpr static int value = int((operation << 8) | byte) - 8192;
+  constexpr static bool valid = operation != 0xffff;
+};
+
+template <uint64_t v> class const_u64 {
+  constexpr static const uint8_t b0 = ((v >> 0 * 8) & 0xff);
+  constexpr static const uint8_t b1 = ((v >> 1 * 8) & 0xff);
+  constexpr static const uint8_t b2 = ((v >> 2 * 8) & 0xff);
+  constexpr static const uint8_t b3 = ((v >> 3 * 8) & 0xff);
+  constexpr static const uint8_t b4 = ((v >> 4 * 8) & 0xff);
+  constexpr static const uint8_t b5 = ((v >> 5 * 8) & 0xff);
+  constexpr static const uint8_t b6 = ((v >> 6 * 8) & 0xff);
+  constexpr static const uint8_t b7 = ((v >> 7 * 8) & 0xff);
+
+  constexpr static bool is_case10 =
+      ((b0 == 0xff) || (b0 == 0x00)) && ((b1 == 0xff) || (b1 == 0x00)) &&
+      ((b2 == 0xff) || (b2 == 0x00)) && ((b3 == 0xff) || (b3 == 0x00)) &&
+      ((b4 == 0xff) || (b4 == 0x00)) && ((b5 == 0xff) || (b5 == 0x00)) &&
+      ((b6 == 0xff) || (b6 == 0x00)) && ((b7 == 0xff) || (b7 == 0x00));
+
+public:
+  constexpr static bool is_32bit =
+      ((v & 0xffffffff) == (v >> 32)) && const_u32<(v >> 32)>::value;
+  constexpr static uint8_t op_32bit = const_u32<(v >> 32)>::operation;
+  constexpr static uint8_t byte_32bit = const_u32<(v >> 32)>::byte;
+
+  constexpr static uint16_t operation = is_32bit    ? op_32bit
+                                        : is_case10 ? 0x11001
+                                                    : 0xffff;
+
+  constexpr static uint16_t byte =
+      is_32bit ? byte_32bit
+      : is_case10
+          ? ((b0 ? 0x01 : 0x00) | (b1 ? 0x02 : 0x00) | (b2 ? 0x04 : 0x00) |
+             (b3 ? 0x08 : 0x00) | (b4 ? 0x10 : 0x00) | (b5 ? 0x20 : 0x00) |
+             (b6 ? 0x40 : 0x00) | (b7 ? 0x80 : 0x00))
+          : 0xffff;
+
+  constexpr static int value = int((operation << 8) | byte) - 8192;
+  constexpr static bool valid = operation != 0xffff;
+};
+} // namespace vldi
+
+// Uncomment when running under QEMU affected
+// by bug https://gitlab.com/qemu-project/qemu/-/issues/2865
+// Versions <= 9.2.2 are affected, likely anything newer is correct.
+#ifndef QEMU_VLDI_BUG
+ #define QEMU_VLDI_BUG 1
+#endif
+
+#ifdef QEMU_VLDI_BUG
+  #define lsx_splat_u16(v) __lsx_vreplgr2vr_h(v)
+  #define lsx_splat_u32(v) __lsx_vreplgr2vr_w(v)
+#else
+template <uint16_t x> constexpr __m128i lsx_splat_u16_aux() {
+  constexpr bool is_imm10 = (int16_t(x) < 512) && (int16_t(x) > -512);
+  constexpr bool is_vldi = vldi::const_u16<x>::valid;
+
+  return is_imm10  ? __lsx_vrepli_h(int16_t(x))
+         : is_vldi ? __lsx_vldi(vldi::const_u16<x>::value)
+                   : __lsx_vreplgr2vr_h(x);
+}
+
+template <uint32_t x> constexpr __m128i lsx_splat_u32_aux() {
+  constexpr bool is_imm10 = (int32_t(x) < 512) && (int32_t(x) > -512);
+  constexpr bool is_vldi = vldi::const_u32<x>::valid;
+
+  return is_imm10  ? __lsx_vrepli_w(int32_t(x))
+         : is_vldi ? __lsx_vldi(vldi::const_u32<x>::value)
+                   : __lsx_vreplgr2vr_w(x);
+}
+
+  #define lsx_splat_u16(v) lsx_splat_u16_aux<(v)>()
+  #define lsx_splat_u32(v) lsx_splat_u32_aux<(v)>()
+#endif // QEMU_VLDI_BUG
+
 #endif //  SIMDUTF_LSX_INTRINSICS_H


### PR DESCRIPTION
The intrinsics for LSX and LASX do not provide opaque broadcast/splat functions, similar to _mm_set1_epiXX known from SSE. It's a programmer responsible to pick a correct instruction. Also, a powerful `vldi` instruction comes with no support for building "magic" constants.

This set of templates should help in everyday vectorization, and for sure make code more readable.