### PR TITLE
Icelake: faster UTF-16 length from UTF-8

### DIFF
--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -15,16 +15,17 @@ void info_message() {
   std::cout << "Using iconv version " << _LIBICONV_VERSION << std::endl;
 #endif
 #if defined(__clang__)
-  std::cout << "Compiler: Clang " << __clang_major__ << "." 
-          << __clang_minor__ << "." << __clang_patchlevel__ << "\n";
+  std::cout << "Compiler: Clang " << __clang_major__ << "." << __clang_minor__
+            << "." << __clang_patchlevel__ << "\n";
 #elif defined(__GNUC__)
-  std::cout << "Compiler: GCC " << __GNUC__ << "." 
-          << __GNUC_MINOR__ << "." << __GNUC_PATCHLEVEL__ << "\n";
+  std::cout << "Compiler: GCC " << __GNUC__ << "." << __GNUC_MINOR__ << "."
+            << __GNUC_PATCHLEVEL__ << "\n";
 #elif defined(_MSC_VER)
   std::cout << "Compiler: MSVC " << _MSC_VER << "\n";
 #endif
   std::cout << "SIMDUTF version: " << SIMDUTF_VERSION << "\n";
-  std::cout << "System: " << simdutf::get_active_implementation()->name() << "\n";
+  std::cout << "System: " << simdutf::get_active_implementation()->name()
+            << "\n";
   std::cout << "===========================\n";
 }
 

--- a/benchmarks/src/benchmark.h
+++ b/benchmarks/src/benchmark.h
@@ -88,6 +88,7 @@ private:
   void
   register_function(std::string name, Fn function, simdutf::encoding_type enc1,
                     simdutf::encoding_type enc2, simdutf::encoding_type enc3);
+
 private:
   void run_validate_utf8(const simdutf::implementation &implementation,
                          size_t iterations);

--- a/src/icelake/icelake_common.inl.cpp
+++ b/src/icelake/icelake_common.inl.cpp
@@ -29,3 +29,9 @@ __m512i shuffle_epi128(__m512i v) {
 template <unsigned idx> constexpr __m512i broadcast_epi128(__m512i v) {
   return shuffle_epi128<idx, idx, idx, idx>(v);
 }
+
+simdutf_really_inline __m512i broadcast_128bit_lane(__m128i lane) {
+  const __m512i tmp = _mm512_castsi128_si512(lane);
+
+  return broadcast_epi128<0>(tmp);
+}


### PR DESCRIPTION
Based on #741

[mula@localhost simdutf]$ ./scripts/benchmark_print.py build/benchmarks/{old,new}
|             dataset             | size [B] | iterations | old GB/s | new GB/s | speedup |
| ------------------------------- | -------- | ---------- | -------- | -------- | ------- |
| utf16_length_from_utf8+icelake                                                          |
| arabic.utf8                     |   533857 |      30000 |    38.29 |    46.12 | 1.20x   |
