### PR TITLE
fix LoongArch64 fuzz error

### DIFF
--- a/fuzz/random_fuzz.sh
+++ b/fuzz/random_fuzz.sh
@@ -107,6 +107,9 @@ case $(uname -m) in
     riscv64)
 	MARCHFLAGS="-march=rv64gcv"
 	;;
+    loongarch64)
+	MARCHFLAGS="-mlsx -mlasx"
+	;;
     *)
 	;;
 esac

--- a/src/lasx/lasx_convert_latin1_to_utf16.cpp
+++ b/src/lasx/lasx_convert_latin1_to_utf16.cpp
@@ -22,7 +22,7 @@ lasx_convert_latin1_to_utf16le(const char *buf, size_t len,
     buf += 32;
   }
 
-  if (buf + 16 <= end) {
+  if (end - buf >= 16) {
     __m128i zero = __lsx_vldi(0);
     __m128i in8 = __lsx_vld(reinterpret_cast<const uint8_t *>(buf), 0);
 
@@ -47,7 +47,7 @@ lasx_convert_latin1_to_utf16be(const char *buf, size_t len,
   }
 
   __m256i zero = __lasx_xvldi(0);
-  while (buf + 32 <= end) {
+  while (end - buf >= 32) {
     __m256i in8 = __lasx_xvld(reinterpret_cast<const uint8_t *>(buf), 0);
 
     __m256i in8_shuf = __lasx_xvpermi_d(in8, 0b11011000);
@@ -60,7 +60,7 @@ lasx_convert_latin1_to_utf16be(const char *buf, size_t len,
     buf += 32;
   }
 
-  if (buf + 16 <= end) {
+  if (end - buf >= 16) {
     __m128i zero_128 = __lsx_vldi(0);
     __m128i in8 = __lsx_vld(reinterpret_cast<const uint8_t *>(buf), 0);
 

--- a/src/lasx/lasx_convert_latin1_to_utf8.cpp
+++ b/src/lasx/lasx_convert_latin1_to_utf8.cpp
@@ -8,11 +8,11 @@ lasx_convert_latin1_to_utf8(const char *latin1_input, size_t len,
                             char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
   const size_t safety_margin = 12;
-  const char *end = latin1_input + len - safety_margin;
+  const char *end = latin1_input + len;
 
   // We always write 16 bytes, of which more than the first 8 bytes
   // are valid. A safety margin of 8 is more than sufficient.
-  while (end - latin1_input >= 16) {
+  while (end - latin1_input >= std::ptrdiff_t(16 + safety_margin)) {
     __m128i in8 = __lsx_vld(reinterpret_cast<const uint8_t *>(latin1_input), 0);
     uint32_t ascii_mask = __lsx_vpickve2gr_wu(__lsx_vmskgez_b(in8), 0);
     if (ascii_mask == 0xFFFF) {

--- a/src/simdutf/lasx/intrinsics.h
+++ b/src/simdutf/lasx/intrinsics.h
@@ -259,19 +259,23 @@ public:
 #else
 template <uint16_t x> constexpr __m256i lasx_splat_u16_aux() {
   constexpr bool is_imm10 = (int16_t(x) < 512) && (int16_t(x) > -512);
+  constexpr uint16_t imm10 = is_imm10 ? x : 0;
   constexpr bool is_vldi = lasx_vldi::const_u16<x>::valid;
+  constexpr int vldi_imm = is_vldi ? lasx_vldi::const_u16<x>::value : 0;
 
-  return is_imm10  ? __lasx_xvrepli_h(int16_t(x))
-         : is_vldi ? __lasx_xvldi(lasx_vldi::const_u16<x>::value)
+  return is_imm10  ? __lasx_xvrepli_h(int16_t(imm10))
+         : is_vldi ? __lasx_xvldi(vldi_imm)
                    : __lasx_xvreplgr2vr_h(x);
 }
 
 template <uint32_t x> constexpr __m256i lasx_splat_u32_aux() {
   constexpr bool is_imm10 = (int32_t(x) < 512) && (int32_t(x) > -512);
+  constexpr uint32_t imm10 = is_imm10 ? x : 0;
   constexpr bool is_vldi = lasx_vldi::const_u32<x>::valid;
+  constexpr int vldi_imm = is_vldi ? lasx_vldi::const_u32<x>::value : 0;
 
-  return is_imm10  ? __lasx_xvrepli_w(int32_t(x))
-         : is_vldi ? __lasx_xvldi(lasx_vldi::const_u32<x>::value)
+  return is_imm10  ? __lasx_xvrepli_w(int32_t(imm10))
+         : is_vldi ? __lasx_xvldi(vldi_imm)
                    : __lasx_xvreplgr2vr_w(x);
 }
 

--- a/src/simdutf/lsx/intrinsics.h
+++ b/src/simdutf/lsx/intrinsics.h
@@ -167,19 +167,23 @@ public:
 #else
 template <uint16_t x> constexpr __m128i lsx_splat_u16_aux() {
   constexpr bool is_imm10 = (int16_t(x) < 512) && (int16_t(x) > -512);
+  constexpr uint16_t imm10 = is_imm10 ? x : 0;
   constexpr bool is_vldi = vldi::const_u16<x>::valid;
+  constexpr int vldi_imm = is_vldi ? vldi::const_u16<x>::value : 0;
 
-  return is_imm10  ? __lsx_vrepli_h(int16_t(x))
-         : is_vldi ? __lsx_vldi(vldi::const_u16<x>::value)
+  return is_imm10  ? __lsx_vrepli_h(int16_t(imm10))
+         : is_vldi ? __lsx_vldi(vldi_imm)
                    : __lsx_vreplgr2vr_h(x);
 }
 
 template <uint32_t x> constexpr __m128i lsx_splat_u32_aux() {
   constexpr bool is_imm10 = (int32_t(x) < 512) && (int32_t(x) > -512);
+  constexpr uint32_t imm10 = is_imm10 ? x : 0;
   constexpr bool is_vldi = vldi::const_u32<x>::valid;
+  constexpr int vldi_imm = is_vldi ? vldi::const_u32<x>::value : 0;
 
-  return is_imm10  ? __lsx_vrepli_w(int32_t(x))
-         : is_vldi ? __lsx_vldi(vldi::const_u32<x>::value)
+  return is_imm10  ? __lsx_vrepli_w(int32_t(imm10))
+         : is_vldi ? __lsx_vldi(vldi_imm)
                    : __lsx_vreplgr2vr_w(x);
 }
 


### PR DESCRIPTION
An error occurs when running `random_fuzz.sh`
```
[ 50%] Building CXX object src/CMakeFiles/simdutf.dir/simdutf.cpp.o
In file included from /home/xiaotao/simd/simdutf/src/simdutf.cpp:28:
In file included from /home/xiaotao/simd/simdutf/src/simdutf/lsx.h:36:
/home/xiaotao/simd/simdutf/src/simdutf/lsx/intrinsics.h:172:22: fatal error: argument value 7936 is outside the valid range [-512, 511]
  172 |   return is_imm10  ? __lsx_vrepli_h(int16_t(x))
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib/llvm-19/lib/clang/19/include/lsxintrin.h:3745:47: note: expanded from macro '__lsx_vrepli_h'                                                                                                                                                                                                                                                                                         
 3745 | #define __lsx_vrepli_h(/*si10*/ _1) ((__m128i)__builtin_lsx_vrepli_h((_1)))
      |                                               ^                      ~~~~
/home/xiaotao/simd/simdutf/src/lsx/implementation.cpp:108:25: note: in instantiation of function template specialization 'lsx_splat_u16_aux<(unsigned short)7936>' requested here                                                                                                                                                                                                            
  108 |   const __m128i v1f00 = lsx_splat_u16(0x1f00);
      |                         ^
/home/xiaotao/simd/simdutf/src/simdutf/lsx/intrinsics.h:186:28: note: expanded from macro 'lsx_splat_u16'                                                                                                                                                                                                                                                                                    
  186 |   #define lsx_splat_u16(v) lsx_splat_u16_aux<(v)>()
      |                            ^
1 error generated. 

```
add `imm10` and `vldi_imm` to avoid this error.

`lasx_convert_latin1_to_utf16le` and `lasx_convert_latin1_to_utf8` will cause **SIGILL** error when `input_buf=nullptr, len=0`
```
#include <cstddef>                                                                                                                                                                                                                                                                                                                                                                            
#include <cstdint>                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                              
extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size);                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                              
int main() {                                                                                                                                                                                                                                                                                                                                                                                  
  unsigned char cleaned_crash[] = {0x28, 0x20, 0x20, 0x20};                                                                                                                                                                                                                                                                                                                                   
  unsigned int cleaned_crash_len = 4;                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                              
  LLVMFuzzerTestOneInput(cleaned_crash, cleaned_crash_len);                                                                                                                                                                                                                                                                                                                                   
}  


(gdb) r
Starting program: /home/xiaotao/simd/simdutf/fuzz/out/reproducer.conversion 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/loongarch64-linux-gnu/libthread_db.so.1".
implementation lsx is available? 1
implementation lasx is available? 1
implementation fallback is available? 1

Program received signal SIGILL, Illegal instruction.
0x0000555555a9872c in simdutf::lasx::(anonymous namespace)::lasx_convert_latin1_to_utf16le (buf=<optimized out>, len=0, utf16_output=<optimized out>) at /home/xiaotao/simd/simdutf/src/lasx/lasx_convert_latin1_to_utf16.cpp:25
25        if (buf + 16 <= end) {
(gdb) bt
#0  0x0000555555a9872c in simdutf::lasx::(anonymous namespace)::lasx_convert_latin1_to_utf16le (buf=<optimized out>, len=0, utf16_output=<optimized out>) at /home/xiaotao/simd/simdutf/src/lasx/lasx_convert_latin1_to_utf16.cpp:25
#1  simdutf::lasx::implementation::convert_latin1_to_utf16le (this=<optimized out>, buf=0x0, len=0, utf16_output=0x0) at /home/xiaotao/simd/simdutf/src/lasx/implementation.cpp:412
#2  0x000055555591b318 in std::__invoke_impl<unsigned long, unsigned long (simdutf::implementation::* const&)(char const*, unsigned long, char16_t*) noexcept const, simdutf::implementation const*&, char const*, unsigned long, char16_t*>(std::__invoke_memfun_deref, unsigned long (simdutf::implementation::* const&)(char const*, unsigned long, char16_t*) noexcept const, simdutf::implementation const*&, char const*&&, unsigned long&&, char16_t*&&) (__f=@0x7ffff5efd030: &virtual table offset 128, __t=@0x7ffff60fd100: 0x5555565e5420 <simdutf::internal::get_lasx_singleton()::lasx_singleton>, __args=@0x7ffff60fd190: 0x0, __args=@0x7ffff60fd190: 0x0, __args=@0x7ffff60fd190: 0x0) at /usr/lib/gcc/loongarch64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:74 
#3  0x000055555591af48 in std::__invoke<unsigned long (simdutf::implementation::* const&)(char const*, unsigned long, char16_t*) noexcept const, simdutf::implementation const*&, char const*, unsigned long, char16_t*>(unsigned long (simdutf::implementation::* const&)(char const*, unsigned long, char16_t*) noexcept const, simdutf::implementation const*&, char const*&&, unsigned long&&, char16_t*&&) (__fn=@0x7ffff5efd030: &virtual table offset 128, __args=@0x7ffff60fd190: 0x0, __args=@0x7ffff60fd190: 0x0, __args=@0x7ffff60fd190: 0x0, __args=@0x7ffff60fd190: 0x0) at /usr/lib/gcc/loongarch64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:96                                                                                                                  
#4  0x000055555591abe4 in std::invoke<unsigned long (simdutf::implementation::* const&)(char const*, unsigned long, char16_t*) noexcept const, simdutf::implementation const*&, char const*, unsigned long, char16_t*>(unsigned long (simdutf::implementation::* const&)(char const*, unsigned long, char16_t*) noexcept const, simdutf::implementation const*&, char const*&&, unsigned long&&, char16_t*&&) (__fn=@0x7ffff5efd030: &virtual table offset 128, __args=@0x7ffff60fd190: 0x0, __args=@0x7ffff60fd190: 0x0, __args=@0x7ffff60fd190: 0x0, __args=@0x7ffff60fd190: 0x0) at /usr/lib/gcc/loongarch64-linux-gnu/14/../../../../include/c++/14/functional:120                                                                                                                      
#5  0x0000555555a2ef60 in Conversion<(UtfEncodings)4, (UtfEncodings)1, unsigned long (simdutf::implementation::*)(unsigned long) noexcept const, unsigned long (simdutf::implementation::*)(char const*, unsigned long, char16_t*) noexcept const>::do_conversion(std::span<char const, 18446744073709551615ul>, std::vector<unsigned long, std::allocator<unsigned long> > const&, bool) const (this=0x7ffff5efd020, src=std::span of length 0, outlength=std::vector of length 3, capacity 4 = {...}, inputisvalid=true) at conversion.cpp:389                                                                                                                                                                                                                                            
#6  0x0000555555a2b8fc in Conversion<(UtfEncodings)4, (UtfEncodings)1, unsigned long (simdutf::implementation::*)(unsigned long) noexcept const, unsigned long (simdutf::implementation::*)(char const*, unsigned long, char16_t*) noexcept const>::fuzz(std::span<char const, 18446744073709551615ul>) const (this=0x7ffff5efd020, chardata=std::span of length 0) at conversion.cpp:206
#7  0x000055555585f6d0 in populate_functions()::$_40::operator()(std::span<char const, 18446744073709551615ul>) const (this=0x7ffff5bfd760, chardata=std::span of length 0) at conversion.cpp:624
#8  0x000055555584c570 in populate_functions()::$_40::__invoke(std::span<char const, 18446744073709551615ul>) (chardata=std::span of length 0) at conversion.cpp:624
#9  0x000055555584cc48 in LLVMFuzzerTestOneInput (data=0x7ffff5bfd624 "", size=0) at conversion.cpp:653
#10 0x000055555584890c in main () at reproducer.conversion.cpp:10

```
This problem has not been fixed in https://github.com/simdutf/simdutf/pull/654/commits/e38deac30cf49a20d3f5ec318a15ad354e3569c7
