### PR TITLE
lsx, lasx: faster count UTF-16

### DIFF
--- a/src/generic/utf16/change_endianness.h
+++ b/src/generic/utf16/change_endianness.h
@@ -1,0 +1,24 @@
+namespace simdutf {
+namespace SIMDUTF_IMPLEMENTATION {
+namespace {
+namespace utf16 {
+
+simdutf_really_inline void
+change_endianness_utf16(const char16_t *in, size_t size, char16_t *output) {
+  size_t pos = 0;
+
+  while (pos < size / 32 * 32) {
+    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
+    input.swap_bytes();
+    input.store(reinterpret_cast<uint16_t *>(output));
+    pos += 32;
+    output += 32;
+  }
+
+  scalar::utf16::change_endianness_utf16(in + pos, size - pos, output);
+}
+
+} // namespace utf16
+} // unnamed namespace
+} // namespace SIMDUTF_IMPLEMENTATION
+} // namespace simdutf

--- a/src/generic/utf16/count_code_points_bytemask.h
+++ b/src/generic/utf16/count_code_points_bytemask.h
@@ -1,0 +1,58 @@
+namespace simdutf {
+namespace SIMDUTF_IMPLEMENTATION {
+namespace {
+namespace utf16 {
+
+using namespace simd;
+
+template <endianness big_endian>
+simdutf_really_inline size_t count_code_points(const char16_t *in,
+                                               size_t size) {
+  using vector_u16 = simd16<uint16_t>;
+  constexpr size_t N = vector_u16::ELEMENTS;
+
+  size_t pos = 0;
+  size_t count = 0;
+
+  constexpr size_t max_itertions = 65535;
+  const auto one = vector_u16::splat(1);
+  const auto zero = vector_u16::zero();
+
+  size_t itertion = 0;
+
+  auto counters = zero;
+  for (; pos < size / N * N; pos += N) {
+    auto input = vector_u16::load(in + pos);
+    if (!match_system(big_endian)) {
+      input = input.swap_bytes();
+    }
+
+    const auto t0 = input & uint16_t(0xfc00);
+    const auto t1 = t0 ^ uint16_t(0xdc00);
+
+    // t2[0] == 1 iff input[0] outside range 0xdc00..dfff (the word is not a
+    // high surrogate)
+    const auto t2 = min(t1, one);
+
+    counters += t2;
+
+    itertion += 1;
+    if (itertion == max_itertions) {
+      count += counters.sum();
+      counters = zero;
+      itertion = 0;
+    }
+  }
+
+  if (itertion > 0) {
+    count += counters.sum();
+  }
+
+  return count +
+         scalar::utf16::count_code_points<big_endian>(in + pos, size - pos);
+}
+
+} // namespace utf16
+} // unnamed namespace
+} // namespace SIMDUTF_IMPLEMENTATION
+} // namespace simdutf

--- a/src/generic/utf16/utf32_length_from_utf16.h
+++ b/src/generic/utf16/utf32_length_from_utf16.h
@@ -1,0 +1,15 @@
+namespace simdutf {
+namespace SIMDUTF_IMPLEMENTATION {
+namespace {
+namespace utf16 {
+
+template <endianness big_endian>
+simdutf_really_inline size_t utf32_length_from_utf16(const char16_t *in,
+                                                     size_t size) {
+  return count_code_points<big_endian>(in, size);
+}
+
+} // namespace utf16
+} // unnamed namespace
+} // namespace SIMDUTF_IMPLEMENTATION
+} // namespace simdutf

--- a/src/generic/utf16/utf8_length_from_utf16.h
+++ b/src/generic/utf16/utf8_length_from_utf16.h
@@ -1,0 +1,35 @@
+namespace simdutf {
+namespace SIMDUTF_IMPLEMENTATION {
+namespace {
+namespace utf16 {
+
+template <endianness big_endian>
+simdutf_really_inline size_t utf8_length_from_utf16(const char16_t *in,
+                                                    size_t size) {
+  size_t pos = 0;
+  size_t count = 0;
+  // This algorithm could no doubt be improved!
+  for (; pos < size / 32 * 32; pos += 32) {
+    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
+    if (!match_system(big_endian)) {
+      input.swap_bytes();
+    }
+    uint64_t ascii_mask = input.lteq(0x7F);
+    uint64_t twobyte_mask = input.lteq(0x7FF);
+    uint64_t not_pair_mask = input.not_in_range(0xD800, 0xDFFF);
+
+    size_t ascii_count = count_ones(ascii_mask) / 2;
+    size_t twobyte_count = count_ones(twobyte_mask & ~ascii_mask) / 2;
+    size_t threebyte_count = count_ones(not_pair_mask & ~twobyte_mask) / 2;
+    size_t fourbyte_count = 32 - count_ones(not_pair_mask) / 2;
+    count += 2 * fourbyte_count + 3 * threebyte_count + 2 * twobyte_count +
+             ascii_count;
+  }
+  return count + scalar::utf16::utf8_length_from_utf16<big_endian>(in + pos,
+                                                                   size - pos);
+}
+
+} // namespace utf16
+} // unnamed namespace
+} // namespace SIMDUTF_IMPLEMENTATION
+} // namespace simdutf

--- a/src/lasx/implementation.cpp
+++ b/src/lasx/implementation.cpp
@@ -204,7 +204,10 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
 #endif // SIMDUTF_FEATURE_UTF8
 
 #if SIMDUTF_FEATURE_UTF16
-  #include "generic/utf16.h"
+  #include "generic/utf16/count_code_points_bytemask.h"
+  #include "generic/utf16/change_endianness.h"
+  #include "generic/utf16/utf8_length_from_utf16.h"
+  #include "generic/utf16/utf32_length_from_utf16.h"
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING

--- a/src/lsx/implementation.cpp
+++ b/src/lsx/implementation.cpp
@@ -203,7 +203,10 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
 #endif // SIMDUTF_FEATURE_UTF8
 
 #if SIMDUTF_FEATURE_UTF16
-  #include "generic/utf16.h"
+  #include "generic/utf16/count_code_points_bytemask.h"
+  #include "generic/utf16/change_endianness.h"
+  #include "generic/utf16/utf8_length_from_utf16.h"
+  #include "generic/utf16/utf32_length_from_utf16.h"
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING


### PR DESCRIPTION
System:

```
CPU Family		: Loongson-64bit
Model Name		: Loongson-3C5000L-LL
```

Benchmark

```shell
$ ./benchmark -P count_utf16 -F ~/unicode_lipsum/wikipedia_mars/*.utf16.txt -I 1000
```

|     dataset      | size [B] | iterations | old GB/s | new GB/s | speedup |
| ---------------- | -------- | ---------- | -------- | -------- | ------- |
| count_utf16+lasx                                                         |
| arabic.utf16     |   849690 |       1000 |     8.85 |    14.38 | 1.62x   |
| chinese.utf16    |   274418 |       1000 |     7.94 |    14.32 | 1.80x   |
| czech.utf16      |   287666 |       1000 |     7.67 |    13.67 | 1.78x   |
| english.utf16    |   775020 |       1000 |     8.84 |    14.54 | 1.64x   |
| esperanto.utf16  |   168252 |       1000 |     7.50 |    14.67 | 1.96x   |
| french.utf16     |   869736 |       1000 |     8.85 |    14.31 | 1.62x   |
| german.utf16     |   402432 |       1000 |     8.82 |    14.29 | 1.62x   |
| greek.utf16      |   286000 |       1000 |     6.76 |    13.22 | 1.96x   |
| hebrew.utf16     |   292704 |       1000 |     6.44 |    12.25 | 1.90x   |
| hindi.utf16      |   547918 |       1000 |     8.82 |    14.64 | 1.66x   |
| japanese.utf16   |   237784 |       1000 |     7.47 |    14.29 | 1.91x   |
| korean.utf16     |   145838 |       1000 |     7.49 |    14.50 | 1.94x   |
| persan.utf16     |   249390 |       1000 |     7.46 |    14.31 | 1.92x   |
| portuguese.utf16 |   547232 |       1000 |     8.82 |    14.81 | 1.68x   |
| russian.utf16    |   624076 |       1000 |     8.82 |    14.81 | 1.68x   |
| thai.utf16       |   809518 |       1000 |     8.84 |    14.43 | 1.63x   |
| turkish.utf16    |   370886 |       1000 |     8.81 |    14.39 | 1.63x   |
| vietnamese.utf16 |   564840 |       1000 |     8.82 |    14.80 | 1.68x   |
| count_utf16+lsx                                                          |
| arabic.utf16     |   849690 |       1000 |     8.52 |    10.20 | 1.20x   |
| chinese.utf16    |   274418 |       1000 |     8.44 |     9.76 | 1.16x   |
| czech.utf16      |   287666 |       1000 |     8.20 |     9.32 | 1.14x   |
| english.utf16    |   775020 |       1000 |     8.51 |    10.20 | 1.20x   |
| esperanto.utf16  |   168252 |       1000 |     8.49 |     9.79 | 1.15x   |
| french.utf16     |   869736 |       1000 |     8.51 |    10.14 | 1.19x   |
| german.utf16     |   402432 |       1000 |     8.49 |    10.18 | 1.20x   |
| greek.utf16      |   286000 |       1000 |     7.71 |     8.56 | 1.11x   |
| hebrew.utf16     |   292704 |       1000 |     7.33 |     8.18 | 1.12x   |
| hindi.utf16      |   547918 |       1000 |     8.49 |    10.20 | 1.20x   |
| japanese.utf16   |   237784 |       1000 |     8.46 |     9.74 | 1.15x   |
| korean.utf16     |   145838 |       1000 |     8.48 |     9.78 | 1.15x   |
| persan.utf16     |   249390 |       1000 |     8.38 |     9.73 | 1.16x   |
| portuguese.utf16 |   547232 |       1000 |     8.49 |    10.20 | 1.20x   |
| russian.utf16    |   624076 |       1000 |     8.53 |    10.19 | 1.19x   |
| thai.utf16       |   809518 |       1000 |     8.51 |    10.20 | 1.20x   |
| turkish.utf16    |   370886 |       1000 |     8.50 |    10.18 | 1.20x   |
| vietnamese.utf16 |   564840 |       1000 |     8.51 |    10.20 | 1.20x   |
