### PR TITLE
Some code in the RVV kernel assumes that char is unsigned

### DIFF
--- a/src/rvv/rvv_utf8_to.inl.cpp
+++ b/src/rvv/rvv_utf8_to.inl.cpp
@@ -20,7 +20,7 @@ simdutf_really_inline static size_t rvv_utf8_to_common(char const *src,
   /* validate first three bytes */
   if (validate) {
     size_t idx = 3;
-    while (idx < len && (src[idx] >> 6) == 0b10)
+    while (idx < len && (uint8_t(src[idx]) >> 6) == 0b10)
       ++idx;
     if (idx > 3 + 3 || !scalar::utf8::validate(src, idx))
       return 0;
@@ -255,9 +255,9 @@ simdutf_really_inline static size_t rvv_utf8_to_common(char const *src,
 
   /* validate the last character and reparse it + tail */
   if (len > tail) {
-    if ((src[0] >> 6) == 0b10)
+    if ((uint8_t(src[0]) >> 6) == 0b10)
       --dst;
-    while ((src[0] >> 6) == 0b10 && tail < len)
+    while ((uint8_t(src[0]) >> 6) == 0b10 && tail < len)
       --src, ++tail;
     if (is16) {
       /* go back one more, when on high surrogate */

--- a/src/rvv/rvv_validate.inl.cpp
+++ b/src/rvv/rvv_validate.inl.cpp
@@ -38,7 +38,7 @@ simdutf_really_inline static size_t rvv_count_valid_utf8(const char *src,
   /* validate first three bytes */
   {
     size_t idx = 3;
-    while (idx < len && (src[idx] >> 6) == 0b10)
+    while (idx < len && (uint8_t(src[idx]) >> 6) == 0b10)
       ++idx;
     if (idx > 3 + 3 || !scalar::utf8::validate(src, idx))
       return 0;
@@ -105,7 +105,7 @@ simdutf_really_inline static size_t rvv_count_valid_utf8(const char *src,
   }
 
   /* we need to validate the last character */
-  while (tail < len && (src[0] >> 6) == 0b10)
+  while (tail < len && (uint8_t(src[0]) >> 6) == 0b10)
     --src, ++tail;
   return src - beg;
 }


### PR DESCRIPTION
In C/C++, that char type is neither signed or unsigned, it is implementation defined. A right shift on a signed type is implementation defined. Thus, if `src` is a pointer to char values, then `src[idx] >> 6` may or may not do what you think.

We had the pattern `(src[idx] >> 6) == 0b10` everywhere in the RISC-V kernel, but in many cases, `(src[0] >> 6) == 0b10` is going to be false (always). 

It is possible that when compiling on RISC-V, chars might be considered unsigned. Maybe it is always so. I do not know. It is so under GCC when compiling to RISC-V, see https://godbolt.org/z/PKqxTPh1r

Still, it seems like a risky proposition to make this assumption !!!

Fixes https://github.com/simdutf/simdutf/issues/728