### PR TITLE
atomic_binary_to_base64 is too atomic: the requested feature was atomic reads

### DIFF
--- a/.github/workflows/ubuntu24sani.yml
+++ b/.github/workflows/ubuntu24sani.yml
@@ -17,20 +17,20 @@ jobs:
         run: |
           mkdir build &&
           cd build &&
-          cmake -DSIMDUTF_SANITIZE=ON ..  &&
+          cmake -DSIMDUTF_CXX_STANDARD=20 -DSIMDUTF_SANITIZE=ON ..  &&
           cmake --build .   &&
           ctest --output-on-failure
       - name: Use cmake with undefined behavior sanitizer
         run: |
           mkdir buildundef &&
           cd buildundef &&
-          cmake -DSIMDUTF_SANITIZE_UNDEFINED=ON ..  &&
+          cmake -DSIMDUTF_CXX_STANDARD=20 -DSIMDUTF_SANITIZE_UNDEFINED=ON ..  &&
           cmake --build .   &&
           ctest --output-on-failure
       - name: Use cmake with thread sanitizer
         run: |
           mkdir buildthread &&
           cd buildthread &&
-          cmake -DSIMDUTF_SANITIZE_THREAD=ON ..  &&
+          cmake -DSIMDUTF_CXX_STANDARD=20 -DSIMDUTF_SANITIZE_THREAD=ON ..  &&
           cmake --build .   &&
           ctest --output-on-failure

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -2959,8 +2959,8 @@ binary_to_base64(const detail::input_span_of_byte_like auto &input,
 /**
  * Convert a binary input to a base64 output, using atomic accesses.
  * This function comes with a potentially significant performance
- * penalty, but it may be useful in some cases where the input and
- * output buffers are shared between threads, to avoid undefined
+ * penalty, but it may be useful in some cases where the input
+ * buffers are shared between threads, to avoid undefined
  * behavior in case of data races.
  *
  * The function is for advanced users. Its main use case is when

--- a/tests/atomic_base64_tests.cpp
+++ b/tests/atomic_base64_tests.cpp
@@ -69,12 +69,9 @@ TEST(threaded) {
       std::uniform_int_distribution<int> dist{0, 255};
       std::uniform_int_distribution<std::size_t> input_index_dist{
           0, input.size() - 1};
-      std::uniform_int_distribution<std::size_t> output_index_dist{
-          0, expected_output.size() - 1};
       sync_point.arrive_and_wait();
       while (keep_running) {
         std::atomic_ref(input[input_index_dist(gen)]).fetch_add(dist(gen));
-        std::atomic_ref(output[output_index_dist(gen)]).store(dist(gen));
       }
     });
   }


### PR DESCRIPTION
We added atomic_binary_to_base64 to meet the needs of 
https://github.com/simdutf/simdutf/issues/658

But we made it too atomic. The request was for *atomic reads*.

<img width="727" alt="Screenshot 2025-04-23 at 9 07 53 AM" src="https://github.com/user-attachments/assets/e34a7216-fabf-4617-b7d3-831c40c41183" />
