### PR TITLE
fixing the base64 garbage processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2027,16 +2027,22 @@ The specification of our base64 functions is as follows:
 // garbage characters are characters that are not part of the base64 alphabet nor ASCII spaces.
 using base64_options = uint64_t;
 enum base64_options : uint64_t {
-  base64_default = 0,         /* standard base64 format (with padding) */
-  base64_url = 1,             /* base64url format (no padding) */
-  base64_reverse_padding = 2, /* modifier for base64_default and base64_url */
+  base64_default = 0, /* standard base64 format (with padding) */
+  base64_url = 1,     /* base64url format (no padding) */
   base64_default_no_padding =
       base64_default |
       base64_reverse_padding, /* standard base64 format without padding */
   base64_url_with_padding =
       base64_url | base64_reverse_padding, /* base64url with padding */
-  base64_default_accept_garbage = 4,       /* standard base64 format accepting garbage characters */
-  base64_url_accept_garbage = 5,           /* base64url format accepting garbage characters */
+  base64_default_accept_garbage =
+      4, /* standard base64 format accepting garbage characters, the input stops with the first '=' if any */
+  base64_url_accept_garbage =
+      5, /* base64url format accepting garbage characters, the input stops with the first '=' if any */
+  base64_default_or_url =
+      8, /* standard/base64url hybrid format (only meaningful for decoding!) */
+  base64_default_or_url_accept_garbage =
+      12, /* standard/base64url hybrid format accepting garbage characters
+             (only meaningful for decoding!), the input stops with the first '=' if any */
 };
 
 // last_chunk_handling_options are used to specify the handling of the last

--- a/benchmarks/base64/benchmark_base64.cpp
+++ b/benchmarks/base64/benchmark_base64.cpp
@@ -388,6 +388,7 @@ private:
       if (!e->supported_by_runtime_system()) {
         continue;
       }
+      simdutf::get_active_implementation() = e;
       summarize("simdutf::" + e->name(), [this, &e]() {
         for (const std::vector<char> &source : data) {
           size_t base64_size =
@@ -428,6 +429,7 @@ private:
       if (!e->supported_by_runtime_system()) {
         continue;
       }
+      simdutf::get_active_implementation() = e;
       summarize("simdutf::" + e->name(), [this, &e, &base64_size]() {
         for (const std::vector<char> &source : data) {
           base64_size =
@@ -458,7 +460,7 @@ private:
       if (!e->supported_by_runtime_system()) {
         continue;
       }
-
+      simdutf::get_active_implementation() = e;
       summarize("simdutf::" + e->name(), [this, &e]() {
         for (const std::vector<char> &source : data) {
           size_t base64_size =
@@ -543,6 +545,7 @@ private:
       if (!e->supported_by_runtime_system()) {
         continue;
       }
+      simdutf::get_active_implementation() = e;
 
       summarize("simdutf::" + e->name(), [this, &e]() {
         for (const std::vector<char> &source : data) {
@@ -655,6 +658,7 @@ void bench_bun() {
       if (!e->supported_by_runtime_system()) {
         continue;
       }
+      simdutf::get_active_implementation() = e;
       pretty_print(1, source.size(), "simdutf::" + e->name(),
                    bench([&source, &buffer1, &e, &base64_size]() {
                      base64_size = e->binary_to_base64(

--- a/fuzz/base64.cpp
+++ b/fuzz/base64.cpp
@@ -114,7 +114,8 @@ struct roundtripresult {
 
 void roundtrip(std::span<const char> binary, const auto selected_option,
                const auto last_chunk_option) {
-  if(last_chunk_option == simdutf::last_chunk_handling_options::stop_before_partial) {
+  if (last_chunk_option ==
+      simdutf::last_chunk_handling_options::stop_before_partial) {
     return; // this is not a valid option for roundtrip
   }
   const auto inputhash = FNV1A_hash::as_str(binary);

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -2792,14 +2792,17 @@ enum base64_options : uint64_t {
   base64_url_with_padding =
       base64_url | base64_reverse_padding, /* base64url with padding */
   base64_default_accept_garbage =
-      4, /* standard base64 format accepting garbage characters */
+      4, /* standard base64 format accepting garbage characters, the input stops
+            with the first '=' if any */
   base64_url_accept_garbage =
-      5, /* base64url format accepting garbage characters */
+      5, /* base64url format accepting garbage characters, the input stops with
+            the first '=' if any */
   base64_default_or_url =
       8, /* standard/base64url hybrid format (only meaningful for decoding!) */
   base64_default_or_url_accept_garbage =
       12, /* standard/base64url hybrid format accepting garbage characters
-             (only meaningful for decoding!) */
+             (only meaningful for decoding!), the input stops with the first '='
+             if any */
 };
 
   #if SIMDUTF_CPLUSPLUS17
@@ -5105,6 +5108,13 @@ public:
   virtual size_t
   binary_to_base64(const char *input, size_t length, char *output,
                    base64_options options = base64_default) const noexcept = 0;
+  /**
+   * Find the first occurrence of a character in a string.
+   */
+  virtual const char *find(const char *start, const char *end,
+                           char character) const noexcept = 0;
+  virtual const char16_t *find(const char16_t *start, const char16_t *end,
+                               char16_t character) const noexcept = 0;
 #endif // SIMDUTF_FEATURE_BASE64
 
 #ifdef SIMDUTF_INTERNAL_TESTS

--- a/src/arm64/arm_find.cpp
+++ b/src/arm64/arm_find.cpp
@@ -1,0 +1,72 @@
+
+simdutf_really_inline const char *find(const char *start, const char *end,
+                                       char character) const noexcept {
+  // Handle empty or invalid range
+  if (start >= end)
+    return end;
+
+  // Process 16 bytes (128 bits) at a time with NEON
+  const size_t step = 16;
+  uint8x16_t char_vec = vdupq_n_u8(static_cast<uint8_t>(character));
+
+  // Main loop for full 16-byte chunks
+  while (start + step <= end) {
+    uint8x16_t data = vld1q_u8(reinterpret_cast<const uint8_t *>(start));
+    uint8x16_t cmp = vceqq_u8(data, char_vec);
+    uint64_t mask = vget_lane_u64(vshrn_n_u16(vreinterpretq_u16_u8(cmp), 4), 0);
+
+    if (mask != 0) {
+      // Found a match, return the first one
+      int index = trailing_zeroes(mask) / 4; // Each character maps to 4 bits
+      return start + index;
+    }
+
+    start += step;
+  }
+
+  // Handle remaining bytes with scalar loop
+  for (; start < end; ++start) {
+    if (*start == character) {
+      return start;
+    }
+  }
+
+  return end;
+}
+
+simdutf_really_inline const char16_t *find(const char16_t *start,
+                                           const char16_t *end,
+                                           char16_t character) const noexcept {
+  // Handle empty or invalid range
+  if (start >= end)
+    return end;
+
+  // Process 8 char16_t (16 bytes, 128 bits) at a time with NEON
+  const size_t step = 8;
+  uint16x8_t char_vec = vdupq_n_u16(character);
+
+  // Main loop for full 8-element chunks
+  while (start + step <= end) {
+    uint16x8_t data = vld1q_u16(reinterpret_cast<const uint16_t *>(start));
+    uint16x8_t cmp = vceqq_u16(data, char_vec);
+    uint64_t mask =
+        vget_lane_u64(vshrn_n_u32(vreinterpretq_u32_u16(cmp), 4), 0);
+
+    if (mask != 0) {
+      // Found a match, return the first one
+      int index = trailing_zeroes(mask) / 8; // Each character maps to 8 bits
+      return start + index;
+    }
+
+    start += step;
+  }
+
+  // Handle remaining elements with scalar loop
+  for (; start < end; ++start) {
+    if (*start == character) {
+      return start;
+    }
+  }
+
+  return end;
+}

--- a/src/arm64/arm_find.cpp
+++ b/src/arm64/arm_find.cpp
@@ -1,6 +1,6 @@
 
 simdutf_really_inline const char *util_find(const char *start, const char *end,
-                                       char character) noexcept {
+                                            char character) noexcept {
   // Handle empty or invalid range
   if (start >= end)
     return end;
@@ -13,7 +13,8 @@ simdutf_really_inline const char *util_find(const char *start, const char *end,
   while (start + step <= end) {
     uint8x16_t data = vld1q_u8(reinterpret_cast<const uint8_t *>(start));
     uint8x16_t cmp = vceqq_u8(data, char_vec);
-    uint64_t mask = vget_lane_u64(vshrn_n_u16(vreinterpretq_u16_u8(cmp), 4), 0);
+    uint64_t mask = vget_lane_u64(
+        vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(cmp), 4)), 0);
 
     if (mask != 0) {
       // Found a match, return the first one
@@ -35,8 +36,8 @@ simdutf_really_inline const char *util_find(const char *start, const char *end,
 }
 
 simdutf_really_inline const char16_t *util_find(const char16_t *start,
-                                           const char16_t *end,
-                                           char16_t character) noexcept {
+                                                const char16_t *end,
+                                                char16_t character) noexcept {
   // Handle empty or invalid range
   if (start >= end)
     return end;

--- a/src/arm64/arm_find.cpp
+++ b/src/arm64/arm_find.cpp
@@ -10,7 +10,7 @@ simdutf_really_inline const char *util_find(const char *start, const char *end,
   uint8x16_t char_vec = vdupq_n_u8(static_cast<uint8_t>(character));
 
   // Main loop for full 16-byte chunks
-  while (start + step <= end) {
+  while (end - start >= step) {
     uint8x16_t data = vld1q_u8(reinterpret_cast<const uint8_t *>(start));
     uint8x16_t cmp = vceqq_u8(data, char_vec);
     uint64_t mask = vget_lane_u64(
@@ -47,7 +47,7 @@ simdutf_really_inline const char16_t *util_find(const char16_t *start,
   uint16x8_t char_vec = vdupq_n_u16(character);
 
   // Main loop for full 8-element chunks
-  while (start + step <= end) {
+  while (end - start >= step) {
     uint16x8_t data = vld1q_u16(reinterpret_cast<const uint16_t *>(start));
     uint16x8_t cmp = vceqq_u16(data, char_vec);
     uint64_t mask = vget_lane_u64(

--- a/src/arm64/arm_find.cpp
+++ b/src/arm64/arm_find.cpp
@@ -1,6 +1,6 @@
 
-simdutf_really_inline const char *find(const char *start, const char *end,
-                                       char character) const noexcept {
+simdutf_really_inline const char *util_find(const char *start, const char *end,
+                                       char character) noexcept {
   // Handle empty or invalid range
   if (start >= end)
     return end;
@@ -34,9 +34,9 @@ simdutf_really_inline const char *find(const char *start, const char *end,
   return end;
 }
 
-simdutf_really_inline const char16_t *find(const char16_t *start,
+simdutf_really_inline const char16_t *util_find(const char16_t *start,
                                            const char16_t *end,
-                                           char16_t character) const noexcept {
+                                           char16_t character) noexcept {
   // Handle empty or invalid range
   if (start >= end)
     return end;

--- a/src/arm64/arm_find.cpp
+++ b/src/arm64/arm_find.cpp
@@ -50,8 +50,8 @@ simdutf_really_inline const char16_t *util_find(const char16_t *start,
   while (start + step <= end) {
     uint16x8_t data = vld1q_u16(reinterpret_cast<const uint16_t *>(start));
     uint16x8_t cmp = vceqq_u16(data, char_vec);
-    uint64_t mask =
-        vget_lane_u64(vshrn_n_u32(vreinterpretq_u32_u16(cmp), 4), 0);
+    uint64_t mask = vget_lane_u64(
+        vreinterpret_u64_u16(vshrn_n_u32(vreinterpretq_u32_u16(cmp), 4)), 0);
 
     if (mask != 0) {
       // Found a match, return the first one

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -1346,12 +1346,12 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
 
 const char *implementation::find(const char *start, const char *end,
                                  char character) const noexcept {
-  return find(start, end, character);
+  return util_find(start, end, character);
 }
 
 const char16_t *implementation::find(const char16_t *start, const char16_t *end,
                                      char16_t character) const noexcept {
-  return find(start, end, character);
+  return util_find(start, end, character);
 }
 #endif // SIMDUTF_FEATURE_BASE64
 

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -149,6 +149,7 @@ convert_utf8_1_to_2_byte_to_utf16(uint8x16_t in, size_t shufutf8_idx) {
 
 #if SIMDUTF_FEATURE_BASE64
   #include "arm64/arm_base64.cpp"
+  #include "arm64/arm_find.cpp"
 #endif // SIMDUTF_FEATURE_BASE64
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
   #include "arm64/arm_convert_utf32_to_latin1.cpp"
@@ -1341,6 +1342,16 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
                                         char *output,
                                         base64_options options) const noexcept {
   return encode_base64(output, input, length, options);
+}
+
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return find(start, end, character);
 }
 #endif // SIMDUTF_FEATURE_BASE64
 

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -549,6 +549,16 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
                                         base64_options options) const noexcept {
   return scalar::base64::tail_encode_base64(output, input, length, options);
 }
+
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return std::find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return std::find(start, end, character);
+}
 #endif // SIMDUTF_FEATURE_BASE64
 
 } // namespace SIMDUTF_IMPLEMENTATION

--- a/src/generic/find.h
+++ b/src/generic/find.h
@@ -20,12 +20,12 @@ simdutf_really_inline const char *find(const char *start, const char *end,
 
 simdutf_really_inline const char16_t *
 find(const char16_t *start, const char16_t *end, char16_t character) noexcept {
-  for (; std::distance(start, end) >= 64; start += 64) {
+  for (; std::distance(start, end) >= 32; start += 32) {
     simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(start));
     uint64_t matches = input.eq(uint16_t(character));
     if (matches != 0) {
       // Found a match, return the first one
-      int index = trailing_zeroes(matches);
+      int index = trailing_zeroes(matches)/2;
       return start + index;
     }
   }

--- a/src/generic/find.h
+++ b/src/generic/find.h
@@ -1,0 +1,37 @@
+
+namespace simdutf {
+namespace SIMDUTF_IMPLEMENTATION {
+namespace {
+namespace util {
+
+simdutf_really_inline const char *find(const char *start, const char *end,
+                                       char character) noexcept {
+  for (; std::distance(start, end) >= 64; start += 64) {
+    simd8x64<uint8_t> input(reinterpret_cast<const uint8_t *>(start));
+    uint64_t matches = input.eq(uint8_t(character));
+    if (matches != 0) {
+      // Found a match, return the first one
+      int index = trailing_zeroes(matches);
+      return start + index;
+    }
+  }
+  return std::find(start, end, character);
+}
+
+simdutf_really_inline const char16_t *
+find(const char16_t *start, const char16_t *end, char16_t character) noexcept {
+  for (; std::distance(start, end) >= 64; start += 64) {
+    simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(start));
+    uint64_t matches = input.eq(uint16_t(character));
+    if (matches != 0) {
+      // Found a match, return the first one
+      int index = trailing_zeroes(matches);
+      return start + index;
+    }
+  }
+  return std::find(start, end, character);
+}
+} // namespace util
+} // namespace
+} // namespace SIMDUTF_IMPLEMENTATION
+} // namespace simdutf

--- a/src/generic/find.h
+++ b/src/generic/find.h
@@ -25,7 +25,7 @@ find(const char16_t *start, const char16_t *end, char16_t character) noexcept {
     uint64_t matches = input.eq(uint16_t(character));
     if (matches != 0) {
       // Found a match, return the first one
-      int index = trailing_zeroes(matches)/2;
+      int index = trailing_zeroes(matches) / 2;
       return start + index;
     }
   }

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -142,6 +142,7 @@ namespace utf16 {
 
 #if SIMDUTF_FEATURE_BASE64
   #include "generic/base64.h"
+  #include "generic/find.h"
 #endif // SIMDUTF_FEATURE_BASE64
 
 namespace simdutf {
@@ -1360,7 +1361,18 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
     return encode_base64<false>(output, input, length, options);
   }
 }
+
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return util::find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return util::find(start, end, character);
+}
 #endif // SIMDUTF_FEATURE_BASE64
+
 } // namespace SIMDUTF_IMPLEMENTATION
 } // namespace simdutf
 

--- a/src/icelake/icelake_find.inl.cpp
+++ b/src/icelake/icelake_find.inl.cpp
@@ -10,7 +10,7 @@ simdutf_really_inline const char *util_find(const char *start, const char *end,
   __m512i char_vec = _mm512_set1_epi8(character);
 
   // Main loop for full 64-byte chunks
-  while (start + step <= end) {
+  while (end - start >= step) {
     __m512i data = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(start));
     __mmask64 mask = _mm512_cmpeq_epi8_mask(data, char_vec);
 
@@ -57,7 +57,7 @@ simdutf_really_inline const char16_t *util_find(const char16_t *start,
   __m512i char_vec = _mm512_set1_epi16(character);
 
   // Main loop for full 32-element chunks
-  while (start + step <= end) {
+  while (end - start >= step) {
     __m512i data = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(start));
     __mmask32 mask = _mm512_cmpeq_epi16_mask(data, char_vec);
 

--- a/src/icelake/icelake_find.inl.cpp
+++ b/src/icelake/icelake_find.inl.cpp
@@ -1,0 +1,93 @@
+
+simdutf_really_inline const char *util_find(const char *start, const char *end,
+                                            char character) noexcept {
+  // Handle empty or invalid range
+  if (start >= end)
+    return end;
+
+  // Process 64 bytes (512 bits) at a time with AVX-512
+  const size_t step = 64;
+  __m512i char_vec = _mm512_set1_epi8(character);
+
+  // Main loop for full 64-byte chunks
+  while (start + step <= end) {
+    __m512i data = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(start));
+    __mmask64 mask = _mm512_cmpeq_epi8_mask(data, char_vec);
+
+    if (mask != 0) {
+      // Found a match, return the first one
+      size_t index = _tzcnt_u64(mask);
+      return start + index;
+    }
+
+    start += step;
+  }
+
+  // Handle remaining bytes with masked load
+  size_t remaining = end - start;
+  if (remaining > 0) {
+    // Create a mask for the remaining bytes using shifted 0xFFFFFFFFFFFFFFFF
+    __mmask64 load_mask = 0xFFFFFFFFFFFFFFFF >> (64 - remaining);
+    __m512i data = _mm512_maskz_loadu_epi8(
+        load_mask, reinterpret_cast<const __m512i *>(start));
+    __mmask64 match_mask = _mm512_cmpeq_epi8_mask(data, char_vec);
+
+    // Apply load mask to avoid false positives
+    match_mask &= load_mask;
+
+    if (match_mask != 0) {
+      // Found a match in the remaining bytes
+      size_t index = _tzcnt_u64(match_mask);
+      return start + index;
+    }
+  }
+
+  return end;
+}
+
+simdutf_really_inline const char16_t *util_find(const char16_t *start,
+                                                const char16_t *end,
+                                                char16_t character) noexcept {
+  // Handle empty or invalid range
+  if (start >= end)
+    return end;
+
+  // Process 32 char16_t (64 bytes, 512 bits) at a time with AVX-512
+  const size_t step = 32;
+  __m512i char_vec = _mm512_set1_epi16(character);
+
+  // Main loop for full 32-element chunks
+  while (start + step <= end) {
+    __m512i data = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(start));
+    __mmask32 mask = _mm512_cmpeq_epi16_mask(data, char_vec);
+
+    if (mask != 0) {
+      // Found a match, return the first one
+      size_t index = _tzcnt_u64(mask);
+      return start + index;
+    }
+
+    start += step;
+  }
+
+  // Handle remaining elements with masked load
+  size_t remaining = end - start;
+  if (remaining > 0) {
+    // Create a mask for the remaining elements using shifted 0xFFFFFFFF
+    __mmask32 load_mask = 0xFFFFFFFF >> (32 - remaining);
+    __m512i data = _mm512_maskz_loadu_epi16(
+        load_mask, reinterpret_cast<const __m512i *>(start));
+    __mmask32 match_mask = _mm512_cmpeq_epi16_mask(data, char_vec);
+
+    // Apply load mask to avoid false positives
+    match_mask &= load_mask;
+
+    if (match_mask != 0) {
+      // Found a match in the remaining elements
+      size_t index = _tzcnt_u64(match_mask);
+      return start + index;
+    }
+  }
+
+  return end;
+}

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -79,6 +79,7 @@ using namespace simd;
 #endif // SIMDUTF_FEATURE_UTF32
 #if SIMDUTF_FEATURE_BASE64
   #include "icelake/icelake_base64.inl.cpp"
+  #include "icelake/icelake_find.inl.cpp"
 #endif // SIMDUTF_FEATURE_BASE64
 
 #include <cstdint>
@@ -1729,6 +1730,16 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
     return encode_base64<false>(output, input, length, options);
   }
 }
+
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return util_find(start, end, character);
+}
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return util_find(start, end, character);
+}
+
 #endif // SIMDUTF_FEATURE_BASE64
 
 } // namespace SIMDUTF_IMPLEMENTATION

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -735,6 +735,16 @@ public:
                           base64_options options) const noexcept override {
     return set_best()->binary_to_base64(input, length, output, options);
   }
+
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept override {
+    return set_best()->find(start, end, character);
+  }
+
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept override {
+    return set_best()->find(start, end, character);
+  }
 #endif // SIMDUTF_FEATURE_BASE64
 
   simdutf_really_inline
@@ -1244,6 +1254,13 @@ public:
   size_t binary_to_base64(const char *, size_t, char *,
                           base64_options) const noexcept override {
     return 0;
+  }
+  const char *find(const char *, const char *, char) const noexcept override {
+    return nullptr;
+  }
+  const char16_t *find(const char16_t *, const char16_t *,
+                       char16_t) const noexcept override {
+    return nullptr;
   }
 #endif // SIMDUTF_FEATURE_BASE64
 

--- a/src/lasx/implementation.cpp
+++ b/src/lasx/implementation.cpp
@@ -1448,7 +1448,18 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
     return encode_base64<false>(output, input, length, options);
   }
 }
+
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return std::find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return std::find(start, end, character);
+}
 #endif // SIMDUTF_FEATURE_BASE64
+
 } // namespace SIMDUTF_IMPLEMENTATION
 } // namespace simdutf
 

--- a/src/lsx/implementation.cpp
+++ b/src/lsx/implementation.cpp
@@ -1334,7 +1334,17 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
     return encode_base64<false>(output, input, length, options);
   }
 }
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return std::find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return std::find(start, end, character);
+}
 #endif // SIMDUTF_FEATURE_BASE64
+
 } // namespace SIMDUTF_IMPLEMENTATION
 } // namespace simdutf
 

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -893,6 +893,15 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
     return encode_base64<false>(output, input, length, options);
   }
 }
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return std::find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return std::find(start, end, character);
+}
 #endif // SIMDUTF_FEATURE_BASE64
 
 #ifdef SIMDUTF_INTERNAL_TESTS

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -95,6 +95,7 @@ enum class ErrorReporting {
 
 #if SIMDUTF_FEATURE_BASE64
   #include "ppc64/ppc64_base64.cpp"
+  #include "generic/find.h"
 #endif // SIMDUTF_FEATURE_BASE64
 
 } // unnamed namespace
@@ -895,12 +896,12 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
 }
 const char *implementation::find(const char *start, const char *end,
                                  char character) const noexcept {
-  return std::find(start, end, character);
+  return util::find(start, end, character);
 }
 
 const char16_t *implementation::find(const char16_t *start, const char16_t *end,
                                      char16_t character) const noexcept {
-  return std::find(start, end, character);
+  return util::find(start, end, character);
 }
 #endif // SIMDUTF_FEATURE_BASE64
 

--- a/src/rvv/implementation.cpp
+++ b/src/rvv/implementation.cpp
@@ -118,6 +118,16 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
                                         base64_options options) const noexcept {
   return scalar::base64::tail_encode_base64(output, input, length, options);
 }
+
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return std::find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return std::find(start, end, character);
+}
 #endif // SIMDUTF_FEATURE_BASE64
 
 } // namespace SIMDUTF_IMPLEMENTATION

--- a/src/scalar/base64.h
+++ b/src/scalar/base64.h
@@ -119,12 +119,10 @@ reduced_input find_end(const char_type *src, size_t srclen,
   size_t equallocation =
       srclen; // location of the first padding character if any
   if (ignore_garbage) {
-    // TODO: std::find is atrocious here, we should use a better algorithm
-    // to find the first padding character.
     // Technically, we don't need to find the first padding character, we can
-    // just change our algorithms, but it adds substantial complexity. A
-    // faster std::find would be the best solution.
-    auto it = std::find(src, src + srclen, '=');
+    // just change our algorithms, but it adds substantial complexity.
+    auto it =
+        simdutf::get_active_implementation()->find(src, src + srclen, '=');
     if (it != src + srclen) {
       equallocation = it - src;
       equalsigns = 1;

--- a/src/scalar/base64.h
+++ b/src/scalar/base64.h
@@ -1,6 +1,7 @@
 #ifndef SIMDUTF_BASE64_H
 #define SIMDUTF_BASE64_H
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -117,6 +118,21 @@ reduced_input find_end(const char_type *src, size_t srclen,
   size_t full_input_length = srclen;
   size_t equallocation =
       srclen; // location of the first padding character if any
+  if (ignore_garbage) {
+    // TODO: std::find is atrocious here, we should use a better algorithm
+    // to find the first padding character.
+    // Technically, we don't need to find the first padding character, we can
+    // just change our algorithms, but it adds substantial complexity. A
+    // faster std::find would be the best solution.
+    auto it = std::find(src, src + srclen, '=');
+    if (it != src + srclen) {
+      equallocation = it - src;
+      equalsigns = 1;
+      srclen = equallocation;
+      full_input_length = equallocation + 1;
+    }
+    return {equalsigns, equallocation, srclen, full_input_length};
+  }
   if (!ignore_garbage && srclen > 0 && src[srclen - 1] == '=') {
     // This is the last '=' sign.
     equallocation = srclen - 1;

--- a/src/simdutf/arm64/implementation.h
+++ b/src/simdutf/arm64/implementation.h
@@ -267,7 +267,7 @@ public:
                    char character) const noexcept;
   const char16_t *find(const char16_t *start, const char16_t *end,
                        char16_t character) const noexcept;
-
+};
 #endif // SIMDUTF_FEATURE_BASE64
 
 } // namespace arm64

--- a/src/simdutf/arm64/implementation.h
+++ b/src/simdutf/arm64/implementation.h
@@ -263,8 +263,12 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
+
 #endif // SIMDUTF_FEATURE_BASE64
-};
 
 } // namespace arm64
 } // namespace simdutf

--- a/src/simdutf/arm64/simd32-inl.h
+++ b/src/simdutf/arm64/simd32-inl.h
@@ -27,9 +27,11 @@ template <> struct simd32<uint32_t> {
   }
 
   void dump() const {
+#ifdef SIMDUTF_LOGGING
     uint32_t temp[4];
     vst1q_u32(temp, value);
     printf("[%08x, %08x, %08x, %08x]\n", temp[0], temp[1], temp[2], temp[3]);
+#endif // SIMDUTF_LOGGING
   }
 
   // operators

--- a/src/simdutf/fallback/implementation.h
+++ b/src/simdutf/fallback/implementation.h
@@ -290,6 +290,11 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
+
 #endif // SIMDUTF_FEATURE_BASE64
 };
 } // namespace fallback

--- a/src/simdutf/haswell/implementation.h
+++ b/src/simdutf/haswell/implementation.h
@@ -293,6 +293,10 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
 #endif // SIMDUTF_FEATURE_BASE64
 };
 

--- a/src/simdutf/haswell/simd.h
+++ b/src/simdutf/haswell/simd.h
@@ -333,7 +333,11 @@ template <typename T> struct simd8x64 {
     return simd8x64<bool>(this->chunks[0] > mask, this->chunks[1] > mask)
         .to_bitmask();
   }
-
+  simdutf_really_inline uint64_t eq(const T m) const {
+    const simd8<T> mask = simd8<T>::splat(m);
+    return simd8x64<bool>(this->chunks[0] == mask, this->chunks[1] == mask)
+        .to_bitmask();
+  }
   simdutf_really_inline uint64_t gteq_unsigned(const uint8_t m) const {
     const simd8<uint8_t> mask = simd8<uint8_t>::splat(m);
     return simd8x64<bool>((simd8<uint8_t>(__m256i(this->chunks[0])) >= mask),

--- a/src/simdutf/haswell/simd16-inl.h
+++ b/src/simdutf/haswell/simd16-inl.h
@@ -236,7 +236,11 @@ template <typename T> struct simd16x32 {
     return simd16x32<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask)
         .to_bitmask();
   }
-
+  simdutf_really_inline uint64_t eq(const T m) const {
+    const simd16<T> mask = simd16<T>::splat(m);
+    return simd16x32<bool>(this->chunks[0] == mask, this->chunks[1] == mask)
+        .to_bitmask();
+  }
   simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
     const simd16<T> mask_low = simd16<T>::splat(static_cast<T>(low - 1));
     const simd16<T> mask_high = simd16<T>::splat(static_cast<T>(high + 1));

--- a/src/simdutf/icelake/implementation.h
+++ b/src/simdutf/icelake/implementation.h
@@ -300,6 +300,10 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
 #endif // SIMDUTF_FEATURE_BASE64
 };
 

--- a/src/simdutf/lasx/implementation.h
+++ b/src/simdutf/lasx/implementation.h
@@ -264,6 +264,10 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
 #endif // SIMDUTF_FEATURE_BASE64
 };
 

--- a/src/simdutf/lsx/implementation.h
+++ b/src/simdutf/lsx/implementation.h
@@ -263,6 +263,10 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
 #endif // SIMDUTF_FEATURE_BASE64
 };
 

--- a/src/simdutf/ppc64/implementation.h
+++ b/src/simdutf/ppc64/implementation.h
@@ -294,15 +294,24 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
 #endif // SIMDUTF_FEATURE_BASE64
 
 #ifdef SIMDUTF_INTERNAL_TESTS
   virtual std::vector<TestProcedure> internal_tests() const override;
 #endif
+#if SIMDUTF_FEATURE_UTF16
+
   void to_well_formed_utf16be(const char16_t *input, size_t len,
                               char16_t *output) const noexcept final;
   void to_well_formed_utf16le(const char16_t *input, size_t len,
                               char16_t *output) const noexcept final;
+#endif
 };
 
 } // namespace ppc64

--- a/src/simdutf/ppc64/simd16-inl.h
+++ b/src/simdutf/ppc64/simd16-inl.h
@@ -300,13 +300,6 @@ template <typename T> struct simd16x32 {
         .to_bitmask();
   }
 
-  simdutf_really_inline uint64_t lteq(const T m) const {
-    const simd16<T> mask = simd16<T>::splat(m);
-    return simd16x32<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask,
-                           this->chunks[2] <= mask, this->chunks[3] <= mask)
-        .to_bitmask();
-  }
-
   simdutf_really_inline uint64_t eq(const T m) const {
     const simd16<T> mask = simd16<T>::splat(m);
     return simd16x32<bool>(this->chunks[0] == mask, this->chunks[1] == mask,

--- a/src/simdutf/ppc64/simd16-inl.h
+++ b/src/simdutf/ppc64/simd16-inl.h
@@ -300,6 +300,20 @@ template <typename T> struct simd16x32 {
         .to_bitmask();
   }
 
+  simdutf_really_inline uint64_t lteq(const T m) const {
+    const simd16<T> mask = simd16<T>::splat(m);
+    return simd16x32<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask,
+                           this->chunks[2] <= mask, this->chunks[3] <= mask)
+        .to_bitmask();
+  }
+
+  simdutf_really_inline uint64_t eq(const T m) const {
+    const simd16<T> mask = simd16<T>::splat(m);
+    return simd16x32<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
+                           this->chunks[2] == mask, this->chunks[3] == mask)
+        .to_bitmask();
+  }
+
   simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
     const simd16<T> mask_low = simd16<T>::splat(static_cast<T>(low - 1));
     const simd16<T> mask_high = simd16<T>::splat(static_cast<T>(high + 1));

--- a/src/simdutf/ppc64/simd8-inl.h
+++ b/src/simdutf/ppc64/simd8-inl.h
@@ -588,7 +588,12 @@ template <typename T> struct simd8x64 {
                           this->chunks[2] > mask, this->chunks[3] > mask)
         .to_bitmask();
   }
-
+  simdutf_really_inline uint64_t eq(const T m) const {
+    const simd8<T> mask = simd8<T>::splat(m);
+    return simd8x64<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
+                          this->chunks[2] == mask, this->chunks[3] == mask)
+        .to_bitmask();
+  }
   simdutf_really_inline uint64_t gteq_unsigned(const uint8_t m) const {
     const simd8<uint8_t> mask = simd8<uint8_t>::splat(m);
     return simd8x64<bool>(simd8<uint8_t>(this->chunks[0]) >= mask,

--- a/src/simdutf/rvv/implementation.h
+++ b/src/simdutf/rvv/implementation.h
@@ -269,6 +269,11 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
 #endif // SIMDUTF_FEATURE_BASE64
 private:
   const bool _supports_zvbb;

--- a/src/simdutf/westmere/implementation.h
+++ b/src/simdutf/westmere/implementation.h
@@ -293,6 +293,10 @@ public:
           last_chunk_handling_options::loose) const noexcept;
   size_t binary_to_base64(const char *input, size_t length, char *output,
                           base64_options options) const noexcept;
+  const char *find(const char *start, const char *end,
+                   char character) const noexcept;
+  const char16_t *find(const char16_t *start, const char16_t *end,
+                       char16_t character) const noexcept;
 #endif // SIMDUTF_FEATURE_BASE64
 };
 

--- a/src/simdutf/westmere/simd.h
+++ b/src/simdutf/westmere/simd.h
@@ -336,6 +336,14 @@ template <typename T> struct simd8x64 {
                           this->chunks[2] > mask, this->chunks[3] > mask)
         .to_bitmask();
   }
+
+  simdutf_really_inline uint64_t eq(const T m) const {
+    const simd8<T> mask = simd8<T>::splat(m);
+    return simd8x64<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
+                          this->chunks[2] == mask, this->chunks[3] == mask)
+        .to_bitmask();
+  }
+
   simdutf_really_inline uint64_t gteq_unsigned(const uint8_t m) const {
     const simd8<uint8_t> mask = simd8<uint8_t>::splat(m);
     return simd8x64<bool>(simd8<uint8_t>(__m128i(this->chunks[0])) >= mask,

--- a/src/simdutf/westmere/simd16-inl.h
+++ b/src/simdutf/westmere/simd16-inl.h
@@ -212,6 +212,13 @@ template <typename T> struct simd16x32 {
         .to_bitmask();
   }
 
+  simdutf_really_inline uint64_t eq(const T m) const {
+    const simd16<T> mask = simd16<T>::splat(m);
+    return simd16x32<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
+                           this->chunks[2] == mask, this->chunks[3] == mask)
+        .to_bitmask();
+  }
+
   simdutf_really_inline uint64_t not_in_range(const T low, const T high) const {
     const simd16<T> mask_low = simd16<T>::splat(static_cast<T>(low - 1));
     const simd16<T> mask_high = simd16<T>::splat(static_cast<T>(high + 1));

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -138,6 +138,7 @@ must_be_2_3_continuation(const simd8<uint8_t> prev2,
 
 #if SIMDUTF_FEATURE_BASE64
   #include "generic/base64.h"
+  #include "generic/find.h"
 #endif // SIMDUTF_FEATURE_BASE64
 
 //
@@ -1391,6 +1392,16 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
   } else {
     return encode_base64<false>(output, input, length, options);
   }
+}
+
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
+  return util::find(start, end, character);
+}
+
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
+  return util::find(start, end, character);
 }
 #endif // SIMDUTF_FEATURE_BASE64
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -116,7 +116,11 @@ if(Python3_FOUND)
   )
   unset(SCRIPT)
 endif(Python3_FOUND)
+add_cpp_test(find_tests)
 
+target_link_libraries(find_tests
+  PUBLIC simdutf::tests::helpers
+         simdutf::tests::reference)
 
 add_cpp_test(convert_latin1_to_utf8_tests)
 target_link_libraries(convert_latin1_to_utf8_tests 

--- a/tests/atomic_base64_tests.cpp
+++ b/tests/atomic_base64_tests.cpp
@@ -376,8 +376,8 @@ TEST(issue_dash) {
   const std::string input = "Iw==";
   std::vector<char> back(1);
   size_t len = back.size();
-  auto r = simdutf::atomic_base64_to_binary_safe(
-      input.data(), input.size(), back.data(), len);
+  auto r = simdutf::atomic_base64_to_binary_safe(input.data(), input.size(),
+                                                 back.data(), len);
   ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
   ASSERT_EQUAL(r.count, 4);
   ASSERT_EQUAL(len, 1);

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -173,7 +173,7 @@ size_t add_garbage(std::vector<char_type> &v, std::mt19937 &gen,
   size_t i = index_dist(gen);
   std::uniform_int_distribution<int> char_dist(
       0, (1 << (sizeof(char_type) * 8)) - 1);
-  uint8_t c = char_dist(gen);
+  char_type c = char_dist(gen);
   while ((uint8_t(c) == c && table[uint8_t(c)] != 255) || c == '=') {
     c = char_dist(gen);
   }

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -174,19 +174,115 @@ size_t add_garbage(std::vector<char_type> &v, std::mt19937 &gen,
   std::uniform_int_distribution<int> char_dist(
       0, (1 << (sizeof(char_type) * 8)) - 1);
   uint8_t c = char_dist(gen);
-  while (uint8_t(c) == c && table[uint8_t(c)] != 255) {
+  while ((uint8_t(c) == c && table[uint8_t(c)] != 255) || c == '=') {
     c = char_dist(gen);
   }
   v.insert(v.begin() + i, c);
   return i;
 }
 
+// From Node.js tests:
+TEST(issue_node_anything_goes) {
+
+  auto test =
+      [](const std::string &input, const std::string &expected,
+         simdutf::base64_options options =
+             simdutf::base64_options::base64_default_or_url_accept_garbage) {
+        size_t buflen = simdutf::maximal_binary_length_from_base64(
+            input.data(), input.size());
+        std::vector<char> back(buflen);
+        size_t written_len = buflen;
+        auto result = simdutf::base64_to_binary_safe(
+            input.data(), input.length(), back.data(), written_len,
+            simdutf::base64_default_or_url_accept_garbage);
+        ASSERT_EQUAL(result.error, simdutf::error_code::SUCCESS);
+        ASSERT_EQUAL(written_len, expected.size());
+        ASSERT_TRUE(std::equal(back.begin(), back.begin() + written_len,
+                               expected.begin()));
+      };
+  test("YQ", "a");
+  test("Y Q", "a");
+  test("Y Q ", "a");
+  test(" Y Q", "a");
+  test("Y Q==", "a");
+  test("YQ ==", "a");
+  test("YQ == junk", "a");
+  test("YWI", "ab");
+  test("YWI=", "ab");
+  test("YWJj", "abc");
+  test("YWJjZA", "abcd");
+  test("YWJjZA==", "abcd");
+  test("YW Jj ZA ==", "abcd");
+  test("YWJjZGU=", "abcde");
+  test("YWJjZGVm", "abcdef");
+  test("Y WJjZGVm", "abcdef");
+  test("YW JjZGVm", "abcdef");
+  test("YWJ jZGVm", "abcdef");
+  test("YWJj ZGVm", "abcdef");
+  test("Y W J j Z G V m", "abcdef");
+  test("Y   W\n JjZ \nG Vm", "abcdef");
+  test("rMeTqoNvw-M_dQ", "\xac\xc7\x93\xaa\x83\x6f\xc3\xe3\x3f\x75");
+
+  const char *text =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do "
+      "eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut "
+      "enim ad minim veniam, quis nostrud exercitation ullamco laboris "
+      "nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in "
+      "reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla "
+      "pariatur. Excepteur sint occaecat cupidatat non proident, sunt in "
+      "culpa qui officia deserunt mollit anim id est laborum.";
+
+  test("TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2Npbmcg"
+       "ZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0"
+       "IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlz"
+       "IG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1"
+       "aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBp"
+       "biByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xv"
+       "cmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNh"
+       "dCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lh"
+       "IGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg==",
+       text);
+
+  test("TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2Npbmcg"
+       "ZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0"
+       "IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlz"
+       "IG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1"
+       "aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBp"
+       "biByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xv"
+       "cmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNh"
+       "dCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lh"
+       "IGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg",
+       text);
+
+  test("TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2Npbmcg\n"
+       "ZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0\n"
+       "IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlz\n"
+       "IG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1\n"
+       "aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBp\n"
+       "biByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xv\n"
+       "cmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNh\n"
+       "dCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lh\n"
+       "IGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg==",
+       text);
+
+  test("TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2Npbmcg\n"
+       "ZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0\n"
+       "IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlz\n"
+       "IG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1\n"
+       "aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBp\n"
+       "biByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xv\n"
+       "cmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNh\n"
+       "dCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lh\n"
+       "IGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg",
+       text);
+}
+
 TEST(issue_dash) {
   const std::string input = "Iw==";
   std::vector<char> back(1);
   size_t len = back.size();
-  auto r = simdutf::base64_to_binary_safe(
-      input.data(), input.size(), back.data(), len);
+  auto r = simdutf::base64_to_binary_safe(input.data(), input.size(),
+                                          back.data(), len);
   ASSERT_EQUAL(r.error, simdutf::error_code::SUCCESS);
   ASSERT_EQUAL(r.count, 4);
   ASSERT_EQUAL(len, 1);

--- a/tests/find_tests.cpp
+++ b/tests/find_tests.cpp
@@ -1,0 +1,51 @@
+#include "simdutf.h"
+
+#include <algorithm>
+#include <random>
+#include <vector>
+#include <tests/helpers/test.h>
+
+const uint64_t seed = 0x123456789ABCDEF0;
+
+
+template <typename char_type, typename impl>
+void random_char_search(impl &implementation) {
+    // Random number generator
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    
+    // Generate random size between 0 and 1024
+    std::uniform_int_distribution<size_t> size_dist(0, 1024);
+    size_t size = size_dist(gen);
+    
+    // Create vector of random characters
+    std::vector<char_type> arr(size);
+    std::uniform_int_distribution<int> char_dist(32, 126);
+    
+    for (size_t i = 0; i < size; ++i) {
+        arr[i] = static_cast<char_type>(char_dist(gen));
+    }
+    
+    // Pick a random character to search for
+    char_type search_char = static_cast<char_type>(char_dist(gen));
+    
+    // Use std::find to search for the character
+    auto result = std::find(arr.begin(), arr.end(), search_char);
+
+    // Nest use simdutf::find to search for the character
+    auto simd_result = implementation.find(arr.data(), arr.data() + size, search_char);
+    ASSERT_TRUE(&*result == simd_result);
+}
+
+TEST(random_char_search_char) {
+    for(size_t i = 0; i < 1000; ++i) {
+        random_char_search<char>(implementation);
+    }
+}
+TEST(random_char_search_char16_t) {
+    for(size_t i = 0; i < 1000; ++i) {
+        random_char_search<char16_t>(implementation);
+    }
+}
+
+TEST_MAIN

--- a/tests/find_tests.cpp
+++ b/tests/find_tests.cpp
@@ -7,46 +7,46 @@
 
 const uint64_t seed = 0x123456789ABCDEF0;
 
-
 template <typename char_type, typename impl>
 void random_char_search(impl &implementation) {
-    // Random number generator
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    
-    // Generate random size between 0 and 1024
-    std::uniform_int_distribution<size_t> size_dist(0, 1024);
-    size_t size = size_dist(gen);
-    
-    // Create vector of random characters
-    std::vector<char_type> arr(size);
-    std::uniform_int_distribution<int> char_dist(32, 126);
-    
-    for (size_t i = 0; i < size; ++i) {
-        arr[i] = static_cast<char_type>(char_dist(gen));
-    }
-    
-    // Pick a random character to search for
-    char_type search_char = static_cast<char_type>(char_dist(gen));
-    
-    // Use std::find to search for the character
-    auto result = std::find(arr.data(), arr.data() + size, search_char);
+  // Random number generator
+  std::random_device rd;
+  std::mt19937 gen(rd());
 
-    // Nest use simdutf::find to search for the character
-    auto simd_result = implementation.find(arr.data(), arr.data() + size, search_char);
-    // Check if the results are the same
-    ASSERT_TRUE(simd_result == result);
+  // Generate random size between 0 and 1024
+  std::uniform_int_distribution<size_t> size_dist(0, 1024);
+  size_t size = size_dist(gen);
+
+  // Create vector of random characters
+  std::vector<char_type> arr(size);
+  std::uniform_int_distribution<int> char_dist(32, 126);
+
+  for (size_t i = 0; i < size; ++i) {
+    arr[i] = static_cast<char_type>(char_dist(gen));
+  }
+
+  // Pick a random character to search for
+  char_type search_char = static_cast<char_type>(char_dist(gen));
+
+  // Use std::find to search for the character
+  auto result = std::find(arr.data(), arr.data() + size, search_char);
+
+  // Nest use simdutf::find to search for the character
+  auto simd_result =
+      implementation.find(arr.data(), arr.data() + size, search_char);
+  // Check if the results are the same
+  ASSERT_TRUE(simd_result == result);
 }
 
 TEST(random_char_search_char) {
-    for(size_t i = 0; i < 1000; ++i) {
-        random_char_search<char>(implementation);
-    }
+  for (size_t i = 0; i < 1000; ++i) {
+    random_char_search<char>(implementation);
+  }
 }
 TEST(random_char_search_char16_t) {
-    for(size_t i = 0; i < 1000; ++i) {
-        random_char_search<char16_t>(implementation);
-    }
+  for (size_t i = 0; i < 1000; ++i) {
+    random_char_search<char16_t>(implementation);
+  }
 }
 
 TEST_MAIN

--- a/tests/find_tests.cpp
+++ b/tests/find_tests.cpp
@@ -30,11 +30,12 @@ void random_char_search(impl &implementation) {
     char_type search_char = static_cast<char_type>(char_dist(gen));
     
     // Use std::find to search for the character
-    auto result = std::find(arr.begin(), arr.end(), search_char);
+    auto result = std::find(arr.data(), arr.data() + size, search_char);
 
     // Nest use simdutf::find to search for the character
     auto simd_result = implementation.find(arr.data(), arr.data() + size, search_char);
-    ASSERT_TRUE(&*result == simd_result);
+    // Check if the results are the same
+    ASSERT_TRUE(simd_result == result);
 }
 
 TEST(random_char_search_char) {


### PR DESCRIPTION
The convention is Node.js is that lenient processing stops with the first '=' character. Thus we have

```C++
 test("YQ ==", "a");
 test("YQ == junk", "a");
```

The current fix is suboptimal: I look for the first occurence of `=`  using std::find. We should roll our own fast 'find' function.

I have coded a fast find function for some kernels.

Fixes https://github.com/simdutf/simdutf/issues/792

Fixes https://github.com/simdutf/simdutf/issues/795