### PR TITLE
haswell: faster UTF-32 to UTF-16

### DIFF
--- a/src/haswell/avx2_convert_utf32_to_utf16.cpp
+++ b/src/haswell/avx2_convert_utf32_to_utf16.cpp
@@ -1,12 +1,80 @@
+struct expansion_result_t {
+  size_t u16count_lo;
+  __m128i compressed_lo;
+
+  size_t u16count_hi;
+  __m128i compressed_hi;
+};
+
+// Function avx2_expand_surrogate takes eight **valid** UTF-32 characters
+// having at least one code-point producing a surrogate pair.
+template <endianness byte_order>
+expansion_result_t avx2_expand_surrogate(const __m256i x) {
+  using vector_u32 = simd32<uint32_t>;
+
+  const auto in = vector_u32(x);
+
+  const auto non_surrogate_mask = (in & uint32_t(0xffff0000)) == uint32_t(0);
+  const uint8_t mask_2x = uint8_t(~non_surrogate_mask.to_8bit_bitmask());
+  const uint8_t mask_lo = uint8_t(mask_2x & 0xf);
+  const uint8_t mask_hi = uint8_t(mask_2x >> 4);
+
+  const auto t0 = in - uint32_t(0x00010000);
+  const auto hi = t0.shr<10>() & uint32_t(0x000003ff);
+  const auto lo = t0.shl<16>() & uint32_t(0x03ff0000);
+  const auto surrogates = (lo | hi) | uint32_t(0xdc00d800);
+
+  const auto merged = as_vector_u8(select(non_surrogate_mask, in, surrogates));
+
+  // Note: we're getting back to the intrinsics world, as there's
+  //       no way to refer to the westmere implementation (we enclose
+  //       implementations in anonymous namespaces).
+  const auto lo_half = _mm256_extractf128_si256(merged.value, 0);
+  const auto hi_half = _mm256_extractf128_si256(merged.value, 1);
+
+  const auto shuffle_lo = _mm_loadu_si128(reinterpret_cast<const __m128i *>(
+      (byte_order == endianness::LITTLE)
+          ? tables::utf32_to_utf16::pack_utf32_to_utf16le[mask_lo]
+          : tables::utf32_to_utf16::pack_utf32_to_utf16be[mask_lo]));
+
+  const auto shuffle_hi = _mm_loadu_si128(reinterpret_cast<const __m128i *>(
+      (byte_order == endianness::LITTLE)
+          ? tables::utf32_to_utf16::pack_utf32_to_utf16le[mask_hi]
+          : tables::utf32_to_utf16::pack_utf32_to_utf16be[mask_hi]));
+
+  const size_t u16count_lo = (4 + count_ones(mask_lo));
+  const size_t u16count_hi = (4 + count_ones(mask_hi));
+
+  const auto compressed_lo = _mm_shuffle_epi8(lo_half, shuffle_lo);
+  const auto compressed_hi = _mm_shuffle_epi8(hi_half, shuffle_hi);
+
+  return {u16count_lo, compressed_lo, u16count_hi, compressed_hi};
+}
+
+// Function `invalid_utf32` returns a bytemask pointing invalid UTF-32
+// characters.
+simdutf_really_inline simd32<bool> invalid_utf32(const __m256i x) {
+  using vector_u32 = simd32<uint32_t>;
+
+  const auto in = vector_u32(x);
+
+  const auto standardmax = vector_u32::splat(0x10ffff);
+
+  const auto too_large = in > standardmax;
+  const auto surrogate = (in & uint32_t(0xfffff800)) == uint32_t(0xd800);
+
+  return too_large | surrogate;
+}
+
 template <endianness big_endian>
 std::pair<const char32_t *, char16_t *>
 avx2_convert_utf32_to_utf16(const char32_t *buf, size_t len,
                             char16_t *utf16_output) {
   const char32_t *end = buf + len;
 
-  const size_t safety_margin =
-      12; // to avoid overruns, see issue
-          // https://github.com/simdutf/simdutf/issues/92
+  // to avoid overruns, see issue https://github.com/simdutf/simdutf/issues/92
+  const size_t safety_margin = 12;
+
   __m256i forbidden_bytemask = _mm256_setzero_si256();
 
   const __m256i v_ffff0000 = _mm256_set1_epi32((int32_t)0xffff0000);
@@ -14,63 +82,49 @@ avx2_convert_utf32_to_utf16(const char32_t *buf, size_t len,
   const __m256i v_d800 = _mm256_set1_epi32((uint32_t)0xd800);
 
   while (end - buf >= std::ptrdiff_t(8 + safety_margin)) {
-    const __m256i in = _mm256_loadu_si256((__m256i *)buf);
+    bool check = false;
+    __m256i in;
+    while (end - buf >= std::ptrdiff_t(8 + safety_margin)) {
+      in = _mm256_loadu_si256((const __m256i *)buf);
 
-    if (simdutf_likely(_mm256_testz_si256(in, v_ffff0000))) {
-      // no bits set above 16th bit <=> can pack to UTF16
-      // without surrogate pairs
-      forbidden_bytemask = _mm256_or_si256(
-          forbidden_bytemask,
-          _mm256_cmpeq_epi32(_mm256_and_si256(in, v_f800), v_d800));
+      if (simdutf_likely(_mm256_testz_si256(in, v_ffff0000))) {
+        // no bits set above 16th bit <=> can pack to UTF16
+        // without surrogate pairs
+        forbidden_bytemask = _mm256_or_si256(
+            forbidden_bytemask,
+            _mm256_cmpeq_epi32(_mm256_and_si256(in, v_f800), v_d800));
 
-      __m128i utf16_packed = _mm_packus_epi32(_mm256_castsi256_si128(in),
-                                              _mm256_extractf128_si256(in, 1));
-      if (big_endian) {
-        const __m128i swap =
-            _mm_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
-        utf16_packed = _mm_shuffle_epi8(utf16_packed, swap);
-      }
-      _mm_storeu_si128((__m128i *)utf16_output, utf16_packed);
-      utf16_output += 8;
-      buf += 8;
-    } else {
-      size_t forward = 7;
-      size_t k = 0;
-      if (size_t(end - buf) < forward + 1) {
-        forward = size_t(end - buf - 1);
-      }
-      for (; k < forward; k++) {
-        uint32_t word = buf[k];
-        if ((word & 0xFFFF0000) == 0) {
-          // will not generate a surrogate pair
-          if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr, utf16_output);
-          }
-          *utf16_output++ =
-              big_endian
-                  ? char16_t((uint16_t(word) >> 8) | (uint16_t(word) << 8))
-                  : char16_t(word);
-        } else {
-          // will generate a surrogate pair
-          if (word > 0x10FFFF) {
-            return std::make_pair(nullptr, utf16_output);
-          }
-          word -= 0x10000;
-          uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
-          uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-          if (big_endian) {
-            high_surrogate =
-                uint16_t((high_surrogate >> 8) | (high_surrogate << 8));
-            low_surrogate =
-                uint16_t((low_surrogate >> 8) | (low_surrogate << 8));
-          }
-          *utf16_output++ = char16_t(high_surrogate);
-          *utf16_output++ = char16_t(low_surrogate);
+        __m128i utf16_packed = _mm_packus_epi32(
+            _mm256_castsi256_si128(in), _mm256_extractf128_si256(in, 1));
+        if (big_endian) {
+          const __m128i swap = _mm_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11,
+                                             10, 13, 12, 15, 14);
+          utf16_packed = _mm_shuffle_epi8(utf16_packed, swap);
         }
+        _mm_storeu_si128((__m128i *)utf16_output, utf16_packed);
+        utf16_output += 8;
+        buf += 8;
+      } else {
+        check = true;
+        break;
       }
-      buf += k;
+    } // inner while
+
+    if (check) {
+      const auto err = invalid_utf32(in);
+      if (simdutf_unlikely(err.any())) {
+        return std::make_pair(nullptr, utf16_output);
+      }
+
+      const auto ret = avx2_expand_surrogate<big_endian>(in);
+      _mm_storeu_si128((__m128i *)utf16_output, ret.compressed_lo);
+      utf16_output += ret.u16count_lo;
+      _mm_storeu_si128((__m128i *)utf16_output, ret.compressed_hi);
+      utf16_output += ret.u16count_hi;
+
+      buf += 8;
     }
-  }
+  } // outer while
 
   // check for invalid input
   if (static_cast<uint32_t>(_mm256_movemask_epi8(forbidden_bytemask)) != 0) {
@@ -120,45 +174,50 @@ avx2_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
       utf16_output += 8;
       buf += 8;
     } else {
-      size_t forward = 7;
-      size_t k = 0;
-      if (size_t(end - buf) < forward + 1) {
-        forward = size_t(end - buf - 1);
-      }
-      for (; k < forward; k++) {
-        uint32_t word = buf[k];
-        if ((word & 0xFFFF0000) == 0) {
-          // will not generate a surrogate pair
-          if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(
-                result(error_code::SURROGATE, buf - start + k), utf16_output);
+      const auto err = invalid_utf32(in);
+      if (simdutf_unlikely(err.any())) {
+        const size_t pos = err.first_set();
+        // write chars prior the error
+        for (size_t i = 0; i < pos; i++) {
+          const uint32_t word = buf[i];
+          if ((word & 0xFFFF0000) == 0) {
+            *utf16_output++ =
+                scalar::u16_force_endianness<endianness::LITTLE, big_endian>(
+                    uint16_t(word));
+          } else {
+            const uint32_t w = word - 0x10000;
+            const uint16_t high_surrogate = uint16_t(0xD800 + (w >> 10));
+            const uint16_t low_surrogate = uint16_t(0xDC00 + (w & 0x3FF));
+            *utf16_output++ =
+                scalar::u16_force_endianness<endianness::LITTLE, big_endian>(
+                    high_surrogate);
+            *utf16_output++ =
+                scalar::u16_force_endianness<endianness::LITTLE, big_endian>(
+                    low_surrogate);
           }
-          *utf16_output++ =
-              big_endian
-                  ? char16_t((uint16_t(word) >> 8) | (uint16_t(word) << 8))
-                  : char16_t(word);
-        } else {
-          // will generate a surrogate pair
-          if (word > 0x10FFFF) {
-            return std::make_pair(
-                result(error_code::TOO_LARGE, buf - start + k), utf16_output);
-          }
-          word -= 0x10000;
-          uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
-          uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-          if (big_endian) {
-            high_surrogate =
-                uint16_t((high_surrogate >> 8) | (high_surrogate << 8));
-            low_surrogate =
-                uint16_t((low_surrogate >> 8) | (low_surrogate << 8));
-          }
-          *utf16_output++ = char16_t(high_surrogate);
-          *utf16_output++ = char16_t(low_surrogate);
         }
+
+        // determine the exact error
+        const uint32_t word = buf[pos];
+        const size_t error_pos = buf - start + pos;
+        if (word > 0x10FFFF) {
+          return {result(error_code::TOO_LARGE, error_pos), utf16_output};
+        }
+        if (word >= 0xD800 && word <= 0xDFFF) {
+          return {result(error_code::SURROGATE, error_pos), utf16_output};
+        }
+        return {result(error_code::OTHER, error_pos), utf16_output};
       }
-      buf += k;
+
+      const auto ret = avx2_expand_surrogate<big_endian>(in);
+      _mm_storeu_si128((__m128i *)utf16_output, ret.compressed_lo);
+      utf16_output += ret.u16count_lo;
+      _mm_storeu_si128((__m128i *)utf16_output, ret.compressed_hi);
+      utf16_output += ret.u16count_hi;
+
+      buf += 8;
     }
   }
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start), utf16_output);
+  return {result(error_code::SUCCESS, buf - start), utf16_output};
 }

--- a/src/scalar/swap_bytes.h
+++ b/src/scalar/swap_bytes.h
@@ -4,11 +4,23 @@
 namespace simdutf {
 namespace scalar {
 
-inline simdutf_warn_unused uint16_t u16_swap_bytes(const uint16_t word) {
+simdutf_really_inline simdutf_warn_unused uint16_t
+u16_swap_bytes(const uint16_t word) {
   return uint16_t((word >> 8) | (word << 8));
 }
 
-inline simdutf_warn_unused uint32_t u32_swap_bytes(const uint32_t word) {
+template <endianness source, endianness destination>
+simdutf_really_inline simdutf_warn_unused uint16_t
+u16_force_endianness(const uint16_t word) {
+  if (source != destination) {
+    return u16_swap_bytes(word);
+  } else {
+    return word;
+  }
+}
+
+simdutf_really_inline simdutf_warn_unused uint32_t
+u32_swap_bytes(const uint32_t word) {
   return ((word >> 24) & 0xff) |      // move byte 3 to byte 0
          ((word << 8) & 0xff0000) |   // move byte 1 to byte 2
          ((word >> 8) & 0xff00) |     // move byte 2 to byte 1

--- a/src/simdutf/haswell/simd.h
+++ b/src/simdutf/haswell/simd.h
@@ -350,6 +350,10 @@ simdutf_really_inline simd64<uint64_t> sum_8bytes(const simd8<uint8_t> v) {
   return _mm256_sad_epu8(v.value, simd8<uint8_t>::zero());
 }
 
+simdutf_really_inline simd8<uint8_t> as_vector_u8(const simd32<uint32_t> v) {
+  return simd8<uint8_t>(v.value);
+}
+
 } // namespace simd
 
 } // unnamed namespace

--- a/src/simdutf/haswell/simd32-inl.h
+++ b/src/simdutf/haswell/simd32-inl.h
@@ -32,6 +32,21 @@ template <> struct simd32<uint32_t> {
     return _mm256_shuffle_epi8(value, shuffle);
   }
 
+  template <int N> simdutf_really_inline simd32<uint32_t> shr() const {
+    return _mm256_srli_epi32(value, N);
+  }
+
+  template <int N> simdutf_really_inline simd32<uint32_t> shl() const {
+    return _mm256_slli_epi32(value, N);
+  }
+
+  void dump() const {
+    uint32_t tmp[8];
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(tmp), value);
+    printf("[%08x %08x %08x %08x %08x %08x %08x %08x]\n", tmp[0], tmp[1],
+           tmp[2], tmp[3], tmp[4], tmp[5], tmp[6], tmp[7]);
+  }
+
   // operators
   simdutf_really_inline simd32 &operator+=(const simd32 other) {
     value = _mm256_add_epi32(value, other.value);
@@ -61,6 +76,22 @@ template <> struct simd32<bool> {
   simdutf_really_inline bool any() const {
     return _mm256_movemask_epi8(value) != 0;
   }
+
+  simdutf_really_inline size_t first_set() const {
+    const auto bitmask = to_8bit_bitmask();
+    return trailing_zeroes(bitmask);
+  }
+
+  simdutf_really_inline uint8_t to_8bit_bitmask() const {
+    return uint8_t(_mm256_movemask_ps(_mm256_castsi256_ps(value)));
+  }
+
+  void dump() const {
+    uint32_t tmp[8];
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(tmp), value);
+    printf("[%08x %08x %08x %08x %08x %08x %08x %08x]\n", tmp[0], tmp[1],
+           tmp[2], tmp[3], tmp[4], tmp[5], tmp[6], tmp[7]);
+  }
 };
 
 //----------------------------------------------------------------------
@@ -71,8 +102,13 @@ simdutf_really_inline simd32<T> operator|(const simd32<T> a,
   return _mm256_or_si256(a.value, b.value);
 }
 
-simdutf_really_inline simd32<uint32_t> min(const simd32<uint32_t> b,
-                                           const simd32<uint32_t> a) {
+simdutf_really_inline simd32<uint32_t> operator|(const simd32<uint32_t> a,
+                                                 const uint32_t b) {
+  return _mm256_or_si256(a.value, _mm256_set1_epi32(b));
+}
+
+simdutf_really_inline simd32<uint32_t> min(const simd32<uint32_t> a,
+                                           const simd32<uint32_t> b) {
   return _mm256_min_epu32(a.value, b.value);
 }
 
@@ -81,9 +117,14 @@ simdutf_really_inline simd32<uint32_t> max(const simd32<uint32_t> a,
   return _mm256_max_epu32(a.value, b.value);
 }
 
-simdutf_really_inline simd32<uint32_t> operator&(const simd32<uint32_t> b,
-                                                 const simd32<uint32_t> a) {
+simdutf_really_inline simd32<uint32_t> operator&(const simd32<uint32_t> a,
+                                                 const simd32<uint32_t> b) {
   return _mm256_and_si256(a.value, b.value);
+}
+
+simdutf_really_inline simd32<uint32_t> operator&(const simd32<uint32_t> a,
+                                                 uint32_t b) {
+  return _mm256_and_si256(a.value, _mm256_set1_epi32(b));
 }
 
 simdutf_really_inline simd32<uint32_t> operator+(const simd32<uint32_t> a,
@@ -91,9 +132,19 @@ simdutf_really_inline simd32<uint32_t> operator+(const simd32<uint32_t> a,
   return _mm256_add_epi32(a.value, b.value);
 }
 
+simdutf_really_inline simd32<uint32_t> operator-(const simd32<uint32_t> a,
+                                                 uint32_t b) {
+  return _mm256_sub_epi32(a.value, _mm256_set1_epi32(b));
+}
+
 simdutf_really_inline simd32<bool> operator==(const simd32<uint32_t> a,
                                               const simd32<uint32_t> b) {
   return _mm256_cmpeq_epi32(a.value, b.value);
+}
+
+simdutf_really_inline simd32<bool> operator==(const simd32<uint32_t> a,
+                                              const uint32_t b) {
+  return _mm256_cmpeq_epi32(a.value, _mm256_set1_epi32(b));
 }
 
 simdutf_really_inline simd32<bool> operator>=(const simd32<uint32_t> a,
@@ -108,4 +159,12 @@ simdutf_really_inline simd32<bool> operator!(const simd32<bool> v) {
 simdutf_really_inline simd32<bool> operator>(const simd32<uint32_t> a,
                                              const simd32<uint32_t> b) {
   return !(b >= a);
+}
+
+// ------------------------------------------------------------
+
+simdutf_really_inline simd32<uint32_t> select(const simd32<bool> cond,
+                                              const simd32<uint32_t> v_true,
+                                              const simd32<uint32_t> v_false) {
+  return _mm256_blendv_epi8(v_false.value, v_true.value, cond.value);
 }

--- a/tests/helpers/transcode_test_base.cpp
+++ b/tests/helpers/transcode_test_base.cpp
@@ -216,9 +216,7 @@ bool transcode_latin1_to_utf16_test_base::validate(size_t saved_chars) const {
                             const std::vector<char16_t> &array) {
     printf("%s", title);
     for (size_t i = 0; i < saved_chars; i++) {
-      printf(
-          " %04x",
-          (uint16_t)array[i]); // Use %04x to print 16-bit hexadecimal numbers
+      printf(" %04x", (uint16_t)array[i]);
     }
     putchar('\n');
   };
@@ -300,7 +298,7 @@ bool transcode_latin1_to_utf32_test_base::validate(size_t saved_chars) const {
                             const std::vector<char32_t> &array) {
     printf("%s", title);
     for (size_t i = 0; i < saved_chars; i++) {
-      printf(" %02x", (unsigned int)array[i]);
+      printf(" %08x", (uint32_t)array[i]);
     }
     putchar('\n');
   };
@@ -384,7 +382,7 @@ bool transcode_utf8_to_latin1_test_base::validate(size_t saved_chars) const {
   auto dump = [saved_chars](const char *title, const std::vector<char> &array) {
     printf("%s", title);
     for (size_t i = 0; i < saved_chars; i++) {
-      printf(" %02x", (char)array[i]);
+      printf(" %02x", (uint8_t)array[i]);
     }
     putchar('\n');
   };
@@ -490,7 +488,7 @@ bool transcode_utf16_to_latin1_test_base::validate(size_t saved_chars) const {
   auto dump = [saved_chars](const char *title, const std::vector<char> &array) {
     printf("%s", title);
     for (size_t i = 0; i < saved_chars; i++) {
-      printf(" %08x", (uint32_t)array[i]);
+      printf(" %02x", (uint8_t)array[i]);
     }
     putchar('\n');
   };
@@ -943,7 +941,7 @@ bool transcode_utf32_to_latin1_test_base::validate(size_t saved_chars) const {
   auto dump = [saved_chars](const char *title, const std::vector<char> &array) {
     printf("%s", title);
     for (size_t i = 0; i < saved_chars; i++) {
-      printf(" %02x", (char)array[i]);
+      printf(" %02x", (uint8_t)array[i]);
     }
     putchar('\n');
   };
@@ -1137,7 +1135,7 @@ bool transcode_utf32_to_utf16_test_base::validate(size_t saved_chars) const {
                             const std::vector<char16_t> &array) {
     printf("%s", title);
     for (size_t i = 0; i < saved_chars; i++) {
-      printf(" %02x", (uint16_t)array[i]);
+      printf(" %04x", (uint16_t)array[i]);
     }
     putchar('\n');
   };


### PR DESCRIPTION
Add vectorized code for surrogate pair generation. This is a port of the westmere solution.

### Ryzen

|                   dataset                    | size [B] | iterations | old GB/s | new GB/s | speedup |
| -------------------------------------------- | -------- | ---------- | -------- | -------- | ------- |
| convert_utf32_to_utf16be+haswell                                                                     |
| arabic.utf32                                 |  1699376 |      30000 |    47.81 |    47.88 | 1.00x   |
| chinese.utf32                                |   548832 |      30000 |    47.80 |    47.68 | 1.00x   |
| czech.utf32                                  |   575328 |      30000 |    47.98 |    47.86 | 1.00x   |
| english.utf32                                |  1550036 |      30000 |    47.58 |    46.56 | 0.98x   |
| esperanto.utf32                              |   336500 |      30000 |    47.78 |    47.64 | 1.00x   |
| french.utf32                                 |  1739468 |      30000 |    47.33 |    46.32 | 0.98x   |
| german.utf32                                 |   804860 |      30000 |    47.85 |    47.26 | 0.99x   |
| greek.utf32                                  |   571996 |      30000 |    47.86 |    47.69 | 1.00x   |
| hebrew.utf32                                 |   585404 |      30000 |    47.89 |    47.70 | 1.00x   |
| hindi.utf32                                  |  1095832 |      30000 |    47.23 |    46.82 | 0.99x   |
| japanese.utf32                               |   475564 |      30000 |    47.76 |    47.75 | 1.00x   |
| korean.utf32                                 |   291672 |      30000 |    47.73 |    47.73 | 1.00x   |
| persan.utf32                                 |   498776 |      30000 |    47.60 |    47.69 | 1.00x   |
| portuguese.utf32                             |  1094456 |      30000 |    46.68 |    45.29 | 0.97x   |
| russian.utf32                                |  1248148 |      30000 |    46.85 |    46.75 | 1.00x   |
| thai.utf32                                   |  1619032 |      30000 |    46.29 |    46.44 | 1.00x   |
| turkish.utf32                                |   741768 |      30000 |    47.55 |    47.37 | 1.00x   |
| vietnamese.utf32                             |  1129676 |      30000 |    47.16 |    46.88 | 0.99x   |
| convert_utf32_to_utf16be_with_errors+haswell                                                         |
| arabic.utf32                                 |  1699376 |      30000 |    47.74 |    34.71 | 0.73x   |
| chinese.utf32                                |   548832 |      30000 |    47.76 |    34.87 | 0.73x   |
| czech.utf32                                  |   575328 |      30000 |    48.01 |    35.00 | 0.73x   |
| english.utf32                                |  1550036 |      30000 |    46.85 |    34.18 | 0.73x   |
| esperanto.utf32                              |   336500 |      30000 |    47.85 |    34.95 | 0.73x   |
| french.utf32                                 |  1739468 |      30000 |    47.23 |    34.41 | 0.73x   |
| german.utf32                                 |   804860 |      30000 |    47.85 |    34.63 | 0.72x   |
| greek.utf32                                  |   571996 |      30000 |    47.86 |    34.85 | 0.73x   |
| hebrew.utf32                                 |   585404 |      30000 |    47.89 |    35.63 | 0.74x   |
| hindi.utf32                                  |  1095832 |      30000 |    47.19 |    35.16 | 0.75x   |
| japanese.utf32                               |   475564 |      30000 |    47.70 |    35.66 | 0.75x   |
| korean.utf32                                 |   291672 |      30000 |    47.73 |    35.81 | 0.75x   |
| persan.utf32                                 |   498776 |      30000 |    47.69 |    35.66 | 0.75x   |
| portuguese.utf32                             |  1094456 |      30000 |    46.66 |    34.72 | 0.74x   |
| russian.utf32                                |  1248148 |      30000 |    46.85 |    34.91 | 0.75x   |
| thai.utf32                                   |  1619032 |      30000 |    45.88 |    34.95 | 0.76x   |
| turkish.utf32                                |   741768 |      30000 |    47.74 |    35.56 | 0.74x   |
| vietnamese.utf32                             |  1129676 |      30000 |    46.77 |    35.15 | 0.75x   |
| convert_utf32_to_utf16le+haswell                                                                     |
| arabic.utf32                                 |  1699376 |      30000 |    55.67 |    55.63 | 1.00x   |
| chinese.utf32                                |   548832 |      30000 |    55.84 |    55.78 | 1.00x   |
| czech.utf32                                  |   575328 |      30000 |    55.86 |    53.77 | 0.96x   |
| english.utf32                                |  1550036 |      30000 |    55.20 |    53.48 | 0.97x   |
| esperanto.utf32                              |   336500 |      30000 |    56.36 |    55.70 | 0.99x   |
| french.utf32                                 |  1739468 |      30000 |    47.19 |    53.54 | 1.13x   |
| german.utf32                                 |   804860 |      30000 |    55.71 |    55.17 | 0.99x   |
| greek.utf32                                  |   571996 |      30000 |    55.81 |    53.31 | 0.96x   |
| hebrew.utf32                                 |   585404 |      30000 |    55.86 |    55.97 | 1.00x   |
| hindi.utf32                                  |  1095832 |      30000 |    54.88 |    46.80 | 0.85x   |
| japanese.utf32                               |   475564 |      30000 |    56.51 |    56.57 | 1.00x   |
| korean.utf32                                 |   291672 |      30000 |    56.54 |    56.86 | 1.01x   |
| persan.utf32                                 |   498776 |      30000 |    55.75 |    55.87 | 1.00x   |
| portuguese.utf32                             |  1094456 |      30000 |    55.37 |    53.55 | 0.97x   |
| russian.utf32                                |  1248148 |      30000 |    55.57 |    50.48 | 0.91x   |
| thai.utf32                                   |  1619032 |      30000 |    54.65 |    55.27 | 1.01x   |
| turkish.utf32                                |   741768 |      30000 |    55.38 |    54.76 | 0.99x   |
| vietnamese.utf32                             |  1129676 |      30000 |    54.90 |    54.37 | 0.99x   |
| convert_utf32_to_utf16le_with_errors+haswell                                                         |
| arabic.utf32                                 |  1699376 |      30000 |    51.56 |    38.03 | 0.74x   |
| chinese.utf32                                |   548832 |      30000 |    52.37 |    38.41 | 0.73x   |
| czech.utf32                                  |   575328 |      30000 |    53.22 |    39.22 | 0.74x   |
| english.utf32                                |  1550036 |      30000 |    49.88 |    38.29 | 0.77x   |
| esperanto.utf32                              |   336500 |      30000 |    53.31 |    39.15 | 0.73x   |
| french.utf32                                 |  1739468 |      30000 |    52.26 |    37.97 | 0.73x   |
| german.utf32                                 |   804860 |      30000 |    51.69 |    38.72 | 0.75x   |
| greek.utf32                                  |   571996 |      30000 |    53.25 |    38.89 | 0.73x   |
| hebrew.utf32                                 |   585404 |      30000 |    49.81 |    38.98 | 0.78x   |
| hindi.utf32                                  |  1095832 |      30000 |    48.94 |    38.50 | 0.79x   |
| japanese.utf32                               |   475564 |      30000 |    53.21 |    38.97 | 0.73x   |
| korean.utf32                                 |   291672 |      30000 |    53.32 |    39.18 | 0.73x   |
| persan.utf32                                 |   498776 |      30000 |    53.19 |    38.98 | 0.73x   |
| portuguese.utf32                             |  1094456 |      30000 |    48.55 |    37.58 | 0.77x   |
| russian.utf32                                |  1248148 |      30000 |    52.23 |    38.32 | 0.73x   |
| thai.utf32                                   |  1619032 |      30000 |    51.56 |    38.16 | 0.74x   |
| turkish.utf32                                |   741768 |      30000 |    52.77 |    39.01 | 0.74x   |
| vietnamese.utf32                             |  1129676 |      30000 |    49.76 |    38.46 | 0.77x   |

|                   dataset                    | size [B] | iterations | old GB/s | new GB/s | speedup |
| -------------------------------------------- | -------- | ---------- | -------- | -------- | ------- |
| convert_utf32_to_utf16be+haswell                                                                     |
| 256k_000perc_surrogates.utf32                |  1048576 |      30000 |    43.70 |    47.10 | 1.08x   |
| 256k_005perc_surrogates.utf32                |  1048576 |      30000 |     5.74 |     8.52 | 1.49x   |
| 256k_025perc_surrogates.utf32                |  1048576 |      30000 |     2.29 |     9.61 | 4.19x   |
| 256k_033perc_surrogates.utf32                |  1048576 |      30000 |     1.83 |    10.19 | 5.56x   |
| 256k_050perc_surrogates.utf32                |  1048576 |      30000 |     1.41 |    10.90 | 7.76x   |
| 256k_075perc_surrogates.utf32                |  1048576 |      30000 |     1.97 |    11.16 | 5.66x   |
| 256k_095perc_surrogates.utf32                |  1048576 |      30000 |     3.38 |    11.10 | 3.29x   |
| 64k_000perc_surrogates.utf32                 |   262144 |      30000 |    43.18 |    47.06 | 1.09x   |
| 64k_005perc_surrogates.utf32                 |   262144 |      30000 |    16.30 |    22.46 | 1.38x   |
| 64k_025perc_surrogates.utf32                 |   262144 |      30000 |     6.65 |    10.79 | 1.62x   |
| 64k_033perc_surrogates.utf32                 |   262144 |      30000 |     2.39 |    10.78 | 4.52x   |
| 64k_050perc_surrogates.utf32                 |   262144 |      30000 |     1.73 |    11.52 | 6.65x   |
| 64k_075perc_surrogates.utf32                 |   262144 |      30000 |     4.65 |    11.59 | 2.49x   |
| 64k_095perc_surrogates.utf32                 |   262144 |      30000 |     3.93 |    11.25 | 2.86x   |
| convert_utf32_to_utf16be_with_errors+haswell                                                         |
| 256k_000perc_surrogates.utf32                |  1048576 |      30000 |    43.55 |    34.42 | 0.79x   |
| 256k_005perc_surrogates.utf32                |  1048576 |      30000 |     5.68 |     8.42 | 1.48x   |
| 256k_025perc_surrogates.utf32                |  1048576 |      30000 |     2.30 |    11.47 | 4.99x   |
| 256k_033perc_surrogates.utf32                |  1048576 |      30000 |     1.85 |    11.82 | 6.39x   |
| 256k_050perc_surrogates.utf32                |  1048576 |      30000 |     1.41 |    12.78 | 9.08x   |
| 256k_075perc_surrogates.utf32                |  1048576 |      30000 |     1.96 |    13.16 | 6.72x   |
| 256k_095perc_surrogates.utf32                |  1048576 |      30000 |     3.38 |    13.03 | 3.86x   |
| 64k_000perc_surrogates.utf32                 |   262144 |      30000 |    42.97 |    35.55 | 0.83x   |
| 64k_005perc_surrogates.utf32                 |   262144 |      30000 |    16.41 |    21.14 | 1.29x   |
| 64k_025perc_surrogates.utf32                 |   262144 |      30000 |     6.96 |    13.54 | 1.95x   |
| 64k_033perc_surrogates.utf32                 |   262144 |      30000 |     2.45 |    12.68 | 5.18x   |
| 64k_050perc_surrogates.utf32                 |   262144 |      30000 |     1.75 |    13.54 | 7.73x   |
| 64k_075perc_surrogates.utf32                 |   262144 |      30000 |     4.70 |    13.64 | 2.90x   |
| 64k_095perc_surrogates.utf32                 |   262144 |      30000 |     3.98 |    13.16 | 3.31x   |
| convert_utf32_to_utf16le+haswell                                                                     |
| 256k_000perc_surrogates.utf32                |  1048576 |      30000 |    53.78 |    54.74 | 1.02x   |
| 256k_005perc_surrogates.utf32                |  1048576 |      30000 |     6.07 |     9.15 | 1.51x   |
| 256k_025perc_surrogates.utf32                |  1048576 |      30000 |     2.38 |    10.26 | 4.32x   |
| 256k_033perc_surrogates.utf32                |  1048576 |      30000 |     1.92 |    10.89 | 5.68x   |
| 256k_050perc_surrogates.utf32                |  1048576 |      30000 |     1.51 |    11.81 | 7.84x   |
| 256k_075perc_surrogates.utf32                |  1048576 |      30000 |     2.33 |    12.05 | 5.18x   |
| 256k_095perc_surrogates.utf32                |  1048576 |      30000 |     5.01 |    12.00 | 2.39x   |
| 64k_000perc_surrogates.utf32                 |   262144 |      30000 |    51.20 |    54.51 | 1.06x   |
| 64k_005perc_surrogates.utf32                 |   262144 |      30000 |    19.04 |    24.43 | 1.28x   |
| 64k_025perc_surrogates.utf32                 |   262144 |      30000 |     7.42 |    11.61 | 1.56x   |
| 64k_033perc_surrogates.utf32                 |   262144 |      30000 |     2.58 |    11.53 | 4.46x   |
| 64k_050perc_surrogates.utf32                 |   262144 |      30000 |     1.88 |    12.46 | 6.63x   |
| 64k_075perc_surrogates.utf32                 |   262144 |      30000 |     6.50 |    12.59 | 1.94x   |
| 64k_095perc_surrogates.utf32                 |   262144 |      30000 |     6.39 |    12.11 | 1.90x   |
| convert_utf32_to_utf16le_with_errors+haswell                                                         |
| 256k_000perc_surrogates.utf32                |  1048576 |      30000 |    51.18 |    38.32 | 0.75x   |
| 256k_005perc_surrogates.utf32                |  1048576 |      30000 |     5.89 |     8.26 | 1.40x   |
| 256k_025perc_surrogates.utf32                |  1048576 |      30000 |     2.37 |    11.05 | 4.66x   |
| 256k_033perc_surrogates.utf32                |  1048576 |      30000 |     1.90 |    11.96 | 6.29x   |
| 256k_050perc_surrogates.utf32                |  1048576 |      30000 |     1.49 |    12.92 | 8.68x   |
| 256k_075perc_surrogates.utf32                |  1048576 |      30000 |     2.31 |    13.22 | 5.72x   |
| 256k_095perc_surrogates.utf32                |  1048576 |      30000 |     5.03 |    13.07 | 2.60x   |
| 64k_000perc_surrogates.utf32                 |   262144 |      30000 |    47.05 |    38.70 | 0.82x   |
| 64k_005perc_surrogates.utf32                 |   262144 |      30000 |    17.52 |    22.87 | 1.31x   |
| 64k_025perc_surrogates.utf32                 |   262144 |      30000 |     7.51 |    13.69 | 1.82x   |
| 64k_033perc_surrogates.utf32                 |   262144 |      30000 |     2.63 |    12.77 | 4.86x   |
| 64k_050perc_surrogates.utf32                 |   262144 |      30000 |     1.89 |    13.63 | 7.23x   |
| 64k_075perc_surrogates.utf32                 |   262144 |      30000 |     6.77 |    13.73 | 2.03x   |
| 64k_095perc_surrogates.utf32                 |   262144 |      30000 |     6.35 |    13.23 | 2.08x   |

### Skylake-X

|                   dataset                    | size [B] | iterations | old GB/s | new GB/s | speedup |
| -------------------------------------------- | -------- | ---------- | -------- | -------- | ------- |
| convert_utf32_to_utf16be+haswell                                                                     |
| arabic.utf32                                 |  1699376 |      30000 |    12.46 |    13.73 | 1.10x   |
| chinese.utf32                                |   548832 |      30000 |    17.93 |    17.59 | 0.98x   |
| czech.utf32                                  |   575328 |      30000 |    17.49 |    17.46 | 1.00x   |
| english.utf32                                |  1550036 |      30000 |    12.48 |    13.76 | 1.10x   |
| esperanto.utf32                              |   336500 |      30000 |    18.37 |    17.92 | 0.98x   |
| french.utf32                                 |  1739468 |      30000 |    13.30 |    14.33 | 1.08x   |
| german.utf32                                 |   804860 |      30000 |    14.99 |    15.64 | 1.04x   |
| greek.utf32                                  |   571996 |      30000 |    17.46 |    17.45 | 1.00x   |
| hebrew.utf32                                 |   585404 |      30000 |    17.09 |    17.38 | 1.02x   |
| hindi.utf32                                  |  1095832 |      30000 |    13.08 |    14.20 | 1.09x   |
| japanese.utf32                               |   475564 |      30000 |    18.07 |    17.78 | 0.98x   |
| korean.utf32                                 |   291672 |      30000 |    18.33 |    17.91 | 0.98x   |
| persan.utf32                                 |   498776 |      30000 |    18.08 |    17.77 | 0.98x   |
| portuguese.utf32                             |  1094456 |      30000 |    13.03 |    14.17 | 1.09x   |
| russian.utf32                                |  1248148 |      30000 |    13.14 |    14.24 | 1.08x   |
| thai.utf32                                   |  1619032 |      30000 |    12.59 |    13.91 | 1.10x   |
| turkish.utf32                                |   741768 |      30000 |    15.33 |    16.16 | 1.05x   |
| vietnamese.utf32                             |  1129676 |      30000 |    13.73 |    14.54 | 1.06x   |
| convert_utf32_to_utf16be_with_errors+haswell                                                         |
| arabic.utf32                                 |  1699376 |      30000 |    12.49 |    13.28 | 1.06x   |
| chinese.utf32                                |   548832 |      30000 |    16.33 |    15.26 | 0.93x   |
| czech.utf32                                  |   575328 |      30000 |    16.10 |    15.24 | 0.95x   |
| english.utf32                                |  1550036 |      30000 |    12.29 |    13.07 | 1.06x   |
| esperanto.utf32                              |   336500 |      30000 |    16.58 |    15.47 | 0.93x   |
| french.utf32                                 |  1739468 |      30000 |    13.15 |    13.94 | 1.06x   |
| german.utf32                                 |   804860 |      30000 |    14.32 |    14.23 | 0.99x   |
| greek.utf32                                  |   571996 |      30000 |    16.06 |    15.29 | 0.95x   |
| hebrew.utf32                                 |   585404 |      30000 |    15.75 |    15.13 | 0.96x   |
| hindi.utf32                                  |  1095832 |      30000 |    12.76 |    13.41 | 1.05x   |
| japanese.utf32                               |   475564 |      30000 |    16.43 |    15.38 | 0.94x   |
| korean.utf32                                 |   291672 |      30000 |    16.57 |    15.43 | 0.93x   |
| persan.utf32                                 |   498776 |      30000 |    16.45 |    15.39 | 0.94x   |
| portuguese.utf32                             |  1094456 |      30000 |    12.74 |    13.43 | 1.05x   |
| russian.utf32                                |  1248148 |      30000 |    12.94 |    13.66 | 1.06x   |
| thai.utf32                                   |  1619032 |      30000 |    12.40 |    13.29 | 1.07x   |
| turkish.utf32                                |   741768 |      30000 |    14.68 |    14.66 | 1.00x   |
| vietnamese.utf32                             |  1129676 |      30000 |    13.49 |    13.90 | 1.03x   |
| convert_utf32_to_utf16le+haswell                                                                     |
| arabic.utf32                                 |  1699376 |      30000 |    13.00 |    14.03 | 1.08x   |
| chinese.utf32                                |   548832 |      30000 |    18.55 |    16.52 | 0.89x   |
| czech.utf32                                  |   575328 |      30000 |    18.28 |    16.53 | 0.90x   |
| english.utf32                                |  1550036 |      30000 |    12.70 |    13.78 | 1.09x   |
| esperanto.utf32                              |   336500 |      30000 |    19.00 |    16.52 | 0.87x   |
| french.utf32                                 |  1739468 |      30000 |    13.50 |    14.41 | 1.07x   |
| german.utf32                                 |   804860 |      30000 |    15.44 |    15.45 | 1.00x   |
| greek.utf32                                  |   571996 |      30000 |    18.24 |    16.56 | 0.91x   |
| hebrew.utf32                                 |   585404 |      30000 |    17.75 |    16.42 | 0.93x   |
| hindi.utf32                                  |  1095832 |      30000 |    13.32 |    14.19 | 1.07x   |
| japanese.utf32                               |   475564 |      30000 |    18.78 |    16.59 | 0.88x   |
| korean.utf32                                 |   291672 |      30000 |    18.94 |    16.44 | 0.87x   |
| persan.utf32                                 |   498776 |      30000 |    18.78 |    16.59 | 0.88x   |
| portuguese.utf32                             |  1094456 |      30000 |    13.30 |    14.18 | 1.07x   |
| russian.utf32                                |  1248148 |      30000 |    13.30 |    14.31 | 1.08x   |
| thai.utf32                                   |  1619032 |      30000 |    12.83 |    13.93 | 1.09x   |
| turkish.utf32                                |   741768 |      30000 |    15.83 |    15.87 | 1.00x   |
| vietnamese.utf32                             |  1129676 |      30000 |    13.86 |    14.61 | 1.05x   |
| convert_utf32_to_utf16le_with_errors+haswell                                                         |
| arabic.utf32                                 |  1699376 |      30000 |    12.52 |    13.62 | 1.09x   |
| chinese.utf32                                |   548832 |      30000 |    16.20 |    16.11 | 0.99x   |
| czech.utf32                                  |   575328 |      30000 |    16.01 |    16.03 | 1.00x   |
| english.utf32                                |  1550036 |      30000 |    12.33 |    13.45 | 1.09x   |
| esperanto.utf32                              |   336500 |      30000 |    16.53 |    16.32 | 0.99x   |
| french.utf32                                 |  1739468 |      30000 |    13.22 |    14.17 | 1.07x   |
| german.utf32                                 |   804860 |      30000 |    14.32 |    14.82 | 1.04x   |
| greek.utf32                                  |   571996 |      30000 |    16.02 |    16.06 | 1.00x   |
| hebrew.utf32                                 |   585404 |      30000 |    15.68 |    15.93 | 1.02x   |
| hindi.utf32                                  |  1095832 |      30000 |    12.78 |    13.74 | 1.07x   |
| japanese.utf32                               |   475564 |      30000 |    16.28 |    16.20 | 0.99x   |
| korean.utf32                                 |   291672 |      30000 |    16.47 |    16.29 | 0.99x   |
| persan.utf32                                 |   498776 |      30000 |    16.29 |    16.22 | 1.00x   |
| portuguese.utf32                             |  1094456 |      30000 |    12.79 |    13.76 | 1.08x   |
| russian.utf32                                |  1248148 |      30000 |    13.00 |    13.91 | 1.07x   |
| thai.utf32                                   |  1619032 |      30000 |    12.41 |    13.59 | 1.09x   |
| turkish.utf32                                |   741768 |      30000 |    14.65 |    15.23 | 1.04x   |
| vietnamese.utf32                             |  1129676 |      30000 |    13.48 |    14.26 | 1.06x   |

|                   dataset                    | size [B] | iterations | old GB/s | new GB/s | speedup |
| -------------------------------------------- | -------- | ---------- | -------- | -------- | ------- |
| convert_utf32_to_utf16be+haswell                                                                     |
| 256k_000perc_surrogates.utf32                |  1048576 |      30000 |    13.74 |    14.02 | 1.02x   |
| 256k_005perc_surrogates.utf32                |  1048576 |      30000 |     2.69 |     5.29 | 1.97x   |
| 256k_025perc_surrogates.utf32                |  1048576 |      30000 |     1.05 |     5.80 | 5.52x   |
| 256k_033perc_surrogates.utf32                |  1048576 |      30000 |     0.86 |     6.15 | 7.19x   |
| 256k_050perc_surrogates.utf32                |  1048576 |      30000 |     0.67 |     6.41 | 9.53x   |
| 256k_075perc_surrogates.utf32                |  1048576 |      30000 |     0.72 |     6.45 | 8.93x   |
| 256k_095perc_surrogates.utf32                |  1048576 |      30000 |     0.88 |     6.45 | 7.36x   |
| 64k_000perc_surrogates.utf32                 |   262144 |      30000 |    18.26 |    17.82 | 0.98x   |
| 64k_005perc_surrogates.utf32                 |   262144 |      30000 |     3.42 |     6.45 | 1.88x   |
| 64k_025perc_surrogates.utf32                 |   262144 |      30000 |     1.09 |     6.44 | 5.92x   |
| 64k_033perc_surrogates.utf32                 |   262144 |      30000 |     0.88 |     6.25 | 7.14x   |
| 64k_050perc_surrogates.utf32                 |   262144 |      30000 |     0.68 |     6.41 | 9.38x   |
| 64k_075perc_surrogates.utf32                 |   262144 |      30000 |     0.73 |     6.43 | 8.75x   |
| 64k_095perc_surrogates.utf32                 |   262144 |      30000 |     0.92 |     6.41 | 7.00x   |
| convert_utf32_to_utf16be_with_errors+haswell                                                         |
| 256k_000perc_surrogates.utf32                |  1048576 |      30000 |    13.99 |    13.77 | 0.98x   |
| 256k_005perc_surrogates.utf32                |  1048576 |      30000 |     2.51 |     4.10 | 1.63x   |
| 256k_025perc_surrogates.utf32                |  1048576 |      30000 |     1.03 |     5.64 | 5.48x   |
| 256k_033perc_surrogates.utf32                |  1048576 |      30000 |     0.84 |     6.22 | 7.38x   |
| 256k_050perc_surrogates.utf32                |  1048576 |      30000 |     0.66 |     6.62 | 10.08x  |
| 256k_075perc_surrogates.utf32                |  1048576 |      30000 |     0.70 |     6.68 | 9.49x   |
| 256k_095perc_surrogates.utf32                |  1048576 |      30000 |     0.85 |     6.68 | 7.85x   |
| 64k_000perc_surrogates.utf32                 |   262144 |      30000 |    16.51 |    15.38 | 0.93x   |
| 64k_005perc_surrogates.utf32                 |   262144 |      30000 |     3.11 |     5.30 | 1.70x   |
| 64k_025perc_surrogates.utf32                 |   262144 |      30000 |     1.06 |     6.51 | 6.11x   |
| 64k_033perc_surrogates.utf32                 |   262144 |      30000 |     0.86 |     6.37 | 7.39x   |
| 64k_050perc_surrogates.utf32                 |   262144 |      30000 |     0.67 |     6.61 | 9.92x   |
| 64k_075perc_surrogates.utf32                 |   262144 |      30000 |     0.72 |     6.64 | 9.26x   |
| 64k_095perc_surrogates.utf32                 |   262144 |      30000 |     0.89 |     6.62 | 7.47x   |
| convert_utf32_to_utf16le+haswell                                                                     |
| 256k_000perc_surrogates.utf32                |  1048576 |      30000 |    14.46 |    14.46 | 1.00x   |
| 256k_005perc_surrogates.utf32                |  1048576 |      30000 |     2.72 |     4.76 | 1.75x   |
| 256k_025perc_surrogates.utf32                |  1048576 |      30000 |     1.09 |     5.60 | 5.15x   |
| 256k_033perc_surrogates.utf32                |  1048576 |      30000 |     0.89 |     6.10 | 6.86x   |
| 256k_050perc_surrogates.utf32                |  1048576 |      30000 |     0.71 |     6.46 | 9.12x   |
| 256k_075perc_surrogates.utf32                |  1048576 |      30000 |     0.77 |     6.50 | 8.49x   |
| 256k_095perc_surrogates.utf32                |  1048576 |      30000 |     0.91 |     6.50 | 7.14x   |
| 64k_000perc_surrogates.utf32                 |   262144 |      30000 |    18.91 |    16.38 | 0.87x   |
| 64k_005perc_surrogates.utf32                 |   262144 |      30000 |     3.46 |     5.73 | 1.66x   |
| 64k_025perc_surrogates.utf32                 |   262144 |      30000 |     1.12 |     6.36 | 5.69x   |
| 64k_033perc_surrogates.utf32                 |   262144 |      30000 |     0.91 |     6.19 | 6.79x   |
| 64k_050perc_surrogates.utf32                 |   262144 |      30000 |     0.72 |     6.45 | 8.97x   |
| 64k_075perc_surrogates.utf32                 |   262144 |      30000 |     0.79 |     6.46 | 8.15x   |
| 64k_095perc_surrogates.utf32                 |   262144 |      30000 |     0.93 |     6.45 | 6.97x   |
| convert_utf32_to_utf16le_with_errors+haswell                                                         |
| 256k_000perc_surrogates.utf32                |  1048576 |      30000 |    13.69 |    14.06 | 1.03x   |
| 256k_005perc_surrogates.utf32                |  1048576 |      30000 |     2.58 |     4.88 | 1.89x   |
| 256k_025perc_surrogates.utf32                |  1048576 |      30000 |     1.06 |     6.04 | 5.72x   |
| 256k_033perc_surrogates.utf32                |  1048576 |      30000 |     0.86 |     6.59 | 7.63x   |
| 256k_050perc_surrogates.utf32                |  1048576 |      30000 |     0.68 |     6.98 | 10.21x  |
| 256k_075perc_surrogates.utf32                |  1048576 |      30000 |     0.75 |     7.03 | 9.41x   |
| 256k_095perc_surrogates.utf32                |  1048576 |      30000 |     0.91 |     7.02 | 7.74x   |
| 64k_000perc_surrogates.utf32                 |   262144 |      30000 |    16.37 |    16.20 | 0.99x   |
| 64k_005perc_surrogates.utf32                 |   262144 |      30000 |     3.28 |     6.04 | 1.84x   |
| 64k_025perc_surrogates.utf32                 |   262144 |      30000 |     1.08 |     6.31 | 5.82x   |
| 64k_033perc_surrogates.utf32                 |   262144 |      30000 |     0.89 |     6.58 | 7.43x   |
| 64k_050perc_surrogates.utf32                 |   262144 |      30000 |     0.69 |     6.98 | 10.04x  |
| 64k_075perc_surrogates.utf32                 |   262144 |      30000 |     0.77 |     6.99 | 9.11x   |
| 64k_095perc_surrogates.utf32                 |   262144 |      30000 |     0.92 |     6.97 | 7.58x   |

### IceLake

|                   dataset                    | size [B] | iterations | old GB/s | new GB/s | speedup |
| -------------------------------------------- | -------- | ---------- | -------- | -------- | ------- |
| convert_utf32_to_utf16be+haswell                                                                     |
| arabic.utf32                                 |  1699376 |      30000 |    18.50 |    18.30 | 0.99x   |
| chinese.utf32                                |   548832 |      30000 |    22.01 |    21.43 | 0.97x   |
| czech.utf32                                  |   575328 |      30000 |    21.97 |    21.42 | 0.98x   |
| english.utf32                                |  1550036 |      30000 |    18.73 |    18.47 | 0.99x   |
| esperanto.utf32                              |   336500 |      30000 |    22.07 |    21.43 | 0.97x   |
| french.utf32                                 |  1739468 |      30000 |    18.91 |    18.60 | 0.98x   |
| german.utf32                                 |   804860 |      30000 |    21.48 |    20.97 | 0.98x   |
| greek.utf32                                  |   571996 |      30000 |    21.96 |    21.45 | 0.98x   |
| hebrew.utf32                                 |   585404 |      30000 |    21.96 |    21.42 | 0.98x   |
| hindi.utf32                                  |  1095832 |      30000 |    19.39 |    19.18 | 0.99x   |
| japanese.utf32                               |   475564 |      30000 |    21.99 |    21.43 | 0.97x   |
| korean.utf32                                 |   291672 |      30000 |    21.99 |    21.47 | 0.98x   |
| persan.utf32                                 |   498776 |      30000 |    21.99 |    21.43 | 0.97x   |
| portuguese.utf32                             |  1094456 |      30000 |    19.90 |    19.64 | 0.99x   |
| russian.utf32                                |  1248148 |      30000 |    19.02 |    18.74 | 0.99x   |
| thai.utf32                                   |  1619032 |      30000 |    19.44 |    19.21 | 0.99x   |
| turkish.utf32                                |   741768 |      30000 |    21.56 |    21.02 | 0.98x   |
| vietnamese.utf32                             |  1129676 |      30000 |    19.73 |    19.45 | 0.99x   |
| convert_utf32_to_utf16be_with_errors+haswell                                                         |
| arabic.utf32                                 |  1699376 |      30000 |    17.47 |    16.81 | 0.96x   |
| chinese.utf32                                |   548832 |      30000 |    19.71 |    18.47 | 0.94x   |
| czech.utf32                                  |   575328 |      30000 |    19.68 |    18.46 | 0.94x   |
| english.utf32                                |  1550036 |      30000 |    17.60 |    16.98 | 0.96x   |
| esperanto.utf32                              |   336500 |      30000 |    19.70 |    18.50 | 0.94x   |
| french.utf32                                 |  1739468 |      30000 |    17.64 |    16.96 | 0.96x   |
| german.utf32                                 |   804860 |      30000 |    19.24 |    18.06 | 0.94x   |
| greek.utf32                                  |   571996 |      30000 |    19.64 |    18.46 | 0.94x   |
| hebrew.utf32                                 |   585404 |      30000 |    19.63 |    18.45 | 0.94x   |
| hindi.utf32                                  |  1095832 |      30000 |    17.94 |    17.17 | 0.96x   |
| japanese.utf32                               |   475564 |      30000 |    19.71 |    18.49 | 0.94x   |
| korean.utf32                                 |   291672 |      30000 |    19.69 |    18.53 | 0.94x   |
| persan.utf32                                 |   498776 |      30000 |    19.69 |    18.47 | 0.94x   |
| portuguese.utf32                             |  1094456 |      30000 |    18.34 |    17.48 | 0.95x   |
| russian.utf32                                |  1248148 |      30000 |    17.86 |    17.19 | 0.96x   |
| thai.utf32                                   |  1619032 |      30000 |    18.27 |    17.53 | 0.96x   |
| turkish.utf32                                |   741768 |      30000 |    19.32 |    18.16 | 0.94x   |
| vietnamese.utf32                             |  1129676 |      30000 |    18.20 |    17.40 | 0.96x   |
| convert_utf32_to_utf16le+haswell                                                                     |
| arabic.utf32                                 |  1699376 |      30000 |    18.67 |    18.36 | 0.98x   |
| chinese.utf32                                |   548832 |      30000 |    21.92 |    21.23 | 0.97x   |
| czech.utf32                                  |   575328 |      30000 |    21.92 |    21.23 | 0.97x   |
| english.utf32                                |  1550036 |      30000 |    18.80 |    18.51 | 0.98x   |
| esperanto.utf32                              |   336500 |      30000 |    22.08 |    21.25 | 0.96x   |
| french.utf32                                 |  1739468 |      30000 |    19.00 |    18.68 | 0.98x   |
| german.utf32                                 |   804860 |      30000 |    21.32 |    20.83 | 0.98x   |
| greek.utf32                                  |   571996 |      30000 |    21.68 |    21.22 | 0.98x   |
| hebrew.utf32                                 |   585404 |      30000 |    21.84 |    21.24 | 0.97x   |
| hindi.utf32                                  |  1095832 |      30000 |    19.45 |    19.13 | 0.98x   |
| japanese.utf32                               |   475564 |      30000 |    21.94 |    21.25 | 0.97x   |
| korean.utf32                                 |   291672 |      30000 |    22.02 |    21.25 | 0.96x   |
| persan.utf32                                 |   498776 |      30000 |    21.98 |    21.24 | 0.97x   |
| portuguese.utf32                             |  1094456 |      30000 |    19.88 |    19.55 | 0.98x   |
| russian.utf32                                |  1248148 |      30000 |    19.13 |    18.78 | 0.98x   |
| thai.utf32                                   |  1619032 |      30000 |    19.46 |    19.20 | 0.99x   |
| turkish.utf32                                |   741768 |      30000 |    21.38 |    20.92 | 0.98x   |
| vietnamese.utf32                             |  1129676 |      30000 |    19.73 |    19.37 | 0.98x   |
| convert_utf32_to_utf16le_with_errors+haswell                                                         |
| arabic.utf32                                 |  1699376 |      30000 |    17.64 |    16.83 | 0.95x   |
| chinese.utf32                                |   548832 |      30000 |    20.11 |    18.40 | 0.92x   |
| czech.utf32                                  |   575328 |      30000 |    20.12 |    18.38 | 0.91x   |
| english.utf32                                |  1550036 |      30000 |    17.80 |    16.97 | 0.95x   |
| esperanto.utf32                              |   336500 |      30000 |    20.16 |    18.40 | 0.91x   |
| french.utf32                                 |  1739468 |      30000 |    17.83 |    16.95 | 0.95x   |
| german.utf32                                 |   804860 |      30000 |    19.64 |    18.03 | 0.92x   |
| greek.utf32                                  |   571996 |      30000 |    19.92 |    18.38 | 0.92x   |
| hebrew.utf32                                 |   585404 |      30000 |    20.07 |    18.37 | 0.92x   |
| hindi.utf32                                  |  1095832 |      30000 |    18.17 |    17.19 | 0.95x   |
| japanese.utf32                               |   475564 |      30000 |    20.13 |    18.38 | 0.91x   |
| korean.utf32                                 |   291672 |      30000 |    20.13 |    18.40 | 0.91x   |
| persan.utf32                                 |   498776 |      30000 |    20.13 |    18.39 | 0.91x   |
| portuguese.utf32                             |  1094456 |      30000 |    18.57 |    17.46 | 0.94x   |
| russian.utf32                                |  1248148 |      30000 |    18.07 |    17.16 | 0.95x   |
| thai.utf32                                   |  1619032 |      30000 |    18.45 |    17.49 | 0.95x   |
| turkish.utf32                                |   741768 |      30000 |    19.70 |    18.09 | 0.92x   |
| vietnamese.utf32                             |  1129676 |      30000 |    18.42 |    17.34 | 0.94x   |

|                   dataset                    | size [B] | iterations | old GB/s | new GB/s | speedup |
| -------------------------------------------- | -------- | ---------- | -------- | -------- | ------- |
| convert_utf32_to_utf16be+haswell                                                                     |
| 256k_000perc_surrogates.utf32                |  1048576 |      30000 |    19.60 |    19.30 | 0.98x   |
| 256k_005perc_surrogates.utf32                |  1048576 |      30000 |     4.00 |     6.25 | 1.56x   |
| 256k_025perc_surrogates.utf32                |  1048576 |      30000 |     1.49 |     7.74 | 5.20x   |
| 256k_033perc_surrogates.utf32                |  1048576 |      30000 |     1.18 |     7.74 | 6.56x   |
| 256k_050perc_surrogates.utf32                |  1048576 |      30000 |     0.93 |     7.84 | 8.41x   |
| 256k_075perc_surrogates.utf32                |  1048576 |      30000 |     1.39 |     7.82 | 5.61x   |
| 256k_095perc_surrogates.utf32                |  1048576 |      30000 |     2.89 |     7.85 | 2.71x   |
| 64k_000perc_surrogates.utf32                 |   262144 |      30000 |    22.02 |    21.44 | 0.97x   |
| 64k_005perc_surrogates.utf32                 |   262144 |      30000 |    11.85 |    13.24 | 1.12x   |
| 64k_025perc_surrogates.utf32                 |   262144 |      30000 |     1.94 |     8.34 | 4.31x   |
| 64k_033perc_surrogates.utf32                 |   262144 |      30000 |     1.46 |     8.00 | 5.48x   |
| 64k_050perc_surrogates.utf32                 |   262144 |      30000 |     1.08 |     7.90 | 7.29x   |
| 64k_075perc_surrogates.utf32                 |   262144 |      30000 |     1.81 |     7.87 | 4.33x   |
| 64k_095perc_surrogates.utf32                 |   262144 |      30000 |     3.49 |     7.92 | 2.27x   |
| convert_utf32_to_utf16be_with_errors+haswell                                                         |
| 256k_000perc_surrogates.utf32                |  1048576 |      30000 |    18.22 |    17.38 | 0.95x   |
| 256k_005perc_surrogates.utf32                |  1048576 |      30000 |     3.80 |     6.33 | 1.66x   |
| 256k_025perc_surrogates.utf32                |  1048576 |      30000 |     1.49 |     7.91 | 5.31x   |
| 256k_033perc_surrogates.utf32                |  1048576 |      30000 |     1.19 |     7.84 | 6.58x   |
| 256k_050perc_surrogates.utf32                |  1048576 |      30000 |     0.92 |     7.91 | 8.56x   |
| 256k_075perc_surrogates.utf32                |  1048576 |      30000 |     1.41 |     7.91 | 5.62x   |
| 256k_095perc_surrogates.utf32                |  1048576 |      30000 |     2.93 |     7.95 | 2.72x   |
| 64k_000perc_surrogates.utf32                 |   262144 |      30000 |    19.69 |    18.48 | 0.94x   |
| 64k_005perc_surrogates.utf32                 |   262144 |      30000 |     8.45 |    12.88 | 1.52x   |
| 64k_025perc_surrogates.utf32                 |   262144 |      30000 |     1.97 |     8.42 | 4.29x   |
| 64k_033perc_surrogates.utf32                 |   262144 |      30000 |     1.47 |     8.04 | 5.45x   |
| 64k_050perc_surrogates.utf32                 |   262144 |      30000 |     1.07 |     7.95 | 7.40x   |
| 64k_075perc_surrogates.utf32                 |   262144 |      30000 |     1.78 |     7.96 | 4.47x   |
| 64k_095perc_surrogates.utf32                 |   262144 |      30000 |     3.50 |     8.02 | 2.29x   |
| convert_utf32_to_utf16le+haswell                                                                     |
| 256k_000perc_surrogates.utf32                |  1048576 |      30000 |    19.94 |    19.64 | 0.99x   |
| 256k_005perc_surrogates.utf32                |  1048576 |      30000 |     4.13 |     6.34 | 1.54x   |
| 256k_025perc_surrogates.utf32                |  1048576 |      30000 |     1.54 |     7.71 | 5.01x   |
| 256k_033perc_surrogates.utf32                |  1048576 |      30000 |     1.21 |     7.77 | 6.41x   |
| 256k_050perc_surrogates.utf32                |  1048576 |      30000 |     0.97 |     7.88 | 8.16x   |
| 256k_075perc_surrogates.utf32                |  1048576 |      30000 |     1.47 |     7.88 | 5.37x   |
| 256k_095perc_surrogates.utf32                |  1048576 |      30000 |     3.11 |     7.92 | 2.55x   |
| 64k_000perc_surrogates.utf32                 |   262144 |      30000 |    22.14 |    21.28 | 0.96x   |
| 64k_005perc_surrogates.utf32                 |   262144 |      30000 |    13.15 |    13.41 | 1.02x   |
| 64k_025perc_surrogates.utf32                 |   262144 |      30000 |     2.03 |     8.40 | 4.14x   |
| 64k_033perc_surrogates.utf32                 |   262144 |      30000 |     1.50 |     8.01 | 5.32x   |
| 64k_050perc_surrogates.utf32                 |   262144 |      30000 |     1.13 |     7.93 | 7.04x   |
| 64k_075perc_surrogates.utf32                 |   262144 |      30000 |     1.68 |     7.94 | 4.72x   |
| 64k_095perc_surrogates.utf32                 |   262144 |      30000 |     4.14 |     7.99 | 1.93x   |
| convert_utf32_to_utf16le_with_errors+haswell                                                         |
| 256k_000perc_surrogates.utf32                |  1048576 |      30000 |    18.51 |    17.35 | 0.94x   |
| 256k_005perc_surrogates.utf32                |  1048576 |      30000 |     3.89 |     6.24 | 1.60x   |
| 256k_025perc_surrogates.utf32                |  1048576 |      30000 |     1.53 |     7.57 | 4.95x   |
| 256k_033perc_surrogates.utf32                |  1048576 |      30000 |     1.21 |     7.75 | 6.40x   |
| 256k_050perc_surrogates.utf32                |  1048576 |      30000 |     0.96 |     8.04 | 8.38x   |
| 256k_075perc_surrogates.utf32                |  1048576 |      30000 |     1.48 |     8.04 | 5.43x   |
| 256k_095perc_surrogates.utf32                |  1048576 |      30000 |     3.29 |     8.09 | 2.46x   |
| 64k_000perc_surrogates.utf32                 |   262144 |      30000 |    20.14 |    18.42 | 0.91x   |
| 64k_005perc_surrogates.utf32                 |   262144 |      30000 |     7.97 |    13.04 | 1.64x   |
| 64k_025perc_surrogates.utf32                 |   262144 |      30000 |     2.02 |     8.54 | 4.23x   |
| 64k_033perc_surrogates.utf32                 |   262144 |      30000 |     1.51 |     8.03 | 5.33x   |
| 64k_050perc_surrogates.utf32                 |   262144 |      30000 |     1.11 |     8.10 | 7.27x   |
| 64k_075perc_surrogates.utf32                 |   262144 |      30000 |     1.87 |     8.10 | 4.32x   |
| 64k_095perc_surrogates.utf32                 |   262144 |      30000 |     3.97 |     8.17 | 2.06x   |
