### PR TITLE
recovering some of the lost speed in utf-32 to utf-16 (arm) when there is no surrogate handling

### DIFF
--- a/src/arm64/arm_convert_utf32_to_utf16.cpp
+++ b/src/arm64/arm_convert_utf32_to_utf16.cpp
@@ -64,7 +64,7 @@ arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
     uint32x4x2_t in = vld1q_u32_x2(reinterpret_cast<const uint32_t *>(buf));
 
     // Check if no bits set above 16th
-    if (vmaxvq_u32(vorrq_u32(in.val[0], in.val[1])) <= 0xFFFF) {
+    if (simdutf_likely(vmaxvq_u32(vorrq_u32(in.val[0], in.val[1])) <= 0xFFFF)) {
       uint16x8_t utf16_packed = vuzp1q_u16(vreinterpretq_u16_u32(in.val[0]),
                                            vreinterpretq_u16_u32(in.val[1]));
 

--- a/src/arm64/arm_convert_utf32_to_utf16.cpp
+++ b/src/arm64/arm_convert_utf32_to_utf16.cpp
@@ -3,7 +3,9 @@ struct expansion_result_t {
   uint8x16_t compressed_v;
 };
 
-static simdutf_really_inline uint64_t invalid_utf32(const uint32x4x2_t in) {
+// This function is used to check for invalid UTF-32 characters
+// and surrogate pairs in the input
+simdutf_really_inline uint64_t invalid_utf32(const uint32x4x2_t in) {
   const auto standardmax = vdupq_n_u32(0x10ffff);
   const auto v_d800 = vdupq_n_u32(0xd800);
   const auto v_fffff800 = vdupq_n_u32(0xfffff800);
@@ -19,8 +21,19 @@ static simdutf_really_inline uint64_t invalid_utf32(const uint32x4x2_t in) {
   return vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(err, 8)), 0);
 }
 
+// This function is used to check for surrogate pairs in the input
+simdutf_really_inline uint64_t fast_invalid_utf32(const uint32x4x2_t in) {
+  const auto v_d800 = vdupq_n_u32(0xd800);
+  const auto v_fffff800 = vdupq_n_u32(0xfffff800);
+  const auto surrogate1 = vceqq_u32(vandq_u32(in.val[0], v_fffff800), v_d800);
+  const auto surrogate2 = vceqq_u32(vandq_u32(in.val[1], v_fffff800), v_d800);
+  const auto err =
+      vuzp2q_u16(vreinterpretq_u16_u32(surrogate1), vreinterpretq_u16_u32(surrogate2));
+  return vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(err, 8)), 0);
+}
+
 template <endianness byte_order>
-expansion_result_t neon_expand_surrogate(const uint32x4_t in) {
+simdutf_really_inline expansion_result_t neon_expand_surrogate(const uint32x4_t in) {
   const uint32x4_t v_ffff0000 = vdupq_n_u32(0xffff0000);
   const uint32x4_t non_surrogate_mask = vceqzq_u32(vandq_u32(in, v_ffff0000));
   const uint64_t cmp_bits =
@@ -64,7 +77,8 @@ arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
     uint32x4x2_t in = vld1q_u32_x2(reinterpret_cast<const uint32_t *>(buf));
 
     // Check if no bits set above 16th
-    if (simdutf_likely(vmaxvq_u32(vorrq_u32(in.val[0], in.val[1])) <= 0xFFFF)) {
+    uint32_t max_val = vmaxvq_u32(vmaxq_u32(in.val[0], in.val[1]));
+    if (simdutf_likely(max_val <= 0xFFFF)) {
       uint16x8_t utf16_packed = vuzp1q_u16(vreinterpretq_u16_u32(in.val[0]),
                                            vreinterpretq_u16_u32(in.val[1]));
 
@@ -82,8 +96,7 @@ arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
       utf16_output += 8;
       buf += 8;
     } else {
-      const uint64_t err = invalid_utf32(in);
-      if (simdutf_unlikely(err)) {
+      if (simdutf_unlikely(max_val > 0x10ffff || fast_invalid_utf32(in))) {
         return std::make_pair(nullptr,
                               reinterpret_cast<char16_t *>(utf16_output));
       }
@@ -98,7 +111,7 @@ arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
   }
 
   // check for invalid input
-  if (vmaxvq_u16(forbidden_bytemask) != 0) {
+  if (vmaxvq_u32(vreinterpretq_u32_u16(forbidden_bytemask)) != 0) {
     return std::make_pair(nullptr, reinterpret_cast<char16_t *>(utf16_output));
   }
 
@@ -119,7 +132,8 @@ arm_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
     uint32x4x2_t in = vld1q_u32_x2(reinterpret_cast<const uint32_t *>(buf));
 
     // Check if no bits set above 16th
-    if (simdutf_likely(vmaxvq_u32(vorrq_u32(in.val[0], in.val[1])) <= 0xFFFF)) {
+    uint32_t max_val = vmaxvq_u32(vmaxq_u32(in.val[0], in.val[1]));
+    if (simdutf_likely(max_val <= 0xFFFF)) {
       uint16x8_t utf16_packed = vuzp1q_u16(vreinterpretq_u16_u32(in.val[0]),
                                            vreinterpretq_u16_u32(in.val[1]));
 
@@ -140,7 +154,7 @@ arm_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
       utf16_output += 8;
       buf += 8;
     } else {
-      const uint64_t err = invalid_utf32(in);
+      const uint64_t err = max_val <=  0x10ffff ? fast_invalid_utf32(in) : invalid_utf32(in);
       if (simdutf_unlikely(err)) {
         const size_t pos = trailing_zeroes(err) / 8;
         for (size_t k = 0; k < pos; k++) {

--- a/src/arm64/arm_convert_utf32_to_utf16.cpp
+++ b/src/arm64/arm_convert_utf32_to_utf16.cpp
@@ -119,7 +119,7 @@ arm_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
     uint32x4x2_t in = vld1q_u32_x2(reinterpret_cast<const uint32_t *>(buf));
 
     // Check if no bits set above 16th
-    if (vmaxvq_u32(vorrq_u32(in.val[0], in.val[1])) <= 0xFFFF) {
+    if (simdutf_likely(vmaxvq_u32(vorrq_u32(in.val[0], in.val[1])) <= 0xFFFF)) {
       uint16x8_t utf16_packed = vuzp1q_u16(vreinterpretq_u16_u32(in.val[0]),
                                            vreinterpretq_u16_u32(in.val[1]));
 


### PR DESCRIPTION
On ARM systems with weak SIMD, PR https://github.com/simdutf/simdutf/pull/749 lead to a significant performance loss in the case where there is no possible surrogate when transcoding from utf-32 to utf-16.

The issue seems to be poor code generation. The fix is to help the compiler a bit with a hint.

With GCC 13 on a Graviton 2 (Neoverse N1), I get the following gains:

|            dataset             | size [B] | iterations | old GB/s | new GB/s | speedup |
| ------------------------------ | -------- | ---------- | -------- | -------- | ------- |
| convert_utf32_to_utf16le+arm64                                                         |
| 256k_000perc_surrogates.utf32  |  1048576 |      30000 |     3.21 |    15.73 | 4.91x   |
| 256k_005perc_surrogates.utf32  |  1048576 |      30000 |     2.41 |     4.08 | 1.69x   |
| 256k_025perc_surrogates.utf32  |  1048576 |      30000 |     2.84 |     2.85 | 1.00x   |
| 256k_033perc_surrogates.utf32  |  1048576 |      30000 |     2.94 |     2.84 | 0.96x   |
| 256k_050perc_surrogates.utf32  |  1048576 |      30000 |     2.95 |     2.77 | 0.94x   |
| 256k_075perc_surrogates.utf32  |  1048576 |      30000 |     2.98 |     2.81 | 0.94x   |
| 256k_095perc_surrogates.utf32  |  1048576 |      30000 |     2.99 |     2.82 | 0.94x   |


If I compare with the results *before* PR https://github.com/simdutf/simdutf/pull/749, I still find  a noticeable regression in the case where there is no surrogate handling (about 10%), but that's much more acceptable.


|            dataset             | size [B] | iterations | old GB/s | new GB/s | speedup |
| ------------------------------ | -------- | ---------- | -------- | -------- | ------- |
| convert_utf32_to_utf16le+arm64                                                         |
| 256k_000perc_surrogates.utf32  |  1048576 |      30000 |    17.36 |    15.73 | 0.91x   |
| 256k_005perc_surrogates.utf32  |  1048576 |      30000 |     3.04 |     4.08 | 1.34x   |
| 256k_025perc_surrogates.utf32  |  1048576 |      30000 |     1.39 |     2.85 | 2.04x   |
| 256k_033perc_surrogates.utf32  |  1048576 |      30000 |     1.17 |     2.84 | 2.43x   |
| 256k_050perc_surrogates.utf32  |  1048576 |      30000 |     0.93 |     2.77 | 2.98x   |
| 256k_075perc_surrogates.utf32  |  1048576 |      30000 |     1.34 |     2.81 | 2.10x   |
| 256k_095perc_surrogates.utf32  |  1048576 |      30000 |     2.22 |     2.82 | 1.27x   |


One might wonder why we are still taking this route, but it is important to consider that we only get this regression on weak processors with GCC. Let us consider the results on an Apple M2 with LLVM 15. I compare before the PR https://github.com/simdutf/simdutf/pull/749 with the results of the current PR.

|            dataset             | size [B] | iterations | old GB/s | new GB/s | speedup |
| ------------------------------ | -------- | ---------- | -------- | -------- | ------- |
| convert_utf32_to_utf16le+arm64                                                         |
| 256k_000perc_surrogates.utf32  |  1048576 |      30000 |    41.73 |    56.18 | 1.35x   |
| 256k_005perc_surrogates.utf32  |  1048576 |      30000 |     5.39 |     9.38 | 1.74x   |
| 256k_025perc_surrogates.utf32  |  1048576 |      30000 |     2.11 |    10.24 | 4.85x   |
| 256k_033perc_surrogates.utf32  |  1048576 |      30000 |     1.69 |    11.04 | 6.52x   |
| 256k_050perc_surrogates.utf32  |  1048576 |      30000 |     1.23 |    11.56 | 9.39x   |
| 256k_075perc_surrogates.utf32  |  1048576 |      30000 |     1.94 |    11.65 | 6.00x   |
| 256k_095perc_surrogates.utf32  |  1048576 |      30000 |     3.84 |    11.63 | 3.03x   |

So we did make progress on performant processors.

People who use Neoverse N1 processors are probably mostly network bounded. Nobody should using these systems for CPU bounded tasks.

---

Instructions:

I run...

```
./build/benchmarks/benchmark -P convert_utf32_to_utf16le+arm64 -F ./unicode_lipsum/utf32_to_utf16/256k_*perc_surrogates.utf32.txt 
```

and

```
./scripts/benchmark_print.py old.txt new.txt
```
