### PR TITLE
Address WebKit Issue 290829: Maximize output in base64_to_binary_safe when an invalid character is encountered.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1874,6 +1874,11 @@ be useful if you seek to decode the input into segments having a maximal capacit
 Another benefit of the `base64_to_binary_safe` functions is that they inform you
 about how much data was written to the output buffer, even when there is a fatal
 error.
+This number might not be 'maximal': our fast functions may leave some data that could
+have been decoded prior to a bad character undecode. With the
+`base64_to_binary_safe` function, you also have the option of requesting that as much
+of the data as possible is decoded despite the error by setting the `decode_up_to_bad_char`
+parameter to true (it defaults to false for best performance).
 
 
 ```C++
@@ -2194,6 +2199,7 @@ size_t binary_to_base64(const char * input, size_t length, char* output, base64_
 simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options = base64_default, last_chunk_handling_options last_chunk_options =
                      last_chunk_handling_options::loose)  noexcept;
 
+
 /**
  * Convert a base64 input to a binary output.
  *
@@ -2204,12 +2210,12 @@ simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t lengt
  *
  * See https://infra.spec.whatwg.org/#forgiving-base64-decode
  *
- * This function will fail in case of invalid input. When last_chunk_options = loose,
- * there are three possible reasons for failure: the input contains a number of base64
- * characters that when divided by 4, leaves a single remainder character
- * (BASE64_INPUT_REMAINDER), the input contains a character that is not a valid
- * base64 character (INVALID_BASE64_CHARACTER), or the output buffer is too
- * small (OUTPUT_BUFFER_TOO_SMALL).
+ * This function will fail in case of invalid input. When last_chunk_options =
+ * loose, there are three possible reasons for failure: the input contains a
+ * number of base64 characters that when divided by 4, leaves a single remainder
+ * character (BASE64_INPUT_REMAINDER), the input contains a character that is
+ * not a valid base64 character (INVALID_BASE64_CHARACTER), or the output buffer
+ * is too small (OUTPUT_BUFFER_TOO_SMALL).
  *
  * When OUTPUT_BUFFER_TOO_SMALL, we return both the number of bytes written
  * and the number of units processed, see description of the parameters and
@@ -2229,7 +2235,9 @@ simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t lengt
  * characters) must be divisible by four.
  *
  * The INVALID_BASE64_CHARACTER cases are considered fatal and you are expected
- * to discard the output.
+ * to discard the output unless the parameter decode_up_to_bad_char is set to
+ * true. In that case, the function will decode up to the first invalid character.
+ * Extra padding characters ('=') are considered invalid characters.
  *
  * Advanced users may want to taylor how the last chunk is handled. By default,
  * we use a loose (forgiving) approach but we also support a strict approach
@@ -2250,15 +2258,20 @@ simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t lengt
  * last_chunk_handling_options::loose by default
  * but can also be last_chunk_handling_options::strict or
  * last_chunk_handling_options::stop_before_partial.
+ * @param decode_up_to_bad_char if true, the function will decode up to the
+ * first invalid character. By default (false), it is assumed that the output
+ * buffer is to be discarded.
  * @return a result pair struct (of type simdutf::result containing the two
  * fields error and count) with an error code and position of the
  * INVALID_BASE64_CHARACTER error (in the input in units) if any, or the number
  * of units processed if successful.
  */
 simdutf_warn_unused result base64_to_binary_safe(const char * input, size_t length, char* output, size_t& outlen, base64_options options = base64_default,
-      last_chunk_handling_options last_chunk_options = loose) noexcept;
+      last_chunk_handling_options last_chunk_options = loose,
+      bool decode_up_to_bad_char = false) noexcept;
 simdutf_warn_unused result base64_to_binary_safe(const char16_t * input, size_t length, char* output, size_t& outlen, base64_options options = base64_default,
-      last_chunk_handling_options last_chunk_options = loose) noexcept;
+      last_chunk_handling_options last_chunk_options = loose,
+      bool decode_up_to_bad_char = false) noexcept;
 ```
 
 

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -3114,16 +3114,15 @@ simdutf_really_inline simdutf_warn_unused result base64_to_binary(
  * characters) must be divisible by four.
  *
  * The INVALID_BASE64_CHARACTER cases are considered fatal and you are expected
- * to discard the output.
+ * to discard the output unless the parameter decode_up_to_bad_char is set to
+ * true. In that case, the function will decode up to the first invalid
+ * character. Extra padding characters ('=') are considered invalid characters.
  *
  * Advanced users may want to taylor how the last chunk is handled. By default,
  * we use a loose (forgiving) approach but we also support a strict approach
  * as well as a stop_before_partial approach, as per the following proposal:
  *
  * https://tc39.es/proposal-arraybuffer-base64/spec/#sec-frombase64
- *
- * When the error is INVALID_BASE64_CHARACTER, this function still writes out
- * the valid bytes that can be decoded before the INVALID_BASE64_CHARACTER.
  *
  * @param input         the base64 string to process, in ASCII stored as 8-bit
  * or 16-bit units
@@ -3138,6 +3137,9 @@ simdutf_really_inline simdutf_warn_unused result base64_to_binary(
  * last_chunk_handling_options::loose by default
  * but can also be last_chunk_handling_options::strict or
  * last_chunk_handling_options::stop_before_partial.
+ * @param decode_up_to_bad_char if true, the function will decode up to the
+ * first invalid character. By default (false), it is assumed that the output
+ * buffer is to be discarded.
  * @return a result pair struct (of type simdutf::result containing the two
  * fields error and count) with an error code and position of the
  * INVALID_BASE64_CHARACTER error (in the input in units) if any, or the number
@@ -3147,21 +3149,23 @@ simdutf_warn_unused result
 base64_to_binary_safe(const char *input, size_t length, char *output,
                       size_t &outlen, base64_options options = base64_default,
                       last_chunk_handling_options last_chunk_options =
-                          last_chunk_handling_options::loose) noexcept;
+                          last_chunk_handling_options::loose,
+                      bool decode_up_to_bad_char = false) noexcept;
   #if SIMDUTF_SPAN
-simdutf_really_inline simdutf_warn_unused result base64_to_binary_safe(
-    const detail::input_span_of_byte_like auto &input,
-    detail::output_span_of_byte_like auto &&binary_output,
-    base64_options options = base64_default,
-    last_chunk_handling_options last_chunk_options = loose) noexcept {
+simdutf_really_inline simdutf_warn_unused result
+base64_to_binary_safe(const detail::input_span_of_byte_like auto &input,
+                      detail::output_span_of_byte_like auto &&binary_output,
+                      base64_options options = base64_default,
+                      last_chunk_handling_options last_chunk_options = loose,
+                      bool decode_up_to_bad_char = false) noexcept {
   // we can't write the outlen to the provided output span, the user will have
   // to pick it up from the returned value instead (assuming success). we still
   // get the benefit of providing info of how long the output buffer is.
   size_t outlen = binary_output.size();
-  return base64_to_binary_safe(reinterpret_cast<const char *>(input.data()),
-                               input.size(),
-                               reinterpret_cast<char *>(binary_output.data()),
-                               outlen, options, last_chunk_options);
+  return base64_to_binary_safe(
+      reinterpret_cast<const char *>(input.data()), input.size(),
+      reinterpret_cast<char *>(binary_output.data()), outlen, options,
+      last_chunk_options, decode_up_to_bad_char);
 }
   #endif // SIMDUTF_SPAN
 
@@ -3169,20 +3173,23 @@ simdutf_warn_unused result
 base64_to_binary_safe(const char16_t *input, size_t length, char *output,
                       size_t &outlen, base64_options options = base64_default,
                       last_chunk_handling_options last_chunk_options =
-                          last_chunk_handling_options::loose) noexcept;
+                          last_chunk_handling_options::loose,
+                      bool decode_up_to_bad_char = false) noexcept;
   #if SIMDUTF_SPAN
-simdutf_really_inline simdutf_warn_unused result base64_to_binary_safe(
-    std::span<const char16_t> input,
-    detail::output_span_of_byte_like auto &&binary_output,
-    base64_options options = base64_default,
-    last_chunk_handling_options last_chunk_options = loose) noexcept {
+simdutf_really_inline simdutf_warn_unused result
+base64_to_binary_safe(std::span<const char16_t> input,
+                      detail::output_span_of_byte_like auto &&binary_output,
+                      base64_options options = base64_default,
+                      last_chunk_handling_options last_chunk_options = loose,
+                      bool decode_up_to_bad_char = false) noexcept {
   // we can't write the outlen to the provided output span, the user will have
   // to pick it up from the returned value instead (assuming success). we still
   // get the benefit of providing info of how long the output buffer is.
   size_t outlen = binary_output.size();
   return base64_to_binary_safe(input.data(), input.size(),
                                reinterpret_cast<char *>(binary_output.data()),
-                               outlen, options, last_chunk_options);
+                               outlen, options, last_chunk_options,
+                               decode_up_to_bad_char);
 }
   #endif // SIMDUTF_SPAN
 
@@ -3213,6 +3220,9 @@ simdutf_really_inline simdutf_warn_unused result base64_to_binary_safe(
  * @param options       the base64 options to use (default, url, etc.)
  * @param last_chunk_options the last chunk handling options (loose, strict,
  * stop_before_partial)
+ * @param decode_up_to_bad_char if true, the function will decode up to the
+ * first invalid character. By default (false), it is assumed that the output
+ * buffer is to be discarded.
  * @return a result struct with an error code and count indicating error
  * position or success
  */
@@ -3220,11 +3230,13 @@ simdutf_warn_unused result atomic_base64_to_binary_safe(
     const char *input, size_t length, char *output, size_t &outlen,
     base64_options options = base64_default,
     last_chunk_handling_options last_chunk_options =
-        last_chunk_handling_options::loose) noexcept;
+        last_chunk_handling_options::loose,
+    bool decode_up_to_bad_char = false) noexcept;
 simdutf_warn_unused result atomic_base64_to_binary_safe(
     const char16_t *input, size_t length, char *output, size_t &outlen,
     base64_options options = base64_default,
-    last_chunk_handling_options last_chunk_options = loose) noexcept;
+    last_chunk_handling_options last_chunk_options = loose,
+    bool decode_up_to_bad_char = false) noexcept;
   #endif // SIMDUTF_ATOMIC_REF
 
 #endif // SIMDUTF_FEATURE_BASE64

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -3122,6 +3122,9 @@ simdutf_really_inline simdutf_warn_unused result base64_to_binary(
  *
  * https://tc39.es/proposal-arraybuffer-base64/spec/#sec-frombase64
  *
+ * When the error is INVALID_BASE64_CHARACTER, this function still writes out
+ * the valid bytes that can be decoded before the INVALID_BASE64_CHARACTER.
+ *
  * @param input         the base64 string to process, in ASCII stored as 8-bit
  * or 16-bit units
  * @param length        the length of the string in 8-bit or 16-bit units.

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -2148,7 +2148,7 @@ simdutf_warn_unused result base64_to_binary_safe_impl(
     if (r.error == error_code::INVALID_BASE64_CHARACTER) {
       // We need to use the slow path because we want to make sure that
       // we write as much data as possible to the output buffer to meet
-      // the requirements of th JavaScript standard.
+      // the requirements of the JavaScript standard.
       return slow_base64_to_binary_safe_impl(
           input, length, output, outlen, options, last_chunk_handling_options);
     }
@@ -2183,7 +2183,7 @@ simdutf_warn_unused result base64_to_binary_safe_impl(
   if (r.error == error_code::INVALID_BASE64_CHARACTER) {
     // We need to use the slow path because we want to make sure that
     // we write as much data as possible to the output buffer to meet
-    // the requirements of th JavaScript standard.
+    // the requirements of the JavaScript standard.
     return slow_base64_to_binary_safe_impl(
         input, length, output, outlen, options, last_chunk_handling_options);
   }

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -2065,14 +2065,12 @@ simdutf_warn_unused result base64_to_binary(
       input, length, output, options, last_chunk_handling_options);
 }
 
-
 template <typename chartype>
 simdutf_warn_unused result slow_base64_to_binary_safe_impl(
     const chartype *input, size_t length, char *output, size_t &outlen,
     base64_options options,
     last_chunk_handling_options last_chunk_options) noexcept {
-  const bool ignore_garbage =
-      (options & base64_default_accept_garbage) != 0;
+  const bool ignore_garbage = (options & base64_default_accept_garbage) != 0;
   while (length > 0 &&
          scalar::base64::is_ascii_white_space(input[length - 1])) {
     length--;
@@ -2121,8 +2119,7 @@ simdutf_warn_unused result slow_base64_to_binary_safe_impl(
   // The function will also return an error code if the input buffer is not
   // valid base64.
   result r = scalar::base64::base64_tail_decode_safe(
-    output, outlen, input, length,
-    equalsigns, options, last_chunk_options);
+      output, outlen, input, length, equalsigns, options, last_chunk_options);
   if (last_chunk_options != stop_before_partial &&
       r.error == error_code::SUCCESS && equalsigns > 0) {
     // additional checks
@@ -2148,12 +2145,12 @@ simdutf_warn_unused result base64_to_binary_safe_impl(
     // fast path
     full_result r = get_default_implementation()->base64_to_binary_details(
         input, length, output, options, last_chunk_handling_options);
-    if(r.error == error_code::INVALID_BASE64_CHARACTER) {
+    if (r.error == error_code::INVALID_BASE64_CHARACTER) {
       // We need to use the slow path because we want to make sure that
       // we write as much data as possible to the output buffer to meet
       // the requirements of th JavaScript standard.
-      return slow_base64_to_binary_safe_impl(input, length, output, outlen,
-                                            options, last_chunk_handling_options);
+      return slow_base64_to_binary_safe_impl(
+          input, length, output, outlen, options, last_chunk_handling_options);
     }
     if (r.error != error_code::INVALID_BASE64_CHARACTER &&
         r.error != error_code::BASE64_EXTRA_BITS) {
@@ -2187,8 +2184,8 @@ simdutf_warn_unused result base64_to_binary_safe_impl(
     // We need to use the slow path because we want to make sure that
     // we write as much data as possible to the output buffer to meet
     // the requirements of th JavaScript standard.
-    return slow_base64_to_binary_safe_impl(input, length, output, outlen,
-                                          options, last_chunk_handling_options);
+    return slow_base64_to_binary_safe_impl(
+        input, length, output, outlen, options, last_chunk_handling_options);
   }
   size_t offset =
       (r.error == error_code::BASE64_INPUT_REMAINDER)

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -554,7 +554,7 @@ TEST(base64_decode_strict_cases_length) {
 // https://bugs.webkit.org/show_bug.cgi?id=290829
 TEST(issue_webkit_290829) {
   std::string data = "MjYyZg===";
-  std::vector<char> output(3);
+  std::vector<char> output(5); // 5 is part of the issue
   std::vector<uint8_t> expected = {0x32, 0x36, 0x32};
 
   for (auto option :
@@ -590,7 +590,7 @@ TEST(issue_webkit_290829) {
 // https://bugs.webkit.org/show_bug.cgi?id=290829
 TEST(issue_webkit_utf16_290829) {
   std::string data = "MjYyZg===";
-  std::vector<char> output(3);
+  std::vector<char> output(5); // 5 is part of the issue
   std::vector<uint16_t> expected = {0x32, 0x36, 0x32};
 
   for (auto option :

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <iostream>
 #include <memory>
@@ -10,6 +11,7 @@
 #include <sys/types.h>
 #include <tests/helpers/random_int.h>
 #include <tests/helpers/test.h>
+#include <vector>
 
 // We may disable base64url tests by commenting out this next line.
 #define SIMDUTF_BASE64URL_TESTS 1
@@ -575,9 +577,10 @@ TEST(issue_webkit_290829) {
         simdutf::last_chunk_handling_options::stop_before_partial}) {
     std::fill(output.begin(), output.end(), 0);
     size_t back_length = output.size();
-    auto r = simdutf::base64_to_binary_safe(data.data(), data.size(),
-                                            output.data(), back_length,
-                                            simdutf::base64_default, option);
+    constexpr bool decode_up_to_bad_char = true;
+    auto r = simdutf::base64_to_binary_safe(
+        data.data(), data.size(), output.data(), back_length,
+        simdutf::base64_default, option, decode_up_to_bad_char);
 
     ASSERT_EQUAL(r.error, simdutf::error_code::INVALID_BASE64_CHARACTER);
     ASSERT_EQUAL(r.count, 6);
@@ -610,14 +613,72 @@ TEST(issue_webkit_utf16_290829) {
         simdutf::last_chunk_handling_options::stop_before_partial}) {
     std::fill(output.begin(), output.end(), 0);
     size_t back_length = output.size();
-    auto r = simdutf::base64_to_binary_safe(data.data(), data.size(),
-                                            output.data(), back_length,
-                                            simdutf::base64_default, option);
+    constexpr bool decode_up_to_bad_char = true;
+    auto r = simdutf::base64_to_binary_safe(
+        data.data(), data.size(), output.data(), back_length,
+        simdutf::base64_default, option, decode_up_to_bad_char);
 
     ASSERT_EQUAL(r.error, simdutf::error_code::INVALID_BASE64_CHARACTER);
     ASSERT_EQUAL(r.count, 6);
     ASSERT_EQUAL(back_length, 3);
     ASSERT_BYTES_EQUAL(output, expected, 3);
+  }
+}
+
+// https://bugs.webkit.org/show_bug.cgi?id=290829
+
+TEST(issue_webkit_utf16_290829_bad_char) {
+  std::string data(1024, 'A');
+  std::vector<char> expected(1024 / 4 * 3, 0);
+  std::vector<char> output(1024 / 4 * 3);
+  for (size_t invalid = 0; invalid < data.size(); invalid++) {
+    data[invalid] = '?'; // invalid
+    for (auto option :
+         {simdutf::last_chunk_handling_options::strict,
+          simdutf::last_chunk_handling_options::loose,
+          simdutf::last_chunk_handling_options::stop_before_partial}) {
+      std::fill(output.begin(), output.end(), 255);
+      size_t back_length = output.size();
+      constexpr bool decode_up_to_bad_char = true;
+      auto r = simdutf::base64_to_binary_safe(
+          data.data(), data.size(), output.data(), back_length,
+          simdutf::base64_default, option, decode_up_to_bad_char);
+
+      ASSERT_EQUAL(r.error, simdutf::error_code::INVALID_BASE64_CHARACTER);
+      ASSERT_EQUAL(r.count, invalid);
+      size_t expected_length = invalid / 4 * 3;
+      ASSERT_EQUAL(back_length, expected_length);
+      ASSERT_BYTES_EQUAL(output, expected, expected_length);
+    }
+    data[invalid] = 'A'; // valid
+  }
+}
+
+
+TEST(issue_webkit_utf16_290829_example) {
+  std::string data(1024, 'A');
+  std::vector<char> expected(1024 / 4 * 3, 0);
+  std::vector<char> output(1024 / 4 * 3);
+  for (size_t invalid = 0; invalid < data.size(); invalid++) {
+    data[invalid] = '?'; // invalid
+    for (auto option :
+         {simdutf::last_chunk_handling_options::strict,
+          simdutf::last_chunk_handling_options::loose,
+          simdutf::last_chunk_handling_options::stop_before_partial}) {
+      std::fill(output.begin(), output.end(), 255);
+      size_t back_length = output.size();
+      constexpr bool decode_up_to_bad_char = true;
+      auto r = simdutf::base64_to_binary_safe(
+          data.data(), data.size(), output.data(), back_length,
+          simdutf::base64_default, option, decode_up_to_bad_char);
+
+      ASSERT_EQUAL(r.error, simdutf::error_code::INVALID_BASE64_CHARACTER);
+      ASSERT_EQUAL(r.count, invalid);
+      size_t expected_length = invalid / 4 * 3;
+      ASSERT_EQUAL(back_length, expected_length);
+      ASSERT_BYTES_EQUAL(output, expected, expected_length);
+    }
+    data[invalid] = 'A'; // valid
   }
 }
 

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -654,7 +654,6 @@ TEST(issue_webkit_utf16_290829_bad_char) {
   }
 }
 
-
 TEST(issue_webkit_utf16_290829_example) {
   std::string data(1024, 'A');
   std::vector<char> expected(1024 / 4 * 3, 0);

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -586,7 +586,6 @@ TEST(issue_webkit_290829) {
   }
 }
 
-
 // https://bugs.webkit.org/show_bug.cgi?id=290829
 TEST(issue_webkit_utf16_290829) {
   std::string data = "MjYyZg===";


### PR DESCRIPTION
When decoding base64, if we encounter an invalid character, we do not always exit after trying to write out as much output as possible. (Our spec does not says so.) This PR adds a slow path that writes out as much as possible.

The core of the issue is that the JavaScript spec assumes a slow, tiny block by tiny block, decoding. We decoding in a more sophisticated and considerably faster manner.


This should fix issue https://bugs.webkit.org/show_bug.cgi?id=290829 

We add a test using UTF-16 inputs.