### PR TITLE
arm64: optimize base64 decode block by replacing ORR + SHL + SHR with SLI + SHR

### DIFF
--- a/src/arm64/arm_base64.cpp
+++ b/src/arm64/arm_base64.cpp
@@ -317,11 +317,9 @@ void load_block(block64 *b, const char16_t *src) {
 void base64_decode_block(char *out, const char *src) {
   uint8x16x4_t str = vld4q_u8((uint8_t *)src);
   uint8x16x3_t outvec;
-  outvec.val[0] =
-      vorrq_u8(vshlq_n_u8(str.val[0], 2), vshrq_n_u8(str.val[1], 4));
-  outvec.val[1] =
-      vorrq_u8(vshlq_n_u8(str.val[1], 4), vshrq_n_u8(str.val[2], 2));
-  outvec.val[2] = vorrq_u8(vshlq_n_u8(str.val[2], 6), str.val[3]);
+  outvec.val[0] = vsliq_n_u8(vshrq_n_u8(str.val[1], 4), str.val[0], 2);
+  outvec.val[1] = vsliq_n_u8(vshrq_n_u8(str.val[2], 2), str.val[1], 4);
+  outvec.val[2] = vsliq_n_u8(str.val[3], str.val[2], 6);
   vst3q_u8((uint8_t *)out, outvec);
 }
 


### PR DESCRIPTION
This is an attempt to reduce the instruction count from 11 to 9 as seen in the below Compiler Explorer link
https://godbolt.org/z/Krze65Kcs

Before:
```
./build/benchmarks/base64/benchmark_base64 -f simdutf -d base64data/email/*
# current system detected as arm64.
# loading files: ...............
# volume: 1976492 bytes
# max length: 1006349 bytes
# number of inputs: 15
# decode
# the base64 data contains spaces, so we cannot use straigth libbase64::base64_decode directly
simdutf::arm64                           :   7.53 GB/s  2.30 %
simdutf::arm64 (accept garbage)          :   7.58 GB/s  1.90 %
```

After:
```
./build2/benchmarks/base64/benchmark_base64 -f simdutf -d base64data/email/*
# current system detected as arm64.
# loading files: ...............
# volume: 1976492 bytes
# max length: 1006349 bytes
# number of inputs: 15
# decode
# the base64 data contains spaces, so we cannot use straigth libbase64::base64_decode directly
simdutf::arm64                           :   7.75 GB/s  2.33 %
simdutf::arm64 (accept garbage)          :   7.73 GB/s  2.35 %
```