### PR TITLE
lsx, lasx: trim SIMD wrappers

### DIFF
--- a/src/lsx/lsx_validate_utf16.cpp
+++ b/src/lsx/lsx_validate_utf16.cpp
@@ -8,6 +8,6 @@ simd8<uint8_t> utf16_gather_high_bytes(const simd16<uint16_t> in0,
 
     return simd16<uint16_t>::pack(t0, t1);
   } else {
-    return simd8<uint8_t>(__lsx_vssrlni_bu_h(in1.value, in0.value, 8));
+    return simd16<uint16_t>::pack_shifted_right<8>(in0, in1);
   }
 }

--- a/src/simdutf/lasx/simd.h
+++ b/src/simdutf/lasx/simd.h
@@ -3,7 +3,6 @@
 
 #include "simdutf.h"
 #include "simdutf/lasx/bitmanipulation.h"
-#include <type_traits>
 
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
@@ -230,22 +229,9 @@ template <typename Child> struct base {
   simdutf_really_inline Child operator^(const Child other) const {
     return __lasx_xvxor_v(this->value, other);
   }
-  simdutf_really_inline Child bit_andnot(const Child other) const {
-    return __lasx_xvandn_v(this->value, other);
-  }
   simdutf_really_inline Child &operator|=(const Child other) {
     auto this_cast = static_cast<Child *>(this);
     *this_cast = *this_cast | other;
-    return *this_cast;
-  }
-  simdutf_really_inline Child &operator&=(const Child other) {
-    auto this_cast = static_cast<Child *>(this);
-    *this_cast = *this_cast & other;
-    return *this_cast;
-  }
-  simdutf_really_inline Child &operator^=(const Child other) {
-    auto this_cast = static_cast<Child *>(this);
-    *this_cast = *this_cast ^ other;
     return *this_cast;
   }
 };
@@ -254,17 +240,8 @@ template <typename T> struct simd8;
 
 template <typename T, typename Mask = simd8<bool>>
 struct base8 : base<simd8<T>> {
-  typedef uint32_t bitmask_t;
-  typedef uint64_t bitmask2_t;
-
   simdutf_really_inline base8() : base<simd8<T>>() {}
   simdutf_really_inline base8(const __m256i _value) : base<simd8<T>>(_value) {}
-  simdutf_really_inline T first() const {
-    return __lasx_xvpickve2gr_wu(this->value, 0);
-  }
-  simdutf_really_inline T last() const {
-    return __lasx_xvpickve2gr_wu(this->value, 7);
-  }
   friend simdutf_really_inline Mask operator==(const simd8<T> lhs,
                                                const simd8<T> rhs) {
     return __lasx_xvseq_b(lhs, rhs);
@@ -272,8 +249,10 @@ struct base8 : base<simd8<T>> {
 
   static const int SIZE = sizeof(base<T>::value);
 
-  template <int N = 1>
+  template <unsigned N = 1>
   simdutf_really_inline simd8<T> prev(const simd8<T> prev_chunk) const {
+    static_assert(N <= 16, "unsupported shift value");
+
     if (!N)
       return this->value;
 
@@ -293,17 +272,7 @@ struct base8 : base<simd8<T>> {
       return result;
     } else if (N == 16) {
       return __lasx_xvpermi_q(this->value, prev_chunk.value, 0b00100001);
-    } /*else {
-      __m256i sll_value = __lasx_xvbsll_v(
-          __lasx_xvpermi_q(zero, this->value, 0b00000011), (N - 16) % 32);
-      __m256i mask = __lasx_xvld(bitsel_mask_table[N], 0);
-      shuf = __lasx_xvld(prev_shuf_table[N], 0);
-      result = __lasx_xvshuf_b(
-          __lasx_xvpermi_q(prev_chunk.value, prev_chunk.value, 0b00000001),
-          prev_chunk.value, shuf);
-      result = __lasx_xvbitsel_v(sll_value, result, mask);
-      return result;
-    }*/
+    }
   }
 };
 
@@ -328,16 +297,6 @@ template <> struct simd8<bool> : base8<bool> {
     if (__lasx_xbz_b(this->value))
       return false;
     return true;
-  }
-  simdutf_really_inline bool none() const {
-    if (__lasx_xbz_b(this->value))
-      return true;
-    return false;
-  }
-  simdutf_really_inline bool all() const {
-    if (__lasx_xbnz_b(this->value))
-      return true;
-    return false;
   }
   simdutf_really_inline simd8<bool> operator~() const { return *this ^ true; }
 };
@@ -367,22 +326,6 @@ template <typename T> struct base8_numeric : base8<T> {
   // Store to array
   simdutf_really_inline void store(T dst[32]) const {
     return __lasx_xvst(this->value, reinterpret_cast<__m256i *>(dst), 0);
-  }
-
-  // Addition/subtraction are the same for signed and unsigned
-  simdutf_really_inline simd8<T> operator+(const simd8<T> other) const {
-    return __lasx_xvadd_b(this->value, other);
-  }
-  simdutf_really_inline simd8<T> operator-(const simd8<T> other) const {
-    return __lasx_xvsub_b(this->value, other);
-  }
-  simdutf_really_inline simd8<T> &operator+=(const simd8<T> other) {
-    *this = *this + other;
-    return *static_cast<simd8<T> *>(this);
-  }
-  simdutf_really_inline simd8<T> &operator-=(const simd8<T> other) {
-    *this = *this - other;
-    return *static_cast<simd8<T> *>(this);
   }
 
   // Override to distinguish from bool version
@@ -420,27 +363,6 @@ template <> struct simd8<int8_t> : base8_numeric<int8_t> {
   // Array constructor
   simdutf_really_inline simd8(const int8_t values[32]) : simd8(load(values)) {}
   simdutf_really_inline operator simd8<uint8_t>() const;
-  // Member-by-member initialization
-  simdutf_really_inline
-  simd8(int8_t v0, int8_t v1, int8_t v2, int8_t v3, int8_t v4, int8_t v5,
-        int8_t v6, int8_t v7, int8_t v8, int8_t v9, int8_t v10, int8_t v11,
-        int8_t v12, int8_t v13, int8_t v14, int8_t v15, int8_t v16, int8_t v17,
-        int8_t v18, int8_t v19, int8_t v20, int8_t v21, int8_t v22, int8_t v23,
-        int8_t v24, int8_t v25, int8_t v26, int8_t v27, int8_t v28, int8_t v29,
-        int8_t v30, int8_t v31)
-      : simd8((__m256i)v32i8{v0,  v1,  v2,  v3,  v4,  v5,  v6,  v7,
-                             v8,  v9,  v10, v11, v12, v13, v14, v15,
-                             v16, v17, v18, v19, v20, v21, v22, v23,
-                             v24, v25, v26, v27, v28, v29, v30, v31}) {}
-  // Repeat 16 values as many times as necessary (usually for lookup tables)
-  simdutf_really_inline static simd8<int8_t>
-  repeat_16(int8_t v0, int8_t v1, int8_t v2, int8_t v3, int8_t v4, int8_t v5,
-            int8_t v6, int8_t v7, int8_t v8, int8_t v9, int8_t v10, int8_t v11,
-            int8_t v12, int8_t v13, int8_t v14, int8_t v15) {
-    return simd8<int8_t>(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12,
-                         v13, v14, v15, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9,
-                         v10, v11, v12, v13, v14, v15);
-  }
   simdutf_really_inline bool is_ascii() const {
     __m256i ascii_mask = __lasx_xvslti_b(this->value, 0);
     if (__lasx_xbnz_v(ascii_mask))
@@ -448,12 +370,6 @@ template <> struct simd8<int8_t> : base8_numeric<int8_t> {
     return true;
   }
   // Order-sensitive comparisons
-  simdutf_really_inline simd8<int8_t> max_val(const simd8<int8_t> other) const {
-    return __lasx_xvmax_b(this->value, other);
-  }
-  simdutf_really_inline simd8<int8_t> min_val(const simd8<int8_t> other) const {
-    return __lasx_xvmin_b(this->value, other);
-  }
   simdutf_really_inline simd8<bool> operator>(const simd8<int8_t> other) const {
     return __lasx_xvslt_b(other, this->value);
   }
@@ -484,76 +400,28 @@ template <> struct simd8<uint8_t> : base8_numeric<uint8_t> {
                              v8,  v9,  v10, v11, v12, v13, v14, v15,
                              v16, v17, v18, v19, v20, v21, v22, v23,
                              v24, v25, v26, v27, v28, v29, v30, v31}) {}
-  // Repeat 16 values as many times as necessary (usually for lookup tables)
-  simdutf_really_inline static simd8<uint8_t>
-  repeat_16(uint8_t v0, uint8_t v1, uint8_t v2, uint8_t v3, uint8_t v4,
-            uint8_t v5, uint8_t v6, uint8_t v7, uint8_t v8, uint8_t v9,
-            uint8_t v10, uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14,
-            uint8_t v15) {
-    return simd8<uint8_t>(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12,
-                          v13, v14, v15, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9,
-                          v10, v11, v12, v13, v14, v15);
-  }
 
   // Saturated math
-  simdutf_really_inline simd8<uint8_t>
-  saturating_add(const simd8<uint8_t> other) const {
-    return __lasx_xvsadd_bu(this->value, other);
-  }
   simdutf_really_inline simd8<uint8_t>
   saturating_sub(const simd8<uint8_t> other) const {
     return __lasx_xvssub_bu(this->value, other);
   }
 
-  // Order-specific operations
-  simdutf_really_inline simd8<uint8_t>
-  max_val(const simd8<uint8_t> other) const {
-    return __lasx_xvmax_bu(*this, other);
-  }
-  simdutf_really_inline simd8<uint8_t>
-  min_val(const simd8<uint8_t> other) const {
-    return __lasx_xvmin_bu(*this, other);
-  }
   // Same as >, but only guarantees true is nonzero (< guarantees true = -1)
   simdutf_really_inline simd8<uint8_t>
   gt_bits(const simd8<uint8_t> other) const {
     return this->saturating_sub(other);
   }
-  // Same as <, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd8<uint8_t>
-  lt_bits(const simd8<uint8_t> other) const {
-    return other.saturating_sub(*this);
-  }
-  simdutf_really_inline simd8<bool>
-  operator<=(const simd8<uint8_t> other) const {
-    return __lasx_xvsle_bu(*this, other);
-  }
   simdutf_really_inline simd8<bool>
   operator>=(const simd8<uint8_t> other) const {
     return __lasx_xvsle_bu(other, *this);
   }
-  simdutf_really_inline simd8<bool>
-  operator>(const simd8<uint8_t> other) const {
-    return __lasx_xvslt_bu(*this, other);
-  }
-  simdutf_really_inline simd8<bool>
-  operator<(const simd8<uint8_t> other) const {
-    return __lasx_xvslt_bu(other, *this);
+  simdutf_really_inline simd8 &operator-=(const simd8<uint8_t> other) {
+    value = __lasx_xvsub_b(value, other.value);
+    return *this;
   }
 
   // Bit-specific operations
-  simdutf_really_inline simd8<bool> bits_not_set() const {
-    return *this == uint8_t(0);
-  }
-  simdutf_really_inline simd8<bool> bits_not_set(simd8<uint8_t> bits) const {
-    return (*this & bits).bits_not_set();
-  }
-  simdutf_really_inline simd8<bool> any_bits_set() const {
-    return ~this->bits_not_set();
-  }
-  simdutf_really_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const {
-    return ~this->bits_not_set(bits);
-  }
   simdutf_really_inline bool is_ascii() const {
     __m256i ascii_mask = __lasx_xvslti_b(this->value, 0);
     if (__lasx_xbnz_v(ascii_mask))
@@ -564,9 +432,6 @@ template <> struct simd8<uint8_t> : base8_numeric<uint8_t> {
     if (__lasx_xbnz_v(this->value))
       return true;
     return false;
-  }
-  simdutf_really_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const {
-    return (*this & bits).any_bits_set_anywhere();
   }
   template <int N> simdutf_really_inline simd8<uint8_t> shr() const {
     return __lasx_xvsrli_b(this->value, N);
@@ -645,46 +510,6 @@ template <typename T> struct simd8x64 {
     this->chunks[1].store_ascii_as_utf32(ptr + sizeof(simd8<T>) * 1);
   }
 
-  simdutf_really_inline simd8x64<T> bit_or(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<T>(this->chunks[0] | mask, this->chunks[1] | mask);
-  }
-
-  simdutf_really_inline uint64_t eq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] == mask, this->chunks[1] == mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t eq(const simd8x64<uint8_t> &other) const {
-    return simd8x64<bool>(this->chunks[0] == other.chunks[0],
-                          this->chunks[1] == other.chunks[1])
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t lteq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t in_range(const T low, const T high) const {
-    const simd8<T> mask_low = simd8<T>::splat(low);
-    const simd8<T> mask_high = simd8<T>::splat(high);
-
-    return simd8x64<bool>(
-               (this->chunks[0] <= mask_high) & (this->chunks[0] >= mask_low),
-               (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low))
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
-    const simd8<T> mask_low = simd8<T>::splat(low);
-    const simd8<T> mask_high = simd8<T>::splat(high);
-    return simd8x64<bool>(
-               (this->chunks[0] > mask_high) | (this->chunks[0] < mask_low),
-               (this->chunks[1] > mask_high) | (this->chunks[1] < mask_low))
-        .to_bitmask();
-  }
   simdutf_really_inline uint64_t lt(const T m) const {
     const simd8<T> mask = simd8<T>::splat(m);
     return simd8x64<bool>(this->chunks[0] < mask, this->chunks[1] < mask)
@@ -694,11 +519,6 @@ template <typename T> struct simd8x64 {
   simdutf_really_inline uint64_t gt(const T m) const {
     const simd8<T> mask = simd8<T>::splat(m);
     return simd8x64<bool>(this->chunks[0] > mask, this->chunks[1] > mask)
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t gteq(const T m) const {
-    const simd8<T> mask = simd8<T>::splat(m);
-    return simd8x64<bool>(this->chunks[0] >= mask, this->chunks[1] >= mask)
         .to_bitmask();
   }
   simdutf_really_inline uint64_t gteq_unsigned(const uint8_t m) const {

--- a/src/simdutf/lasx/simd16-inl.h
+++ b/src/simdutf/lasx/simd16-inl.h
@@ -10,50 +10,12 @@ struct base16 : base<simd16<T>> {
   template <typename Pointer>
   simdutf_really_inline base16(const Pointer *ptr)
       : base16(__lasx_xvld(reinterpret_cast<const __m256i *>(ptr), 0)) {}
-  friend simdutf_really_inline Mask operator==(const simd16<T> lhs,
-                                               const simd16<T> rhs) {
-    return __lasx_xvseq_h(lhs.value, rhs.value);
-  }
 
   /// the size of vector in bytes
   static const int SIZE = sizeof(base<simd16<T>>::value);
 
   /// the number of elements of type T a vector can hold
   static const int ELEMENTS = SIZE / sizeof(T);
-
-  template <int N = 1>
-  simdutf_really_inline simd16<T> prev(const simd16<T> prev_chunk) const {
-    if (!N)
-      return this->value;
-
-    __m256i zero = __lasx_xvldi(0);
-    __m256i result, shuf;
-    if (N < 8) {
-      shuf = __lasx_xvld(prev_shuf_table[N * 2], 0);
-
-      result = __lasx_xvshuf_b(
-          __lasx_xvpermi_q(this->value, this->value, 0b00000001), this->value,
-          shuf);
-      __m256i srl_prev = __lasx_xvbsrl_v(
-          __lasx_xvpermi_q(zero, prev_chunk, 0b00110001), (16 - N * 2));
-      __m256i mask = __lasx_xvld(bitsel_mask_table[N], 0);
-      result = __lasx_xvbitsel_v(result, srl_prev, mask);
-
-      return result;
-    } else if (N == 8) {
-      return __lasx_xvpermi_q(this->value, prev_chunk, 0b00100001);
-    } else {
-      __m256i sll_value = __lasx_xvbsll_v(
-          __lasx_xvpermi_q(zero, this->value, 0b00000011), (N * 2 - 16));
-      __m256i mask = __lasx_xvld(bitsel_mask_table[N * 2], 0);
-      shuf = __lasx_xvld(prev_shuf_table[N * 2], 0);
-      result =
-          __lasx_xvshuf_b(__lasx_xvpermi_q(prev_chunk, prev_chunk, 0b00000001),
-                          prev_chunk, shuf);
-      result = __lasx_xvbitsel_v(sll_value, result, mask);
-      return result;
-    }
-  }
 };
 
 // SIMD byte mask type (returned by things like eq and gt)
@@ -72,11 +34,6 @@ template <> struct simd16<bool> : base16<bool> {
     bitmask_type mask0 = __lasx_xvpickve2gr_wu(mask, 0);
     bitmask_type mask1 = __lasx_xvpickve2gr_wu(mask, 4);
     return (mask0 | (mask1 << 16));
-  }
-  simdutf_really_inline bool any() const {
-    if (__lasx_xbz_v(this->value))
-      return false;
-    return true;
   }
   simdutf_really_inline simd16<bool> operator~() const { return *this ^ true; }
 };
@@ -101,52 +58,6 @@ template <typename T> struct base16_numeric : base16<T> {
 
   // Override to distinguish from bool version
   simdutf_really_inline simd16<T> operator~() const { return *this ^ 0xFFFFu; }
-
-  // Addition/subtraction are the same for signed and unsigned
-  simdutf_really_inline simd16<T> operator+(const simd16<T> other) const {
-    return __lasx_xvadd_h(*this, other);
-  }
-  simdutf_really_inline simd16<T> operator-(const simd16<T> other) const {
-    return __lasx_xvsub_h(*this, other);
-  }
-  simdutf_really_inline simd16<T> &operator+=(const simd16<T> other) {
-    *this = *this + other;
-    return *static_cast<simd16<T> *>(this);
-  }
-  simdutf_really_inline simd16<T> &operator-=(const simd16<T> other) {
-    *this = *this - other;
-    return *static_cast<simd16<T> *>(this);
-  }
-};
-
-// Signed code units
-template <> struct simd16<int16_t> : base16_numeric<int16_t> {
-  simdutf_really_inline simd16() : base16_numeric<int16_t>() {}
-  simdutf_really_inline simd16(const __m256i _value)
-      : base16_numeric<int16_t>(_value) {}
-  // Splat constructor
-  simdutf_really_inline simd16(int16_t _value) : simd16(splat(_value)) {}
-  // Array constructor
-  simdutf_really_inline simd16(const int16_t *values) : simd16(load(values)) {}
-  simdutf_really_inline simd16(const char16_t *values)
-      : simd16(load(reinterpret_cast<const int16_t *>(values))) {}
-  // Order-sensitive comparisons
-  simdutf_really_inline simd16<int16_t>
-  max_val(const simd16<int16_t> other) const {
-    return __lasx_xvmax_h(*this, other);
-  }
-  simdutf_really_inline simd16<int16_t>
-  min_val(const simd16<int16_t> other) const {
-    return __lasx_xvmin_h(*this, other);
-  }
-  simdutf_really_inline simd16<bool>
-  operator>(const simd16<int16_t> other) const {
-    return __lasx_xvsle_h(other.value, this->value);
-  }
-  simdutf_really_inline simd16<bool>
-  operator<(const simd16<int16_t> other) const {
-    return __lasx_xvslt_h(this->value, other.value);
-  }
 };
 
 // Unsigned code units
@@ -157,40 +68,13 @@ template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
 
   // Splat constructor
   simdutf_really_inline simd16(uint16_t _value) : simd16(splat(_value)) {}
+
   // Array constructor
   simdutf_really_inline simd16(const uint16_t *values) : simd16(load(values)) {}
   simdutf_really_inline simd16(const char16_t *values)
       : simd16(load(reinterpret_cast<const uint16_t *>(values))) {}
 
-  // Saturated math
-  simdutf_really_inline simd16<uint16_t>
-  saturating_add(const simd16<uint16_t> other) const {
-    return __lasx_xvsadd_hu(this->value, other.value);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  saturating_sub(const simd16<uint16_t> other) const {
-    return __lasx_xvssub_hu(this->value, other.value);
-  }
-
   // Order-specific operations
-  simdutf_really_inline simd16<uint16_t>
-  max_val(const simd16<uint16_t> other) const {
-    return __lasx_xvmax_hu(this->value, other.value);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  min_val(const simd16<uint16_t> other) const {
-    return __lasx_xvmin_hu(this->value, other.value);
-  }
-  // Same as >, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd16<uint16_t>
-  gt_bits(const simd16<uint16_t> other) const {
-    return this->saturating_sub(other);
-  }
-  // Same as <, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd16<uint16_t>
-  lt_bits(const simd16<uint16_t> other) const {
-    return other.saturating_sub(*this);
-  }
   simdutf_really_inline simd16<bool>
   operator<=(const simd16<uint16_t> other) const {
     return __lasx_xvsle_hu(this->value, other.value);
@@ -198,45 +82,6 @@ template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
   simdutf_really_inline simd16<bool>
   operator>=(const simd16<uint16_t> other) const {
     return __lasx_xvsle_hu(other.value, this->value);
-  }
-  simdutf_really_inline simd16<bool>
-  operator>(const simd16<uint16_t> other) const {
-    return __lasx_xvslt_hu(other.value, this->value);
-  }
-  simdutf_really_inline simd16<bool>
-  operator<(const simd16<uint16_t> other) const {
-    return __lasx_xvslt_hu(this->value, other.value);
-  }
-
-  // Bit-specific operations
-  simdutf_really_inline simd16<bool> bits_not_set() const {
-    return *this == uint16_t(0);
-  }
-  simdutf_really_inline simd16<bool> bits_not_set(simd16<uint16_t> bits) const {
-    return (*this & bits).bits_not_set();
-  }
-  simdutf_really_inline simd16<bool> any_bits_set() const {
-    return ~this->bits_not_set();
-  }
-  simdutf_really_inline simd16<bool> any_bits_set(simd16<uint16_t> bits) const {
-    return ~this->bits_not_set(bits);
-  }
-
-  simdutf_really_inline bool any_bits_set_anywhere() const {
-    if (__lasx_xbnz_v(this->value))
-      return true;
-    return false;
-  }
-  simdutf_really_inline bool
-  any_bits_set_anywhere(simd16<uint16_t> bits) const {
-    return (*this & bits).any_bits_set_anywhere();
-  }
-
-  template <int N> simdutf_really_inline simd16<uint16_t> shr() const {
-    return simd16<uint16_t>(__lasx_xvsrli_h(this->value, N));
-  }
-  template <int N> simdutf_really_inline simd16<uint16_t> shl() const {
-    return simd16<uint16_t>(__lasx_xvslli_h(this->value, N));
   }
 
   // Change the endianness
@@ -289,39 +134,14 @@ template <typename T> struct simd16x32 {
     return r_lo | (r_hi << 32);
   }
 
-  simdutf_really_inline simd16<T> reduce_or() const {
-    return this->chunks[0] | this->chunks[1];
-  }
-
-  simdutf_really_inline bool is_ascii() const {
-    return this->reduce_or().is_ascii();
-  }
-
   simdutf_really_inline void store_ascii_as_utf16(char16_t *ptr) const {
     this->chunks[0].store_ascii_as_utf16(ptr + sizeof(simd16<T>) * 0);
     this->chunks[1].store_ascii_as_utf16(ptr + sizeof(simd16<T>));
   }
 
-  simdutf_really_inline simd16x32<T> bit_or(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<T>(this->chunks[0] | mask, this->chunks[1] | mask);
-  }
-
   simdutf_really_inline void swap_bytes() {
     this->chunks[0] = this->chunks[0].swap_bytes();
     this->chunks[1] = this->chunks[1].swap_bytes();
-  }
-
-  simdutf_really_inline uint64_t eq(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] == mask, this->chunks[1] == mask)
-        .to_bitmask();
-  }
-
-  simdutf_really_inline uint64_t eq(const simd16x32<uint16_t> &other) const {
-    return simd16x32<bool>(this->chunks[0] == other.chunks[0],
-                           this->chunks[1] == other.chunks[1])
-        .to_bitmask();
   }
 
   simdutf_really_inline uint64_t lteq(const T m) const {
@@ -330,26 +150,12 @@ template <typename T> struct simd16x32 {
         .to_bitmask();
   }
 
-  simdutf_really_inline uint64_t in_range(const T low, const T high) const {
-    const simd16<T> mask_low = simd16<T>::splat(low);
-    const simd16<T> mask_high = simd16<T>::splat(high);
-
-    return simd16x32<bool>(
-               (this->chunks[0] <= mask_high) & (this->chunks[0] >= mask_low),
-               (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low))
-        .to_bitmask();
-  }
   simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
     const simd16<T> mask_low = simd16<T>::splat(static_cast<T>(low - 1));
     const simd16<T> mask_high = simd16<T>::splat(static_cast<T>(high + 1));
     return simd16x32<bool>(
                (this->chunks[0] >= mask_high) | (this->chunks[0] <= mask_low),
                (this->chunks[1] >= mask_high) | (this->chunks[1] <= mask_low))
-        .to_bitmask();
-  }
-  simdutf_really_inline uint64_t lt(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] < mask, this->chunks[1] < mask)
         .to_bitmask();
   }
 }; // struct simd16x32<T>

--- a/src/simdutf/lsx/simd16-inl.h
+++ b/src/simdutf/lsx/simd16-inl.h
@@ -14,28 +14,7 @@ template <typename T, typename Mask = simd16<bool>> struct base_u16 {
   simdutf_really_inline simd16<T> operator&(const simd16<T> other) const {
     return __lsx_vand_v(this->value, other.value);
   }
-  simdutf_really_inline simd16<T> operator^(const simd16<T> other) const {
-    return __lsx_vxor_v(this->value, other.value);
-  }
-  simdutf_really_inline simd16<T> bit_andnot(const simd16<T> other) const {
-    return __lsx_vandn_v(this->value, other.value);
-  }
   simdutf_really_inline simd16<T> operator~() const { return *this ^ 0xFFu; }
-  simdutf_really_inline simd16<T> &operator|=(const simd16<T> other) {
-    auto this_cast = static_cast<simd16<T> *>(this);
-    *this_cast = *this_cast | other;
-    return *this_cast;
-  }
-  simdutf_really_inline simd16<T> &operator&=(const simd16<T> other) {
-    auto this_cast = static_cast<simd16<T> *>(this);
-    *this_cast = *this_cast & other;
-    return *this_cast;
-  }
-  simdutf_really_inline simd16<T> &operator^=(const simd16<T> other) {
-    auto this_cast = static_cast<simd16<T> *>(this);
-    *this_cast = *this_cast ^ other;
-    return *this_cast;
-  }
 
   friend simdutf_really_inline Mask operator==(const simd16<T> lhs,
                                                const simd16<T> rhs) {
@@ -51,9 +30,6 @@ template <typename T, typename Mask = simd16<bool>> struct base_u16 {
 
 template <typename T, typename Mask = simd16<bool>>
 struct base16 : base_u16<T> {
-  typedef uint16_t bitmask_t;
-  typedef uint32_t bitmask2_t;
-
   simdutf_really_inline base16() : base_u16<T>() {}
   simdutf_really_inline base16(const __m128i _value) : base_u16<T>(_value) {}
   template <typename Pointer>
@@ -77,8 +53,6 @@ template <> struct simd16<bool> : base16<bool> {
 
   simdutf_really_inline simd16() : base16() {}
   simdutf_really_inline simd16(const __m128i _value) : base16<bool>(_value) {}
-  // Splat constructor
-  simdutf_really_inline simd16(bool _value) : base16<bool>(splat(_value)) {}
 };
 
 template <typename T> struct base16_numeric : base16<T> {
@@ -90,7 +64,6 @@ template <typename T> struct base16_numeric : base16<T> {
     return __lsx_vld(reinterpret_cast<const uint16_t *>(values), 0);
   }
 
-  simdutf_really_inline base16_numeric() : base16<T>() {}
   simdutf_really_inline base16_numeric(const __m128i _value)
       : base16<T>(_value) {}
 
@@ -119,92 +92,23 @@ template <typename T> struct base16_numeric : base16<T> {
   }
 };
 
-// Signed code unitstemplate<>
-template <> struct simd16<int16_t> : base16_numeric<int16_t> {
-  simdutf_really_inline simd16() : base16_numeric<int16_t>() {}
-  simdutf_really_inline simd16(const __m128i _value)
-      : base16_numeric<int16_t>(_value) {}
-  simdutf_really_inline simd16(simd16<bool> other)
-      : base16_numeric<int16_t>(other.value) {}
-
-  // Splat constructor
-  simdutf_really_inline simd16(int16_t _value) : simd16(splat(_value)) {}
-  // Array constructor
-  simdutf_really_inline simd16(const int16_t *values) : simd16(load(values)) {}
-  simdutf_really_inline simd16(const char16_t *values)
-      : simd16(load(reinterpret_cast<const int16_t *>(values))) {}
-  simdutf_really_inline operator simd16<uint16_t>() const;
-
-  // Order-sensitive comparisons
-  simdutf_really_inline simd16<int16_t>
-  max_val(const simd16<int16_t> other) const {
-    return __lsx_vmax_h(this->value, other.value);
-  }
-  simdutf_really_inline simd16<int16_t>
-  min_val(const simd16<int16_t> other) const {
-    return __lsx_vmin_h(this->value, other.value);
-  }
-  simdutf_really_inline simd16<bool>
-  operator>(const simd16<int16_t> other) const {
-    return __lsx_vsle_h(other.value, this->value);
-  }
-  simdutf_really_inline simd16<bool>
-  operator<(const simd16<int16_t> other) const {
-    return __lsx_vslt_h(this->value, other.value);
-  }
-};
-
 // Unsigned code unitstemplate<>
 template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
-  simdutf_really_inline simd16() : base16_numeric<uint16_t>() {}
   simdutf_really_inline simd16(const __m128i _value)
       : base16_numeric<uint16_t>((__m128i)_value) {}
-  simdutf_really_inline simd16(simd16<bool> other)
-      : base16_numeric<uint16_t>(other.value) {}
 
   // Splat constructor
   simdutf_really_inline simd16(uint16_t _value) : simd16(splat(_value)) {}
+
   // Array constructor
   simdutf_really_inline simd16(const uint16_t *values) : simd16(load(values)) {}
   simdutf_really_inline simd16(const char16_t *values)
       : simd16(load(reinterpret_cast<const uint16_t *>(values))) {}
 
-  // Saturated math
-  simdutf_really_inline simd16<uint16_t>
-  saturating_add(const simd16<uint16_t> other) const {
-    return __lsx_vsadd_hu(this->value, other.value);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  saturating_sub(const simd16<uint16_t> other) const {
-    return __lsx_vssub_hu(this->value, other.value);
-  }
-
   // Order-specific operations
-  simdutf_really_inline simd16<uint16_t>
-  max_val(const simd16<uint16_t> other) const {
-    return __lsx_vmax_hu(this->value, other.value);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  min_val(const simd16<uint16_t> other) const {
-    return __lsx_vmin_hu(this->value, other.value);
-  }
-  // Same as >, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd16<uint16_t>
-  gt_bits(const simd16<uint16_t> other) const {
-    return this->saturating_sub(other);
-  }
-  // Same as <, but only guarantees true is nonzero (< guarantees true = -1)
-  simdutf_really_inline simd16<uint16_t>
-  lt_bits(const simd16<uint16_t> other) const {
-    return other.saturating_sub(*this);
-  }
   simdutf_really_inline simd16<bool>
   operator<=(const simd16<uint16_t> other) const {
     return __lsx_vsle_hu(this->value, other.value);
-  }
-  simdutf_really_inline simd16<bool>
-  operator>=(const simd16<uint16_t> other) const {
-    return __lsx_vsle_hu(other.value, this->value);
   }
   simdutf_really_inline simd16<bool>
   operator>(const simd16<uint16_t> other) const {
@@ -215,36 +119,17 @@ template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
     return __lsx_vslt_hu(this->value, other.value);
   }
 
-  // Bit-specific operations
-  simdutf_really_inline simd16<bool> bits_not_set() const {
-    return *this == uint16_t(0);
-  }
-  template <int N> simdutf_really_inline simd16<uint16_t> shr() const {
-    return simd16<uint16_t>(__lsx_vsrli_h(this->value, N));
-  }
-  template <int N> simdutf_really_inline simd16<uint16_t> shl() const {
-    return simd16<uint16_t>(__lsx_vslli_h(this->value, N));
-  }
-
-  // logical operations
-  simdutf_really_inline simd16<uint16_t>
-  operator|(const simd16<uint16_t> other) const {
-    return __lsx_vor_v(this->value, other.value);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  operator&(const simd16<uint16_t> other) const {
-    return __lsx_vand_v(this->value, other.value);
-  }
-  simdutf_really_inline simd16<uint16_t>
-  operator^(const simd16<uint16_t> other) const {
-    return __lsx_vxor_v(this->value, other.value);
+  template <unsigned N>
+  static simdutf_really_inline simd8<uint8_t>
+  pack_shifted_right(const simd16<uint16_t> &v0, const simd16<uint16_t> &v1) {
+    return __lsx_vssrlni_bu_h(v1.value, v0.value, N);
   }
 
   // Pack with the unsigned saturation of two uint16_t code units into single
   // uint8_t vector
   static simdutf_really_inline simd8<uint8_t> pack(const simd16<uint16_t> &v0,
                                                    const simd16<uint16_t> &v1) {
-    return __lsx_vssrlni_bu_h(v1.value, v0.value, 0);
+    return pack_shifted_right<0>(v0, v1);
   }
 
   // Change the endianness
@@ -252,10 +137,6 @@ template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
     return __lsx_vshuf4i_b(this->value, 0b10110001);
   }
 };
-
-simdutf_really_inline simd16<int16_t>::operator simd16<uint16_t>() const {
-  return this->value;
-}
 
 template <typename T> struct simd16x32 {
   static constexpr int NUM_CHUNKS = 64 / sizeof(simd16<T>);
@@ -286,20 +167,6 @@ template <typename T> struct simd16x32 {
     this->chunks[3].store(ptr + sizeof(simd16<T>) * 3 / sizeof(T));
   }
 
-  simdutf_really_inline simd16<T> reduce_or() const {
-    return (this->chunks[0] | this->chunks[1]) |
-           (this->chunks[2] | this->chunks[3]);
-  }
-
-  simdutf_really_inline bool is_ascii() const { return reduce_or().is_ascii(); }
-
-  simdutf_really_inline void store_ascii_as_utf16(char16_t *ptr) const {
-    this->chunks[0].store_ascii_as_utf16(ptr + sizeof(simd16<T>) * 0);
-    this->chunks[1].store_ascii_as_utf16(ptr + sizeof(simd16<T>) * 1);
-    this->chunks[2].store_ascii_as_utf16(ptr + sizeof(simd16<T>) * 2);
-    this->chunks[3].store_ascii_as_utf16(ptr + sizeof(simd16<T>) * 3);
-  }
-
   simdutf_really_inline uint64_t to_bitmask() const {
     __m128i mask = __lsx_vbsll_v(__lsx_vmsknz_b((this->chunks[3]).value), 6);
     mask = __lsx_vor_v(
@@ -317,13 +184,6 @@ template <typename T> struct simd16x32 {
     this->chunks[3] = this->chunks[3].swap_bytes();
   }
 
-  simdutf_really_inline uint64_t eq(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
-                           this->chunks[2] == mask, this->chunks[3] == mask)
-        .to_bitmask();
-  }
-
   simdutf_really_inline uint64_t lteq(const T m) const {
     const simd16<T> mask = simd16<T>::splat(m);
     return simd16x32<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask,
@@ -331,17 +191,6 @@ template <typename T> struct simd16x32 {
         .to_bitmask();
   }
 
-  simdutf_really_inline uint64_t in_range(const T low, const T high) const {
-    const simd16<T> mask_low = simd16<T>::splat(low);
-    const simd16<T> mask_high = simd16<T>::splat(high);
-
-    return simd16x32<bool>(
-               (this->chunks[0] <= mask_high) & (this->chunks[0] >= mask_low),
-               (this->chunks[1] <= mask_high) & (this->chunks[1] >= mask_low),
-               (this->chunks[2] <= mask_high) & (this->chunks[2] >= mask_low),
-               (this->chunks[3] <= mask_high) & (this->chunks[3] >= mask_low))
-        .to_bitmask();
-  }
   simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
     const simd16<T> mask_low = simd16<T>::splat(low);
     const simd16<T> mask_high = simd16<T>::splat(high);
@@ -352,27 +201,4 @@ template <typename T> struct simd16x32 {
                (this->chunks[3] > mask_high) | (this->chunks[3] < mask_low))
         .to_bitmask();
   }
-  simdutf_really_inline uint64_t lt(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] < mask, this->chunks[1] < mask,
-                           this->chunks[2] < mask, this->chunks[3] < mask)
-        .to_bitmask();
-  }
-
 }; // struct simd16x32<T>
-
-template <>
-simdutf_really_inline uint64_t simd16x32<uint16_t>::not_in_range(
-    const uint16_t low, const uint16_t high) const {
-  const simd16<uint16_t> mask_low = simd16<uint16_t>::splat(low);
-  const simd16<uint16_t> mask_high = simd16<uint16_t>::splat(high);
-  simd16x32<uint16_t> x(simd16<uint16_t>((this->chunks[0] > mask_high) |
-                                         (this->chunks[0] < mask_low)),
-                        simd16<uint16_t>((this->chunks[1] > mask_high) |
-                                         (this->chunks[1] < mask_low)),
-                        simd16<uint16_t>((this->chunks[2] > mask_high) |
-                                         (this->chunks[2] < mask_low)),
-                        simd16<uint16_t>((this->chunks[3] > mask_high) |
-                                         (this->chunks[3] < mask_low)));
-  return x.to_bitmask();
-}


### PR DESCRIPTION
The wrappers for these targets expose way more functions that are really needed. The unused methods and fields got removed.