### PR TITLE
Vectorized the aarch64 utf32 to utf16 surrogate handling loop using NEON

### DIFF
--- a/src/arm64/arm_convert_utf32_to_utf16.cpp
+++ b/src/arm64/arm_convert_utf32_to_utf16.cpp
@@ -1,3 +1,55 @@
+struct expansion_result_t {
+  size_t u16count;
+  uint8x16_t compressed_v;
+};
+
+static simdutf_really_inline uint64_t invalid_utf32(const uint32x4x2_t in) {
+  const auto standardmax = vdupq_n_u32(0x10ffff);
+  const auto v_d800 = vdupq_n_u32(0xd800);
+  const auto v_fffff800 = vdupq_n_u32(0xfffff800);
+  const auto too_large1 = vcgtq_u32(in.val[0], standardmax);
+  const auto too_large2 = vcgtq_u32(in.val[1], standardmax);
+  const auto surrogate1 = vceqq_u32(vandq_u32(in.val[0], v_fffff800), v_d800);
+  const auto surrogate2 = vceqq_u32(vandq_u32(in.val[1], v_fffff800), v_d800);
+  const auto err1 = vorrq_u32(too_large1, surrogate1);
+  const auto err2 = vorrq_u32(too_large2, surrogate2);
+  const auto err =
+      vuzp2q_u16(vreinterpretq_u16_u32(err1), vreinterpretq_u16_u32(err2));
+
+  return vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(err, 8)), 0);
+}
+
+template <endianness byte_order>
+expansion_result_t neon_expand_surrogate(const uint32x4_t in) {
+  const uint32x4_t v_ffff0000 = vdupq_n_u32(0xffff0000);
+  const uint32x4_t non_surrogate_mask = vceqzq_u32(vandq_u32(in, v_ffff0000));
+  const uint64_t cmp_bits =
+      vget_lane_u64(vreinterpret_u64_u32(vshrn_n_u64(
+                        vreinterpretq_u64_u32(non_surrogate_mask), 31)),
+                    0);
+  const uint8_t mask =
+      uint8_t(~((cmp_bits & 0x3) | ((cmp_bits >> 30) & 0xc)) & 0xf);
+  const uint32x4_t v_10000 = vdupq_n_u32(0x00010000);
+  const uint32x4_t t0 = vsubq_u32(in, v_10000);
+  const uint32x4_t t1 = vandq_u32(t0, vdupq_n_u32(0xfffff));
+  const uint32x4_t t2 = vshrq_n_u32(t1, 10);
+  const uint32x4_t t3 = vsliq_n_u32(t2, t1, 16);
+  const uint32x4_t surrogates = vorrq_u32(
+      vandq_u32(t3, vdupq_n_u32(0x03ff03ff)), vdupq_n_u32(0xdc00d800));
+  const uint8x16_t merged =
+      vreinterpretq_u8_u32(vbslq_u32(non_surrogate_mask, in, surrogates));
+
+  const uint8x16_t shuffle_v = vld1q_u8(reinterpret_cast<const uint8_t *>(
+      (byte_order == endianness::LITTLE)
+          ? tables::utf32_to_utf16::pack_utf32_to_utf16le[mask]
+          : tables::utf32_to_utf16::pack_utf32_to_utf16be[mask]));
+
+  const size_t u16count = 4 + vget_lane_u8(vcnt_u8(vcreate_u8(mask)), 0);
+  const uint8x16_t compressed_v = vqtbl1q_u8(merged, shuffle_v);
+
+  return {u16count, compressed_v};
+}
+
 template <endianness big_endian>
 std::pair<const char32_t *, char16_t *>
 arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
@@ -6,8 +58,9 @@ arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
   const char32_t *end = buf + len;
 
   uint16x8_t forbidden_bytemask = vmovq_n_u16(0x0);
-
-  while (end - buf >= 8) {
+  // To avoid buffer overflow while writing compressed_v
+  const size_t safety_margin = 4;
+  while (end - buf >= std::ptrdiff_t(8 + safety_margin)) {
     uint32x4x2_t in = vld1q_u32_x2(reinterpret_cast<const uint32_t *>(buf));
 
     // Check if no bits set above 16th
@@ -29,41 +82,18 @@ arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
       utf16_output += 8;
       buf += 8;
     } else {
-      size_t forward = 7;
-      size_t k = 0;
-      if (size_t(end - buf) < forward + 1) {
-        forward = size_t(end - buf - 1);
+      const uint64_t err = invalid_utf32(in);
+      if (simdutf_unlikely(err)) {
+        return std::make_pair(nullptr,
+                              reinterpret_cast<char16_t *>(utf16_output));
       }
-      for (; k < forward; k++) {
-        uint32_t word = buf[k];
-        if ((word & 0xFFFF0000) == 0) {
-          // will not generate a surrogate pair
-          if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char16_t *>(utf16_output));
-          }
-          *utf16_output++ = !match_system(big_endian)
-                                ? char16_t(word >> 8 | word << 8)
-                                : char16_t(word);
-        } else {
-          // will generate a surrogate pair
-          if (word > 0x10FFFF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char16_t *>(utf16_output));
-          }
-          word -= 0x10000;
-          uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
-          uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-          if (!match_system(big_endian)) {
-            high_surrogate =
-                uint16_t(high_surrogate >> 8 | high_surrogate << 8);
-            low_surrogate = uint16_t(low_surrogate << 8 | low_surrogate >> 8);
-          }
-          *utf16_output++ = char16_t(high_surrogate);
-          *utf16_output++ = char16_t(low_surrogate);
-        }
-      }
-      buf += k;
+      expansion_result_t res = neon_expand_surrogate<big_endian>(in.val[0]);
+      vst1q_u8(reinterpret_cast<uint8_t *>(utf16_output), res.compressed_v);
+      utf16_output += res.u16count;
+      res = neon_expand_surrogate<big_endian>(in.val[1]);
+      vst1q_u8(reinterpret_cast<uint8_t *>(utf16_output), res.compressed_v);
+      utf16_output += res.u16count;
+      buf += 8;
     }
   }
 
@@ -83,7 +113,9 @@ arm_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
   const char32_t *start = buf;
   const char32_t *end = buf + len;
 
-  while (end - buf >= 8) {
+  // To avoid buffer overflow while writing compressed_v
+  const size_t safety_margin = 4;
+  while (end - buf >= std::ptrdiff_t(8 + safety_margin)) {
     uint32x4x2_t in = vld1q_u32_x2(reinterpret_cast<const uint32_t *>(buf));
 
     // Check if no bits set above 16th
@@ -108,43 +140,50 @@ arm_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
       utf16_output += 8;
       buf += 8;
     } else {
-      size_t forward = 7;
-      size_t k = 0;
-      if (size_t(end - buf) < forward + 1) {
-        forward = size_t(end - buf - 1);
-      }
-      for (; k < forward; k++) {
-        uint32_t word = buf[k];
-        if ((word & 0xFFFF0000) == 0) {
-          // will not generate a surrogate pair
-          if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(
-                result(error_code::SURROGATE, buf - start + k),
-                reinterpret_cast<char16_t *>(utf16_output));
+      const uint64_t err = invalid_utf32(in);
+      if (simdutf_unlikely(err)) {
+        const size_t pos = trailing_zeroes(err) / 8;
+        for (size_t k = 0; k < pos; k++) {
+          uint32_t word = buf[k];
+          if ((word & 0xFFFF0000) == 0) {
+            // will not generate a surrogate pair
+            *utf16_output++ = !match_system(big_endian)
+                                  ? char16_t(word >> 8 | word << 8)
+                                  : char16_t(word);
+          } else {
+            // will generate a surrogate pair
+            word -= 0x10000;
+            uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
+            uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
+            if (!match_system(big_endian)) {
+              high_surrogate =
+                  uint16_t(high_surrogate >> 8 | high_surrogate << 8);
+              low_surrogate = uint16_t(low_surrogate << 8 | low_surrogate >> 8);
+            }
+            *utf16_output++ = char16_t(high_surrogate);
+            *utf16_output++ = char16_t(low_surrogate);
           }
-          *utf16_output++ = !match_system(big_endian)
-                                ? char16_t(word >> 8 | word << 8)
-                                : char16_t(word);
-        } else {
-          // will generate a surrogate pair
-          if (word > 0x10FFFF) {
-            return std::make_pair(
-                result(error_code::TOO_LARGE, buf - start + k),
-                reinterpret_cast<char16_t *>(utf16_output));
-          }
-          word -= 0x10000;
-          uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
-          uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-          if (!match_system(big_endian)) {
-            high_surrogate =
-                uint16_t(high_surrogate >> 8 | high_surrogate << 8);
-            low_surrogate = uint16_t(low_surrogate << 8 | low_surrogate >> 8);
-          }
-          *utf16_output++ = char16_t(high_surrogate);
-          *utf16_output++ = char16_t(low_surrogate);
         }
+        const uint32_t word = buf[pos];
+        const size_t error_pos = buf - start + pos;
+        if (word > 0x10FFFF) {
+          return {result(error_code::TOO_LARGE, error_pos),
+                  reinterpret_cast<char16_t *>(utf16_output)};
+        }
+        if (word >= 0xD800 && word <= 0xDFFF) {
+          return {result(error_code::SURROGATE, error_pos),
+                  reinterpret_cast<char16_t *>(utf16_output)};
+        }
+        return {result(error_code::OTHER, error_pos),
+                reinterpret_cast<char16_t *>(utf16_output)};
       }
-      buf += k;
+      expansion_result_t res = neon_expand_surrogate<big_endian>(in.val[0]);
+      vst1q_u8(reinterpret_cast<uint8_t *>(utf16_output), res.compressed_v);
+      utf16_output += res.u16count;
+      res = neon_expand_surrogate<big_endian>(in.val[1]);
+      vst1q_u8(reinterpret_cast<uint8_t *>(utf16_output), res.compressed_v);
+      utf16_output += res.u16count;
+      buf += 8;
     }
   }
 


### PR DESCRIPTION
Logic is based on the westmere code and the ongoing haswell https://github.com/simdutf/simdutf/pull/738
In the worst case, the 4 utf32 words could map to 4 non-surrogate utf16 words. 
Thus the vector store would have 8 bytes overrun. To prevent buffer overflow, 4 words safety margin is introduced.
Verified that unit tests pass with SIMDUTF_SANITIZER enabled.