### PR TITLE
a bit faster generic validate UTF32 with errors

### DIFF
--- a/src/generic/validate_utf32.h
+++ b/src/generic/validate_utf32.h
@@ -59,9 +59,9 @@ simdutf_really_inline result validate_with_errors(const char32_t *input,
 
   using vector_u32 = simd32<uint32_t>;
 
-  const auto standardmax = vector_u32::splat(0x10ffff);
-  const auto offset = vector_u32::splat(0xffff2000);
-  const auto standardoffsetmax = vector_u32::splat(0xfffff7ff);
+  const auto standardmax = vector_u32::splat(0x10ffff + 1);
+  const auto surrogate_mask = vector_u32::splat(0xfffff800);
+  const auto surrogate_byte = vector_u32::splat(0x0000d800);
 
   constexpr size_t N = vector_u32::ELEMENTS;
 
@@ -71,8 +71,8 @@ simdutf_really_inline result validate_with_errors(const char32_t *input,
       in.swap_bytes();
     }
 
-    const auto too_large = in > standardmax;
-    const auto surrogate = (in + offset) > standardoffsetmax;
+    const auto too_large = in >= standardmax;
+    const auto surrogate = (in & surrogate_mask) == surrogate_byte;
 
     const auto combined = too_large | surrogate;
     if (simdutf_unlikely(combined.any())) {

--- a/src/simdutf/haswell/simd32-inl.h
+++ b/src/simdutf/haswell/simd32-inl.h
@@ -91,6 +91,11 @@ simdutf_really_inline simd32<uint32_t> operator+(const simd32<uint32_t> a,
   return _mm256_add_epi32(a.value, b.value);
 }
 
+simdutf_really_inline simd32<bool> operator==(const simd32<uint32_t> a,
+                                              const simd32<uint32_t> b) {
+  return _mm256_cmpeq_epi32(a.value, b.value);
+}
+
 simdutf_really_inline simd32<bool> operator>=(const simd32<uint32_t> a,
                                               const simd32<uint32_t> b) {
   return _mm256_cmpeq_epi32(_mm256_max_epu32(a.value, b.value), a.value);

--- a/src/simdutf/ppc64/simd32-inl.h
+++ b/src/simdutf/ppc64/simd32-inl.h
@@ -209,6 +209,11 @@ simd32<bool> operator>(const simd32<T> a, const simd32<T> b) {
 }
 
 template <typename T>
+simd32<bool> operator>=(const simd32<T> a, const simd32<T> b) {
+  return vec_cmpge(a.value, b.value);
+}
+
+template <typename T>
 simd32<T> operator&(const simd32<T> a, const simd32<T> b) {
   return vec_and(a.value, b.value);
 }

--- a/src/simdutf/westmere/simd32-inl.h
+++ b/src/simdutf/westmere/simd32-inl.h
@@ -124,6 +124,11 @@ simdutf_really_inline simd32<uint32_t> operator-(const simd32<uint32_t> a,
   return _mm_sub_epi32(a.value, _mm_set1_epi32(b));
 }
 
+simdutf_really_inline simd32<bool> operator==(const simd32<uint32_t> a,
+                                              const simd32<uint32_t> b) {
+  return _mm_cmpeq_epi32(a.value, b.value);
+}
+
 simdutf_really_inline simd32<bool> operator>=(const simd32<uint32_t> a,
                                               const simd32<uint32_t> b) {
   return _mm_cmpeq_epi32(_mm_max_epu32(a.value, b.value), a.value);


### PR DESCRIPTION
Make the implementation of validator more friendly for SSE (do not use `greater than`, as SSE does not support it for unsigned numbers) and also simplify conditions to test surrogates.

Improvements are not too big, but some number of CPU cycles got shaved.

Benchmark for `./benchmark -P validate_utf32_with_errors -F ~/unicode_lipsum/wikipedia_mars/*.utf32.txt -I 1000`

### Ryzen 7

|               dataset               | size [B] | iterations | old GB/s | new GB/s | speedup |
| ----------------------------------- | -------- | ---------- | -------- | -------- | ------- |
| validate_utf32_with_errors+fallback                                                         |
| arabic.utf32                        |  1699376 |       1000 |    12.10 |    12.10 | 1.00x   |
| chinese.utf32                       |   548832 |       1000 |    12.10 |    12.09 | 1.00x   |
| czech.utf32                         |   575328 |       1000 |    12.10 |    12.10 | 1.00x   |
| english.utf32                       |  1550036 |       1000 |    12.10 |    12.10 | 1.00x   |
| esperanto.utf32                     |   336500 |       1000 |    12.11 |    12.10 | 1.00x   |
| french.utf32                        |  1739468 |       1000 |    12.10 |    12.10 | 1.00x   |
| german.utf32                        |   804860 |       1000 |    12.10 |    12.10 | 1.00x   |
| greek.utf32                         |   571996 |       1000 |    12.10 |    12.10 | 1.00x   |
| hebrew.utf32                        |   585404 |       1000 |    12.10 |    12.10 | 1.00x   |
| hindi.utf32                         |  1095832 |       1000 |    12.10 |    12.10 | 1.00x   |
| japanese.utf32                      |   475564 |       1000 |    12.10 |    12.09 | 1.00x   |
| korean.utf32                        |   291672 |       1000 |    12.10 |    12.10 | 1.00x   |
| persan.utf32                        |   498776 |       1000 |    12.10 |    12.10 | 1.00x   |
| portuguese.utf32                    |  1094456 |       1000 |    12.10 |    12.10 | 1.00x   |
| russian.utf32                       |  1248148 |       1000 |    12.10 |    12.10 | 1.00x   |
| thai.utf32                          |  1619032 |       1000 |    12.10 |    12.10 | 1.00x   |
| turkish.utf32                       |   741768 |       1000 |    12.10 |    12.10 | 1.00x   |
| vietnamese.utf32                    |  1129676 |       1000 |    12.10 |    12.10 | 1.00x   |
| validate_utf32_with_errors+haswell                                                          |
| arabic.utf32                        |  1699376 |       1000 |    65.80 |    71.97 | 1.09x   |
| chinese.utf32                       |   548832 |       1000 |    64.94 |    71.61 | 1.10x   |
| czech.utf32                         |   575328 |       1000 |    65.89 |    71.70 | 1.09x   |
| english.utf32                       |  1550036 |       1000 |    65.78 |    72.00 | 1.09x   |
| esperanto.utf32                     |   336500 |       1000 |    66.67 |    72.09 | 1.08x   |
| french.utf32                        |  1739468 |       1000 |    65.90 |    72.02 | 1.09x   |
| german.utf32                        |   804860 |       1000 |    63.84 |    71.80 | 1.12x   |
| greek.utf32                         |   571996 |       1000 |    66.03 |    71.81 | 1.09x   |
| hebrew.utf32                        |   585404 |       1000 |    65.83 |    67.47 | 1.02x   |
| hindi.utf32                         |  1095832 |       1000 |    65.33 |    71.87 | 1.10x   |
| japanese.utf32                      |   475564 |       1000 |    65.96 |    71.28 | 1.08x   |
| korean.utf32                        |   291672 |       1000 |    66.35 |    72.07 | 1.09x   |
| persan.utf32                        |   498776 |       1000 |    65.98 |    70.62 | 1.07x   |
| portuguese.utf32                    |  1094456 |       1000 |    65.48 |    68.36 | 1.04x   |
| russian.utf32                       |  1248148 |       1000 |    65.53 |    71.89 | 1.10x   |
| thai.utf32                          |  1619032 |       1000 |    65.83 |    71.92 | 1.09x   |
| turkish.utf32                       |   741768 |       1000 |    65.61 |    71.81 | 1.09x   |
| vietnamese.utf32                    |  1129676 |       1000 |    65.40 |    70.79 | 1.08x   |
| validate_utf32_with_errors+westmere                                                         |
| arabic.utf32                        |  1699376 |       1000 |    31.02 |    33.36 | 1.08x   |
| chinese.utf32                       |   548832 |       1000 |    31.02 |    33.34 | 1.07x   |
| czech.utf32                         |   575328 |       1000 |    31.06 |    33.33 | 1.07x   |
| english.utf32                       |  1550036 |       1000 |    31.01 |    33.34 | 1.08x   |
| esperanto.utf32                     |   336500 |       1000 |    31.06 |    33.42 | 1.08x   |
| french.utf32                        |  1739468 |       1000 |    31.03 |    33.37 | 1.08x   |
| german.utf32                        |   804860 |       1000 |    31.07 |    33.35 | 1.07x   |
| greek.utf32                         |   571996 |       1000 |    31.06 |    33.35 | 1.07x   |
| hebrew.utf32                        |   585404 |       1000 |    31.06 |    33.35 | 1.07x   |
| hindi.utf32                         |  1095832 |       1000 |    31.03 |    33.36 | 1.08x   |
| japanese.utf32                      |   475564 |       1000 |    31.04 |    33.41 | 1.08x   |
| korean.utf32                        |   291672 |       1000 |    31.09 |    33.43 | 1.08x   |
| persan.utf32                        |   498776 |       1000 |    31.05 |    33.41 | 1.08x   |
| portuguese.utf32                    |  1094456 |       1000 |    31.05 |    33.37 | 1.07x   |
| russian.utf32                       |  1248148 |       1000 |    31.04 |    33.36 | 1.07x   |
| thai.utf32                          |  1619032 |       1000 |    31.02 |    33.36 | 1.08x   |
| turkish.utf32                       |   741768 |       1000 |    31.07 |    33.38 | 1.07x   |
| vietnamese.utf32                    |  1129676 |       1000 |    31.03 |    33.37 | 1.08x   |

### Skylake

|               dataset               | size [B] | iterations | old GB/s | new GB/s | speedup |
| ----------------------------------- | -------- | ---------- | -------- | -------- | ------- |
| validate_utf32_with_errors+fallback                                                         |
| arabic.utf32                        |  1699376 |       1000 |     6.35 |     6.36 | 1.00x   |
| chinese.utf32                       |   548832 |       1000 |     6.34 |     6.34 | 1.00x   |
| czech.utf32                         |   575328 |       1000 |     6.34 |     6.34 | 1.00x   |
| english.utf32                       |  1550036 |       1000 |     6.35 |     6.35 | 1.00x   |
| esperanto.utf32                     |   336500 |       1000 |     6.32 |     6.32 | 1.00x   |
| french.utf32                        |  1739468 |       1000 |     6.35 |     6.36 | 1.00x   |
| german.utf32                        |   804860 |       1000 |     6.35 |     6.35 | 1.00x   |
| greek.utf32                         |   571996 |       1000 |     6.34 |     6.34 | 1.00x   |
| hebrew.utf32                        |   585404 |       1000 |     6.34 |     6.34 | 1.00x   |
| hindi.utf32                         |  1095832 |       1000 |     6.34 |     6.35 | 1.00x   |
| japanese.utf32                      |   475564 |       1000 |     6.33 |     6.33 | 1.00x   |
| korean.utf32                        |   291672 |       1000 |     6.30 |     6.30 | 1.00x   |
| persan.utf32                        |   498776 |       1000 |     6.34 |     6.34 | 1.00x   |
| portuguese.utf32                    |  1094456 |       1000 |     6.35 |     6.35 | 1.00x   |
| russian.utf32                       |  1248148 |       1000 |     6.35 |     6.35 | 1.00x   |
| thai.utf32                          |  1619032 |       1000 |     6.36 |     6.36 | 1.00x   |
| turkish.utf32                       |   741768 |       1000 |     6.35 |     6.35 | 1.00x   |
| vietnamese.utf32                    |  1129676 |       1000 |     6.35 |     6.35 | 1.00x   |
| validate_utf32_with_errors+haswell                                                          |
| arabic.utf32                        |  1699376 |       1000 |    16.39 |    17.32 | 1.06x   |
| chinese.utf32                       |   548832 |       1000 |    20.48 |    20.86 | 1.02x   |
| czech.utf32                         |   575328 |       1000 |    20.47 |    20.78 | 1.02x   |
| english.utf32                       |  1550036 |       1000 |    16.74 |    17.66 | 1.05x   |
| esperanto.utf32                     |   336500 |       1000 |    20.26 |    20.54 | 1.01x   |
| french.utf32                        |  1739468 |       1000 |    16.98 |    17.47 | 1.03x   |
| german.utf32                        |   804860 |       1000 |    20.00 |    20.42 | 1.02x   |
| greek.utf32                         |   571996 |       1000 |    20.41 |    20.86 | 1.02x   |
| hebrew.utf32                        |   585404 |       1000 |    20.44 |    20.74 | 1.01x   |
| hindi.utf32                         |  1095832 |       1000 |    18.49 |    18.87 | 1.02x   |
| japanese.utf32                      |   475564 |       1000 |    20.43 |    20.81 | 1.02x   |
| korean.utf32                        |   291672 |       1000 |    20.16 |    20.48 | 1.02x   |
| persan.utf32                        |   498776 |       1000 |    20.45 |    20.81 | 1.02x   |
| portuguese.utf32                    |  1094456 |       1000 |    18.32 |    19.21 | 1.05x   |
| russian.utf32                       |  1248148 |       1000 |    18.01 |    18.50 | 1.03x   |
| thai.utf32                          |  1619032 |       1000 |    17.16 |    17.89 | 1.04x   |
| turkish.utf32                       |   741768 |       1000 |    19.97 |    20.46 | 1.02x   |
| vietnamese.utf32                    |  1129676 |       1000 |    18.29 |    18.69 | 1.02x   |
| validate_utf32_with_errors+westmere                                                         |
| arabic.utf32                        |  1699376 |       1000 |    12.49 |    12.54 | 1.00x   |
| chinese.utf32                       |   548832 |       1000 |    12.60 |    12.60 | 1.00x   |
| czech.utf32                         |   575328 |       1000 |    12.60 |    12.60 | 1.00x   |
| english.utf32                       |  1550036 |       1000 |    12.45 |    12.51 | 1.00x   |
| esperanto.utf32                     |   336500 |       1000 |    12.50 |    12.49 | 1.00x   |
| french.utf32                        |  1739468 |       1000 |    12.55 |    12.60 | 1.00x   |
| german.utf32                        |   804860 |       1000 |    12.56 |    12.56 | 1.00x   |
| greek.utf32                         |   571996 |       1000 |    12.60 |    12.60 | 1.00x   |
| hebrew.utf32                        |   585404 |       1000 |    12.60 |    12.60 | 1.00x   |
| hindi.utf32                         |  1095832 |       1000 |    12.44 |    12.53 | 1.01x   |
| japanese.utf32                      |   475564 |       1000 |    12.57 |    12.57 | 1.00x   |
| korean.utf32                        |   291672 |       1000 |    12.45 |    12.45 | 1.00x   |
| persan.utf32                        |   498776 |       1000 |    12.58 |    12.58 | 1.00x   |
| portuguese.utf32                    |  1094456 |       1000 |    12.48 |    12.56 | 1.01x   |
| russian.utf32                       |  1248148 |       1000 |    12.55 |    12.58 | 1.00x   |
| thai.utf32                          |  1619032 |       1000 |    12.62 |    12.66 | 1.00x   |
| turkish.utf32                       |   741768 |       1000 |    12.57 |    12.59 | 1.00x   |
| vietnamese.utf32                    |  1129676 |       1000 |    12.53 |    12.60 | 1.01x   |

### IceLake

|               dataset               | size [B] | iterations | old GB/s | new GB/s | speedup |
| ----------------------------------- | -------- | ---------- | -------- | -------- | ------- |
| validate_utf32_with_errors+haswell                                                          |
| arabic.utf32                        |  1699376 |       1000 |    14.35 |    13.35 | 0.93x   |
| chinese.utf32                       |   548832 |       1000 |    25.98 |    25.48 | 0.98x   |
| czech.utf32                         |   575328 |       1000 |    25.98 |    25.55 | 0.98x   |
| english.utf32                       |  1550036 |       1000 |    23.47 |    23.17 | 0.99x   |
| esperanto.utf32                     |   336500 |       1000 |    26.03 |    25.55 | 0.98x   |
| french.utf32                        |  1739468 |       1000 |    23.41 |    23.26 | 0.99x   |
| german.utf32                        |   804860 |       1000 |    25.98 |    25.48 | 0.98x   |
| greek.utf32                         |   571996 |       1000 |    25.97 |    25.55 | 0.98x   |
| hebrew.utf32                        |   585404 |       1000 |    25.98 |    25.49 | 0.98x   |
| hindi.utf32                         |  1095832 |       1000 |    25.29 |    25.41 | 1.00x   |
| japanese.utf32                      |   475564 |       1000 |    25.99 |    25.46 | 0.98x   |
| korean.utf32                        |   291672 |       1000 |    26.02 |    25.49 | 0.98x   |
| persan.utf32                        |   498776 |       1000 |    26.01 |    25.49 | 0.98x   |
| portuguese.utf32                    |  1094456 |       1000 |    25.24 |    25.38 | 1.01x   |
| russian.utf32                       |  1248148 |       1000 |    24.45 |    24.61 | 1.01x   |
| thai.utf32                          |  1619032 |       1000 |    23.24 |    23.51 | 1.01x   |
| turkish.utf32                       |   741768 |       1000 |    25.98 |    25.46 | 0.98x   |
| vietnamese.utf32                    |  1129676 |       1000 |    24.98 |    25.17 | 1.01x   |
| validate_utf32_with_errors+icelake                                                          |
| arabic.utf32                        |  1699376 |       1000 |    23.68 |    22.99 | 0.97x   |
| chinese.utf32                       |   548832 |       1000 |    46.79 |    46.82 | 1.00x   |
| czech.utf32                         |   575328 |       1000 |    46.80 |    46.80 | 1.00x   |
| english.utf32                       |  1550036 |       1000 |    35.34 |    35.99 | 1.02x   |
| esperanto.utf32                     |   336500 |       1000 |    46.75 |    46.80 | 1.00x   |
| french.utf32                        |  1739468 |       1000 |    33.24 |    33.63 | 1.01x   |
| german.utf32                        |   804860 |       1000 |    46.69 |    46.80 | 1.00x   |
| greek.utf32                         |   571996 |       1000 |    46.79 |    46.77 | 1.00x   |
| hebrew.utf32                        |   585404 |       1000 |    46.78 |    46.78 | 1.00x   |
| hindi.utf32                         |  1095832 |       1000 |    43.90 |    46.60 | 1.06x   |
| japanese.utf32                      |   475564 |       1000 |    46.82 |    46.77 | 1.00x   |
| korean.utf32                        |   291672 |       1000 |    46.80 |    46.93 | 1.00x   |
| persan.utf32                        |   498776 |       1000 |    46.89 |    46.83 | 1.00x   |
| portuguese.utf32                    |  1094456 |       1000 |    43.77 |    46.40 | 1.06x   |
| russian.utf32                       |  1248148 |       1000 |    40.26 |    43.62 | 1.08x   |
| thai.utf32                          |  1619032 |       1000 |    34.15 |    34.89 | 1.02x   |
| turkish.utf32                       |   741768 |       1000 |    46.72 |    46.98 | 1.01x   |
| vietnamese.utf32                    |  1129676 |       1000 |    42.48 |    45.70 | 1.08x   |
| validate_utf32_with_errors+westmere                                                         |
| arabic.utf32                        |  1699376 |       1000 |    14.95 |    15.53 | 1.04x   |
| chinese.utf32                       |   548832 |       1000 |    16.36 |    17.00 | 1.04x   |
| czech.utf32                         |   575328 |       1000 |    16.45 |    16.99 | 1.03x   |
| english.utf32                       |  1550036 |       1000 |    14.97 |    16.11 | 1.08x   |
| esperanto.utf32                     |   336500 |       1000 |    16.70 |    16.99 | 1.02x   |
| french.utf32                        |  1739468 |       1000 |    14.94 |    16.37 | 1.10x   |
| german.utf32                        |   804860 |       1000 |    16.23 |    16.99 | 1.05x   |
| greek.utf32                         |   571996 |       1000 |    16.50 |    17.00 | 1.03x   |
| hebrew.utf32                        |   585404 |       1000 |    16.51 |    17.00 | 1.03x   |
| hindi.utf32                         |  1095832 |       1000 |    15.54 |    16.91 | 1.09x   |
| japanese.utf32                      |   475564 |       1000 |    16.58 |    16.99 | 1.02x   |
| korean.utf32                        |   291672 |       1000 |    16.83 |    16.98 | 1.01x   |
| persan.utf32                        |   498776 |       1000 |    16.42 |    17.00 | 1.04x   |
| portuguese.utf32                    |  1094456 |       1000 |    15.52 |    16.82 | 1.08x   |
| russian.utf32                       |  1248148 |       1000 |    15.18 |    16.18 | 1.07x   |
| thai.utf32                          |  1619032 |       1000 |    15.02 |    16.45 | 1.10x   |
| turkish.utf32                       |   741768 |       1000 |    16.27 |    17.00 | 1.04x   |
| vietnamese.utf32                    |  1129676 |       1000 |    15.38 |    16.49 | 1.07x   |