### PR TITLE
Fix scope error in atomic thread test

### DIFF
--- a/src/scalar/atomic_util.h
+++ b/src/scalar/atomic_util.h
@@ -1,6 +1,6 @@
 #ifndef SIMDUTF_ATOMIC_UTIL_H
 #define SIMDUTF_ATOMIC_UTIL_H
-#if SIMDUTF_ATOMIC_REF || 1
+#if SIMDUTF_ATOMIC_REF
   #include <atomic>
 namespace simdutf {
 namespace scalar {

--- a/tests/atomic_base64_tests.cpp
+++ b/tests/atomic_base64_tests.cpp
@@ -301,8 +301,8 @@ TEST(threaded_binary_to_base64) {
     std::printf("all %u threads reached the barrier\n", nthreads);
   });
 
-  std::vector<std::jthread> threads;
   std::atomic_bool keep_running{true};
+  std::vector<std::jthread> threads;
   for (std::size_t threadi = 0; threadi < nthreads; ++threadi) {
     threads.emplace_back([&, threadi]() {
       std::mt19937 gen{static_cast<std::mt19937::result_type>(threadi)};
@@ -344,8 +344,8 @@ TEST(threaded_base64_to_binary_safe) {
     std::printf("all %u threads reached the barrier\n", nthreads);
   });
 
-  std::vector<std::jthread> threads;
   std::atomic_bool keep_running{true};
+  std::vector<std::jthread> threads;
   for (std::size_t threadi = 0; threadi < nthreads; ++threadi) {
     threads.emplace_back([&, threadi]() {
       std::mt19937 gen{static_cast<std::mt19937::result_type>(threadi)};


### PR DESCRIPTION
this fixes two minor issues.

The first one is a scope issue in the atomic thread test. I discovered this by accident when fiddling around with the threaded test when running without thread sanitizer, but with address sanitizer.

The other is a temporary hack I committed by mistake. I believe it is harmless because it is only included in c++20 anyway, but it shall be removed regardless.