### PR TITLE
silence unused warnings

### DIFF
--- a/include/simdutf/common_defs.h
+++ b/include/simdutf/common_defs.h
@@ -43,7 +43,7 @@
   #define SIMDUTF_DISABLE_DEPRECATED_WARNING SIMDUTF_DISABLE_VS_WARNING(4996)
   #define SIMDUTF_DISABLE_STRICT_OVERFLOW_WARNING
   #define SIMDUTF_POP_DISABLE_WARNINGS __pragma(warning(pop))
-
+  #define SIMDUTF_DISABLE_UNUSED_WARNING
 #else // SIMDUTF_REGULAR_VISUAL_STUDIO
   #if defined(__OPTIMIZE__) || defined(NDEBUG)
     #define simdutf_really_inline inline __attribute__((always_inline))
@@ -64,7 +64,6 @@
   #ifndef simdutf_unlikely
     #define simdutf_unlikely(x) __builtin_expect(!!(x), 0)
   #endif
-
   // clang-format off
   #define SIMDUTF_PUSH_DISABLE_WARNINGS _Pragma("GCC diagnostic push")
   // gcc doesn't seem to disable all warnings with all and extra, add warnings
@@ -96,6 +95,10 @@
   #define SIMDUTF_DISABLE_STRICT_OVERFLOW_WARNING                              \
     SIMDUTF_DISABLE_GCC_WARNING(-Wstrict-overflow)
   #define SIMDUTF_POP_DISABLE_WARNINGS _Pragma("GCC diagnostic pop")
+  #define SIMDUTF_DISABLE_UNUSED_WARNING                                       \
+    SIMDUTF_PUSH_DISABLE_WARNINGS                                              \
+    SIMDUTF_DISABLE_GCC_WARNING(-Wunused-function)                             \
+    SIMDUTF_DISABLE_GCC_WARNING(-Wunused-const-variable)
   // clang-format on
 
 #endif // MSC_VER

--- a/src/simdutf.cpp
+++ b/src/simdutf.cpp
@@ -19,6 +19,7 @@
 // only for peculiar build targets.
 
 // The best choice should always come first!
+SIMDUTF_DISABLE_UNUSED_WARNING
 #include "simdutf/arm64.h"
 #include "simdutf/icelake.h"
 #include "simdutf/haswell.h"
@@ -28,6 +29,7 @@
 #include "simdutf/lsx.h"
 #include "simdutf/lasx.h"
 #include "simdutf/fallback.h" // have it always last.
+SIMDUTF_POP_DISABLE_WARNINGS
 
 // The scalar routines should be included once.
 #include "scalar/swap_bytes.h"


### PR DESCRIPTION
In some instances, we have functions that are not immediately used in our code base but they do not cause any harm. This is especially true in our SIMD wrapper.

Fixes https://github.com/simdutf/simdutf/issues/765