### PR TITLE
LoongArch64: implement `to_well_formed_utf16`

### DIFF
--- a/src/generic/utf16/to_well_formed.h
+++ b/src/generic/utf16/to_well_formed.h
@@ -1,0 +1,94 @@
+namespace simdutf {
+namespace SIMDUTF_IMPLEMENTATION {
+namespace {
+namespace utf16 {
+
+// Note: this is direct translation of westmere implementation.
+
+/*
+ * Process one block of 8 characters.  If in_place is false,
+ * copy the block from in to out.  If there is a sequencing
+ * error in the block, overwrite the illsequenced characters
+ * with the replacement character.  This function reads one
+ * character before the beginning of the buffer as a lookback.
+ * If that character is illsequenced, it too is overwritten.
+ */
+template <endianness big_endian, bool in_place>
+simdutf_really_inline void utf16fix_block(char16_t *out, const char16_t *in) {
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+  auto swap_if_needed = [](uint16_t c) -> uint16_t {
+    return !simdutf::match_system(big_endian) ? scalar::u16_swap_bytes(c) : c;
+  };
+
+  using vector_u16 = simd16<uint16_t>;
+
+  const auto lookback = vector_u16::load(in - 1);
+  const auto block = vector_u16::load(in);
+
+  const auto lb_masked = lookback & swap_if_needed(0xfc00);
+  const auto block_masked = block & swap_if_needed(0xfc00);
+
+  const auto lb_is_high = lb_masked == swap_if_needed(0xd800);
+  const auto block_is_low = block_masked == swap_if_needed(0xdc00);
+
+  const auto illseq = lb_is_high ^ block_is_low;
+  if (!illseq.is_zero()) {
+    /* compute the cause of the illegal sequencing */
+    const auto lb_illseq = ~block_is_low & lb_is_high;
+    const auto block_illseq =
+        (~lb_is_high & block_is_low) | lb_illseq.template byte_right_shift<2>();
+
+    /* fix illegal sequencing in the lookback */
+    const auto lb = lb_illseq.first();
+    out[-1] = char16_t((lb & replacement) | (~lb & out[-1]));
+    /* fix illegal sequencing in the main block */
+    const auto mask = as_vector_u16(block_illseq);
+    const auto fixed = (~mask & block) | (mask & replacement);
+
+    fixed.store(reinterpret_cast<uint16_t *>(out));
+  } else if (!in_place) {
+    block.store(reinterpret_cast<uint16_t *>(out));
+  }
+}
+
+template <endianness big_endian>
+void to_well_formed(const char16_t *in, size_t n, char16_t *out) {
+  using vector_u16 = simd16<uint16_t>;
+  constexpr size_t N = vector_u16::ELEMENTS;
+
+  if (n < N + 1) {
+    scalar::utf16::to_well_formed_utf16<big_endian>(in, n, out);
+    return;
+  }
+
+  const char16_t replacement = scalar::utf16::replacement<big_endian>();
+
+  out[0] =
+      scalar::utf16::is_low_surrogate<big_endian>(in[0]) ? replacement : in[0];
+
+  /* duplicate code to have the compiler specialise utf16fix_block() */
+  if (in == out) {
+    constexpr bool inplace = true;
+    for (size_t i = 1; i + N < n; i += N) {
+      utf16fix_block<big_endian, inplace>(out + i, in + i);
+    }
+
+    utf16fix_block<big_endian, inplace>(out + n - N, in + n - N);
+  } else {
+    constexpr bool copy_data = false;
+    for (size_t i = 1; i + N < n; i += N) {
+      utf16fix_block<big_endian, copy_data>(out + i, in + i);
+    }
+
+    utf16fix_block<big_endian, copy_data>(out + n - N, in + n - N);
+  }
+
+  out[n - 1] = scalar::utf16::is_high_surrogate<big_endian>(out[n - 1])
+                   ? replacement
+                   : out[n - 1];
+}
+
+} // namespace utf16
+} // unnamed namespace
+} // namespace SIMDUTF_IMPLEMENTATION
+} // namespace simdutf

--- a/src/lasx/implementation.cpp
+++ b/src/lasx/implementation.cpp
@@ -208,6 +208,7 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
   #include "generic/utf16/change_endianness.h"
   #include "generic/utf16/utf8_length_from_utf16_bytemask.h"
   #include "generic/utf16/utf32_length_from_utf16.h"
+  #include "generic/utf16/to_well_formed.h"
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
@@ -361,14 +362,12 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
 
 void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
                                             char16_t *output) const noexcept {
-  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
-                                                                 output);
+  return utf16::to_well_formed<endianness::LITTLE>(input, len, output);
 }
 
 void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
                                             char16_t *output) const noexcept {
-  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
-                                                              output);
+  return utf16::to_well_formed<endianness::BIG>(input, len, output);
 }
 #endif // SIMDUTF_FEATURE_UTF16
 

--- a/src/lsx/implementation.cpp
+++ b/src/lsx/implementation.cpp
@@ -207,6 +207,7 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
   #include "generic/utf16/change_endianness.h"
   #include "generic/utf16/utf8_length_from_utf16_bytemask.h"
   #include "generic/utf16/utf32_length_from_utf16.h"
+  #include "generic/utf16/to_well_formed.h"
 #endif // SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
@@ -361,14 +362,12 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
 
 void implementation::to_well_formed_utf16le(const char16_t *input, size_t len,
                                             char16_t *output) const noexcept {
-  return scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len,
-                                                                 output);
+  utf16::to_well_formed<endianness::LITTLE>(input, len, output);
 }
 
 void implementation::to_well_formed_utf16be(const char16_t *input, size_t len,
                                             char16_t *output) const noexcept {
-  return scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len,
-                                                              output);
+  utf16::to_well_formed<endianness::BIG>(input, len, output);
 }
 #endif // SIMDUTF_FEATURE_UTF16
 


### PR DESCRIPTION
Finally run it on a real machine, performance is quite good, IMHO.

Machine:

```
CPU Family		: Loongson-64bit
Model Name		: Loongson-3C5000L-LL
```

Benchmark results:

|     dataset      | run_to_well_formed_utf16+lasx | run_to_well_formed_utf16+lsx |
| ---------------- | ----------------------------- | ---------------------------- |
| arabic.utf16     | 6.795 GB/s                    | 5.949 GB/s                   |
| chinese.utf16    | 7.156 GB/s                    | 5.932 GB/s                   |
| czech.utf16      | 6.969 GB/s                    | 5.919 GB/s                   |
| english.utf16    | 7.054 GB/s                    | 5.953 GB/s                   |
| esperanto.utf16  | 6.996 GB/s                    | 5.475 GB/s                   |
| french.utf16     | 6.790 GB/s                    | 5.514 GB/s                   |
| german.utf16     | 6.975 GB/s                    | 5.956 GB/s                   |
| greek.utf16      | 6.986 GB/s                    | 5.784 GB/s                   |
| hebrew.utf16     | 7.033 GB/s                    | 5.715 GB/s                   |
| hindi.utf16      | 6.930 GB/s                    | 5.951 GB/s                   |
| japanese.utf16   | 6.911 GB/s                    | 5.937 GB/s                   |
| korean.utf16     | 6.869 GB/s                    | 4.482 GB/s                   |
| persan.utf16     | 7.189 GB/s                    | 5.781 GB/s                   |
| portuguese.utf16 | 7.068 GB/s                    | 5.953 GB/s                   |
| russian.utf16    | 7.038 GB/s                    | 5.772 GB/s                   |
| thai.utf16       | 6.970 GB/s                    | 5.945 GB/s                   |
| turkish.utf16    | 7.216 GB/s                    | 5.941 GB/s                   |
| vietnamese.utf16 | 7.318 GB/s                    | 5.733 GB/s                   |
