### PR TITLE
rvv: simplify UTF-32 to UTF-{8,16}

### DIFF
--- a/src/rvv/rvv_utf32_to.inl.cpp
+++ b/src/rvv/rvv_utf32_to.inl.cpp
@@ -88,23 +88,18 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
       n -= vl, src += vl, dst += vlOut;
       continue;
     }
-    long idx1 =
+    const long idx1 =
         __riscv_vfirst_m_b8(__riscv_vmsgtu_vx_u32m4_b8(v, 0x10FFFF, vl), vl);
     vbool8_t sur = __riscv_vmseq_vx_u32m4_b8(
         __riscv_vand_vx_u32m4(v, 0xFFFFF800, vl), 0xD800, vl);
-    long idx2 = __riscv_vfirst_m_b8(sur, vl);
-    if (idx1 >= 0 && idx2 >= 0) {
-      if (idx1 <= idx2) {
+    const long idx2 = __riscv_vfirst_m_b8(sur, vl);
+    if (idx1 >= 0 || idx2 >= 0) {
+      if (static_cast<unsigned long>(idx1) <=
+          static_cast<unsigned long>(idx2)) {
         return result(error_code::TOO_LARGE, src - srcBeg + idx1);
       } else {
         return result(error_code::SURROGATE, src - srcBeg + idx2);
       }
-    }
-    if (idx1 >= 0) {
-      return result(error_code::TOO_LARGE, src - srcBeg + idx1);
-    }
-    if (idx2 >= 0) {
-      return result(error_code::SURROGATE, src - srcBeg + idx2);
     }
 
     vbool8_t m4 = __riscv_vmsgtu_vx_u32m4_b8(v, 0x10000 - 1, vl);
@@ -198,20 +193,19 @@ rvv_convert_utf32_to_utf16_with_errors(const char32_t *src, size_t len,
     vl = __riscv_vsetvl_e32m4(len);
     vuint32m4_t v = __riscv_vle32_v_u32m4((uint32_t *)src, vl);
     vuint32m4_t off = __riscv_vadd_vx_u32m4(v, 0xFFFF2000, vl);
-    long idx1 =
+    const long idx1 =
         __riscv_vfirst_m_b8(__riscv_vmsgtu_vx_u32m4_b8(v, 0x10FFFF, vl), vl);
-    long idx2 = __riscv_vfirst_m_b8(
+    const long idx2 = __riscv_vfirst_m_b8(
         __riscv_vmsgtu_vx_u32m4_b8(off, 0xFFFFF7FF, vl), vl);
-    if (idx1 >= 0 && idx2 >= 0) {
-      if (idx1 <= idx2)
+    if (idx1 >= 0 || idx2 >= 0) {
+      if (static_cast<unsigned long>(idx1) <=
+          static_cast<unsigned long>(idx2)) {
         return result(error_code::TOO_LARGE, src - srcBeg + idx1);
-      return result(error_code::SURROGATE, src - srcBeg + idx2);
+      } else {
+        return result(error_code::SURROGATE, src - srcBeg + idx2);
+      }
     }
-    if (idx1 >= 0)
-      return result(error_code::TOO_LARGE, src - srcBeg + idx1);
-    if (idx2 >= 0)
-      return result(error_code::SURROGATE, src - srcBeg + idx2);
-    long idx =
+    const long idx =
         __riscv_vfirst_m_b8(__riscv_vmsgtu_vx_u32m4_b8(v, 0xFFFF, vl), vl);
     if (idx < 0) {
       vlOut = vl;


### PR DESCRIPTION
Use simpler conditions, taking into account that `vfirst` returns -1 when the mask is empty. Number -1 cast to unsigned is always greater than the max positive `vfirst` value.