### PR TITLE
 _safe variant of convert_utf16_to_utf8 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ To contribute code or documentation:
     ```bash
     git push origin feature/your-feature-name
     ```
-8. Open a pull request with: A descriptive title and explanation. References to related issues (e.g., "Fixes #123"). 
+8. Open a pull request with: A descriptive title and explanation. References to related issues (e.g., "Fixes #123").
 9. Address feedback during review.
 
 ## Development Setup
@@ -93,7 +93,7 @@ All code should be pure ASCII, including the strings.
 We do not use `assert` expressions in the code. We either always check a condition, or else we
 only test it when logging is enabled (`simdutf_log_assert`).
 
-It is sometimes beneficial to use logging or assertions to help debug code. Configure the build directory with the 
+It is sometimes beneficial to use logging or assertions to help debug code. Configure the build directory with the
 `SIMDUTF_LOGGING` variable set to `ON`.
 
 ```bash
@@ -132,8 +132,8 @@ All optimizations should be based on benchmarks, please configure your projects 
 ```bash
 cmake -B build -D SIMDUTF_BENCHMARKS=ON
 cmake --build build
-./build/benchmarks/benchmark 
-./build/benchmarks/base64/benchmark_base64 
+./build/benchmarks/benchmark
+./build/benchmarks/base64/benchmark_base64
 ```
 
 The scripts `./scripts/benchmark_print.py`and `./scripts/base64bench_print.py` can be used to produce good-looking before/after tables in MarkDown. Please consider using these scripts.

--- a/README.md
+++ b/README.md
@@ -1160,6 +1160,47 @@ simdutf_warn_unused size_t convert_utf8_to_utf16be(const char * input, size_t le
  */
 simdutf_warn_unused size_t convert_utf8_to_utf32(const char * input, size_t length, char32_t* utf32_output) noexcept;
 
+/**
+ * Using native endianness, convert possibly broken UTF-16 string into UTF-8
+ * string.
+ *
+ * During the conversion also validation of the input string is done.
+ * This function is suitable to work with inputs from untrusted sources.
+ *
+ * This function is not BOM-aware.
+ *
+ * @param input         the UTF-16 string to convert
+ * @param length        the length of the string in 2-byte code units (char16_t)
+ * @param utf8_buffer   the pointer to buffer that can hold conversion result
+ * @return number of written code units; 0 if input is not a valid UTF-16LE
+ * string
+ */
+simdutf_warn_unused size_t convert_utf16_to_utf8(const char16_t *input,
+                                                 size_t length,
+                                                 char *utf8_buffer) noexcept;
+
+
+/**
+ * Using native endianness, convert possibly broken UTF-16 string into UTF-8
+ * string with output limit.
+ *
+ * We write as many characters as possible into the output buffer,
+ *
+ * During the conversion also validation of the input string is done.
+ * This function is suitable to work with inputs from untrusted sources.
+ *
+ * This function is not BOM-aware.
+ *
+ *
+ * @param input         the UTF-16 string to convert
+ * @param length        the length of the string in 16-bit code units (char16_t)
+ * @param utf8_output  	the pointer to buffer that can hold conversion result
+ * @param utf8_len      the maximum output length
+ * @return the number of written char; 0 if conversion is not possible
+ */
+simdutf_warn_unused size_t
+convert_utf16_to_utf8_safe(const char16_t *input, size_t length, char *utf8_output,
+                            size_t utf8_len) noexcept;
 
 /**
  * Using native endianness, convert possibly broken UTF-16 string into Latin1 string.

--- a/benchmarks/src/benchmark.h
+++ b/benchmarks/src/benchmark.h
@@ -163,6 +163,9 @@ private:
   void
   run_convert_utf16le_to_utf8(const simdutf::implementation &implementation,
                               size_t iterations);
+  void
+  run_convert_utf16_to_utf8_safe(const simdutf::implementation &implementation,
+                                 size_t iterations);
   void run_convert_utf16le_to_utf8_with_errors(
       const simdutf::implementation &implementation, size_t iterations);
   void

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -539,6 +539,8 @@ simdutf_really_inline simdutf_warn_unused size_t convert_latin1_to_utf8(
  *
  * This function is suitable to work with inputs from untrusted sources.
  *
+ * We write as many characters as possible.
+ *
  * @param input         the Latin1 string to convert
  * @param length        the length of the string in bytes
  * @param utf8_output  	the pointer to buffer that can hold conversion result
@@ -1195,6 +1197,44 @@ simdutf_really_inline simdutf_warn_unused size_t convert_utf16_to_utf8(
     detail::output_span_of_byte_like auto &&utf8_output) noexcept {
   return convert_utf16_to_utf8(utf16_input.data(), utf16_input.size(),
                                reinterpret_cast<char *>(utf8_output.data()));
+}
+  #endif // SIMDUTF_SPAN
+
+/**
+ * Using native endianness, convert possibly broken UTF-16 string into UTF-8
+ * string with output limit.
+ *
+ * We write as many characters as possible into the output buffer,
+ *
+ * During the conversion also validation of the input string is done.
+ * This function is suitable to work with inputs from untrusted sources.
+ *
+ * This function is not BOM-aware.
+ *
+ *
+ * @param input         the UTF-16 string to convert
+ * @param length        the length of the string in 16-bit code units (char16_t)
+ * @param utf8_output  	the pointer to buffer that can hold conversion result
+ * @param utf8_len      the maximum output length
+ * @return the number of written char; 0 if conversion is not possible
+ */
+simdutf_warn_unused size_t convert_utf16_to_utf8_safe(const char16_t *input,
+                                                      size_t length,
+                                                      char *utf8_output,
+                                                      size_t utf8_len) noexcept;
+  #if SIMDUTF_SPAN
+simdutf_really_inline simdutf_warn_unused size_t convert_utf16_to_utf8_safe(
+    std::span<const char16_t> utf16_input,
+    detail::output_span_of_byte_like auto &&utf8_output) noexcept {
+  // implementation note: outputspan is a forwarding ref to avoid copying and
+  // allow both lvalues and rvalues. std::span can be copied without problems,
+  // but std::vector should not, and this function should accept both. it will
+  // allow using an owning rvalue ref (example: passing a temporary std::string)
+  // as output, but the user will quickly find out that he has no way of getting
+  // the data out of the object in that case.
+  return convert_utf16_to_utf8_safe(
+      utf16_input.data(), utf16_input.size(),
+      reinterpret_cast<char *>(utf8_output.data()), utf8_output.size());
 }
   #endif // SIMDUTF_SPAN
 #endif   // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1703,10 +1703,9 @@ convert_utf16_to_utf8_safe(const char16_t *buf, size_t len, char *utf8_output,
       break;
     }
     if (read_len < len) {
-      // printf("checking value %zx\n", uint16_t(buf[read_len - 1]));
       //  If we have a high surrogate at the end of the buffer, we need to
       //  either read one more char16_t or backtrack.
-      if (buf[read_len - 1] >= 0xD800 && buf[read_len - 1] <= 0xDBFF) {
+      if (scalar::utf16::high_surrogate(buf[read_len - 1])) {
         read_len--;
       }
     }

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1685,6 +1685,63 @@ simdutf_warn_unused size_t convert_utf16_to_utf8(const char16_t *buf,
   return convert_utf16le_to_utf8(buf, len, utf8_buffer);
   #endif
 }
+
+simdutf_warn_unused size_t
+convert_utf16_to_utf8_safe(const char16_t *buf, size_t len, char *utf8_output,
+                           size_t utf8_len) noexcept {
+  const auto start{utf8_output};
+  // We might be able to go faster by first scanning the input buffer to
+  // determine how many char16_t characters we can read without exceeding the
+  // utf8_len. This is a one-pass algorithm that has the benefit of not
+  // requiring a first pass to determine the length.
+  while (true) {
+    // The worst case for convert_utf16_to_utf8 is when you go from 1 char16_t
+    // to 3 characters of UTF-8. So we can read at most utf8_len / 3 char16_t
+    // characters.
+    auto read_len = std::min(len, utf8_len / 3);
+    if (read_len <= 16) {
+      break;
+    }
+    if (read_len < len) {
+      // printf("checking value %zx\n", uint16_t(buf[read_len - 1]));
+      //  If we have a high surrogate at the end of the buffer, we need to
+      //  either read one more char16_t or backtrack.
+      if (buf[read_len - 1] >= 0xD800 && buf[read_len - 1] <= 0xDBFF) {
+        read_len--;
+      }
+    }
+    if (read_len == 0) {
+      // If we cannot read anything, we are done.
+      break;
+    }
+    const auto write_len =
+        simdutf::convert_utf16_to_utf8(buf, read_len, utf8_output);
+    if (write_len == 0) {
+      // There was an error in the conversion, we cannot continue.
+      return 0; // indicating failure
+    }
+
+    utf8_output += write_len;
+    utf8_len -= write_len;
+    buf += read_len;
+    len -= read_len;
+  }
+  #if SIMDUTF_IS_BIG_ENDIAN
+  full_result r =
+      scalar::utf16_to_utf8::convert_with_errors<endianness::BIG, true>(
+          buf, len, utf8_output, utf8_len);
+  #else
+  full_result r =
+      scalar::utf16_to_utf8::convert_with_errors<endianness::LITTLE, true>(
+          buf, len, utf8_output, utf8_len);
+  #endif
+  if (r.error != error_code::SUCCESS &&
+      r.error != error_code::OUTPUT_BUFFER_TOO_SMALL) {
+    // If there was an error, we return 0 to indicate failure.
+    return 0; // indicating failure
+  }
+  return r.output_count + (utf8_output - start);
+}
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -497,7 +497,7 @@ simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
 
   return convert_with_errors_impl(
       ppc64_convert_utf16_to_utf8<endianness::LITTLE>,
-      scalar::utf16_to_utf8::convert_with_errors<endianness::LITTLE>, buf, len,
+      scalar::utf16_to_utf8::simple_convert_with_errors<endianness::LITTLE>, buf, len,
       utf8_output);
 }
 
@@ -506,7 +506,7 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
 
   return convert_with_errors_impl(
       ppc64_convert_utf16_to_utf8<endianness::BIG>,
-      scalar::utf16_to_utf8::convert_with_errors<endianness::BIG>, buf, len,
+      scalar::utf16_to_utf8::simple_convert_with_errors<endianness::BIG>, buf, len,
       utf8_output);
 }
 

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -497,8 +497,8 @@ simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
 
   return convert_with_errors_impl(
       ppc64_convert_utf16_to_utf8<endianness::LITTLE>,
-      scalar::utf16_to_utf8::simple_convert_with_errors<endianness::LITTLE>, buf, len,
-      utf8_output);
+      scalar::utf16_to_utf8::simple_convert_with_errors<endianness::LITTLE>,
+      buf, len, utf8_output);
 }
 
 simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
@@ -506,8 +506,8 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
 
   return convert_with_errors_impl(
       ppc64_convert_utf16_to_utf8<endianness::BIG>,
-      scalar::utf16_to_utf8::simple_convert_with_errors<endianness::BIG>, buf, len,
-      utf8_output);
+      scalar::utf16_to_utf8::simple_convert_with_errors<endianness::BIG>, buf,
+      len, utf8_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_utf8(

--- a/src/scalar/utf16.h
+++ b/src/scalar/utf16.h
@@ -133,6 +133,14 @@ template <endianness big_endian> bool is_low_surrogate(char16_t c) {
   return (0xdc00 <= c && c <= 0xdfff);
 }
 
+simdutf_really_inline bool high_surrogate(char16_t c) {
+  return (0xd800 <= c && c <= 0xdbff);
+}
+
+simdutf_really_inline bool low_surrogate(char16_t c) {
+  return (0xdc00 <= c && c <= 0xdfff);
+}
+
 // variable templates are a C++14 extension
 template <endianness big_endian> char16_t replacement() {
   return !match_system(big_endian) ? scalar::u16_swap_bytes(0xfffd) : 0xfffd;

--- a/src/scalar/utf16_to_utf8/utf16_to_utf8.h
+++ b/src/scalar/utf16_to_utf8/utf16_to_utf8.h
@@ -180,6 +180,15 @@ inline full_result convert_with_errors(const char16_t *buf, size_t len,
   return full_result(error_code::SUCCESS, pos, utf8_output - start);
 }
 
+
+
+
+template <endianness big_endian>
+inline result simple_convert_with_errors(const char16_t *buf, size_t len,
+                                       char *utf8_output) {
+  return convert_with_errors<big_endian, false>(buf, len, utf8_output, 0);
+}
+
 } // namespace utf16_to_utf8
 } // unnamed namespace
 } // namespace scalar

--- a/src/scalar/utf16_to_utf8/utf16_to_utf8.h
+++ b/src/scalar/utf16_to_utf8/utf16_to_utf8.h
@@ -180,12 +180,9 @@ inline full_result convert_with_errors(const char16_t *buf, size_t len,
   return full_result(error_code::SUCCESS, pos, utf8_output - start);
 }
 
-
-
-
 template <endianness big_endian>
 inline result simple_convert_with_errors(const char16_t *buf, size_t len,
-                                       char *utf8_output) {
+                                         char *utf8_output) {
   return convert_with_errors<big_endian, false>(buf, len, utf8_output, 0);
 }
 

--- a/src/scalar/utf16_to_utf8/utf16_to_utf8.h
+++ b/src/scalar/utf16_to_utf8/utf16_to_utf8.h
@@ -79,12 +79,18 @@ inline size_t convert(const char16_t *buf, size_t len, char *utf8_output) {
   return utf8_output - start;
 }
 
-template <endianness big_endian>
-inline result convert_with_errors(const char16_t *buf, size_t len,
-                                  char *utf8_output) {
+template <endianness big_endian, bool check_output = false>
+inline full_result convert_with_errors(const char16_t *buf, size_t len,
+                                       char *utf8_output, size_t utf8_len = 0) {
   const uint16_t *data = reinterpret_cast<const uint16_t *>(buf);
+  if (check_output && utf8_len == 0) {
+    return full_result(error_code::OUTPUT_BUFFER_TOO_SMALL, 0, 0);
+  }
+
   size_t pos = 0;
   char *start{utf8_output};
+  char *end{utf8_output + utf8_len};
+
   while (pos < len) {
     // try to convert the next block of 8 bytes
     if (pos + 4 <=
@@ -100,6 +106,10 @@ inline result convert_with_errors(const char16_t *buf, size_t len,
                                ? char(u16_swap_bytes(buf[pos]))
                                : char(buf[pos]);
           pos++;
+          if (check_output && size_t(end - utf8_output) == 0) {
+            return full_result(error_code::OUTPUT_BUFFER_TOO_SMALL, pos,
+                               utf8_output - start);
+          }
         }
         continue;
       }
@@ -110,34 +120,52 @@ inline result convert_with_errors(const char16_t *buf, size_t len,
       // will generate one UTF-8 bytes
       *utf8_output++ = char(word);
       pos++;
+      if (check_output && size_t(end - utf8_output) == 0) {
+        return full_result(error_code::OUTPUT_BUFFER_TOO_SMALL, pos,
+                           utf8_output - start);
+      }
     } else if ((word & 0xF800) == 0) {
       // will generate two UTF-8 bytes
       // we have 0b110XXXXX 0b10XXXXXX
+      if (check_output && size_t(end - utf8_output) < 2) {
+        return full_result(error_code::OUTPUT_BUFFER_TOO_SMALL, pos,
+                           utf8_output - start);
+      }
       *utf8_output++ = char((word >> 6) | 0b11000000);
       *utf8_output++ = char((word & 0b111111) | 0b10000000);
       pos++;
+
     } else if ((word & 0xF800) != 0xD800) {
       // will generate three UTF-8 bytes
       // we have 0b1110XXXX 0b10XXXXXX 0b10XXXXXX
+      if (check_output && size_t(end - utf8_output) < 3) {
+        return full_result(error_code::OUTPUT_BUFFER_TOO_SMALL, pos,
+                           utf8_output - start);
+      }
       *utf8_output++ = char((word >> 12) | 0b11100000);
       *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
       *utf8_output++ = char((word & 0b111111) | 0b10000000);
       pos++;
     } else {
+
+      if (check_output && size_t(end - utf8_output) < 4) {
+        return full_result(error_code::OUTPUT_BUFFER_TOO_SMALL, pos,
+                           utf8_output - start);
+      }
       // must be a surrogate pair
       if (pos + 1 >= len) {
-        return result(error_code::SURROGATE, pos);
+        return full_result(error_code::SURROGATE, pos, utf8_output - start);
       }
       uint16_t diff = uint16_t(word - 0xD800);
       if (diff > 0x3FF) {
-        return result(error_code::SURROGATE, pos);
+        return full_result(error_code::SURROGATE, pos, utf8_output - start);
       }
       uint16_t next_word = !match_system(big_endian)
                                ? u16_swap_bytes(data[pos + 1])
                                : data[pos + 1];
       uint16_t diff2 = uint16_t(next_word - 0xDC00);
       if (diff2 > 0x3FF) {
-        return result(error_code::SURROGATE, pos);
+        return full_result(error_code::SURROGATE, pos, utf8_output - start);
       }
       uint32_t value = (diff << 10) + diff2 + 0x10000;
       // will generate four UTF-8 bytes
@@ -149,7 +177,7 @@ inline result convert_with_errors(const char16_t *buf, size_t len,
       pos += 2;
     }
   }
-  return result(error_code::SUCCESS, utf8_output - start);
+  return full_result(error_code::SUCCESS, pos, utf8_output - start);
 }
 
 } // namespace utf16_to_utf8

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -231,7 +231,12 @@ add_cpp_test(convert_valid_utf16be_to_latin1_tests)
 target_link_libraries(convert_valid_utf16be_to_latin1_tests 
   PUBLIC simdutf::tests::helpers
           simdutf::tests::reference)
-                
+
+add_cpp_test(convert_utf16_to_utf8_safe_tests)
+target_link_libraries(convert_utf16_to_utf8_safe_tests
+  PUBLIC simdutf::tests::helpers
+         simdutf::tests::reference)
+
 add_cpp_test(convert_utf16le_to_utf8_tests)
 target_link_libraries(convert_utf16le_to_utf8_tests
   PUBLIC simdutf::tests::helpers

--- a/tests/convert_utf16_to_utf8_safe_tests.cpp
+++ b/tests/convert_utf16_to_utf8_safe_tests.cpp
@@ -1,0 +1,146 @@
+#include "simdutf.h"
+
+#include <array>
+#include <vector>
+
+#include <tests/reference/validate_utf16.h>
+#include <tests/helpers/transcode_test_base.h>
+#include <tests/helpers/random_int.h>
+#include <tests/helpers/test.h>
+
+namespace {
+constexpr std::array<size_t, 7> input_size{7, 16, 12, 64, 67, 128, 256};
+#if SIMDUTF_IS_BIG_ENDIAN
+constexpr simdutf::endianness BE = simdutf::endianness::BIG;
+#else
+constexpr simdutf::endianness BE = simdutf::endianness::LITTLE;
+#endif
+using simdutf::tests::helpers::transcode_utf16_to_utf8_test_base;
+
+constexpr int trials = 1000;
+} // namespace
+
+inline void verify_subset(std::vector<char16_t> &utf16,
+                          std::vector<char> &utf8) {
+  size_t max_budget =
+      simdutf::utf8_length_from_utf16(utf16.data(), utf16.size());
+  std::vector<char> output_utf8(max_budget, ' ');
+  size_t previous_size = 0;
+  size_t i = 0;
+  for (; i < max_budget; i += 7) {
+    size_t ret = simdutf::convert_utf16_to_utf8_safe(
+        utf16.data(), utf16.size(), output_utf8.data(), max_budget);
+    ASSERT_TRUE(ret <= max_budget);
+    ASSERT_TRUE(ret >= previous_size);
+    for (size_t j = 0; j < ret; j++) {
+      ASSERT_EQUAL(output_utf8[j], utf8[j]);
+    }
+    previous_size = ret;
+  }
+  for (; i < max_budget; i++) {
+    size_t ret = simdutf::convert_utf16_to_utf8_safe(
+        utf16.data(), utf16.size(), output_utf8.data(), max_budget);
+    ASSERT_TRUE(ret <= max_budget);
+    ASSERT_TRUE(ret >= previous_size);
+    for (size_t j = 0; j < ret; j++) {
+      ASSERT_EQUAL(output_utf8[j], utf8[j]);
+    }
+    previous_size = ret;
+  }
+  {
+    size_t ret = simdutf::convert_utf16_to_utf8_safe(
+        utf16.data(), utf16.size(), output_utf8.data(), max_budget);
+    ASSERT_EQUAL(ret, max_budget);
+    for (size_t j = 0; j < max_budget; j++) {
+      ASSERT_EQUAL(output_utf8[j], utf8[j]);
+    }
+  }
+}
+
+TEST(convert_pure_ASCII) {
+  size_t counter = 0;
+  auto generator = [&counter]() -> uint32_t { return counter++ & 0x7f; };
+
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
+                                     char *utf8) -> size_t {
+    return simdutf::convert_utf16_to_utf8_safe(
+        utf16, size, utf8, simdutf::utf8_length_from_utf16(utf16, size));
+  };
+  auto size_procedure = [&implementation](const char16_t *utf16,
+                                          size_t size) -> size_t {
+    return simdutf::utf8_length_from_utf16(utf16, size);
+  };
+  for (size_t size : input_size) {
+    transcode_utf16_to_utf8_test_base test(BE, generator, size);
+    verify_subset(test.input_utf16, test.reference_output_utf8);
+    ASSERT_TRUE(test(procedure));
+    ASSERT_TRUE(test.check_size(size_procedure));
+  }
+}
+
+TEST_LOOP(trials, convert_into_1_or_2_UTF8_bytes) {
+  simdutf::tests::helpers::RandomInt random(
+      0x0000, 0x07ff, seed); // range for 1 or 2 UTF-8 bytes
+
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
+                                     char *utf8) -> size_t {
+    return simdutf::convert_utf16_to_utf8_safe(
+        utf16, size, utf8, simdutf::utf8_length_from_utf16(utf16, size));
+  };
+  auto size_procedure = [&implementation](const char16_t *utf16,
+                                          size_t size) -> size_t {
+    return simdutf::utf8_length_from_utf16(utf16, size);
+  };
+  for (size_t size : input_size) {
+    transcode_utf16_to_utf8_test_base test(BE, random, size);
+    verify_subset(test.input_utf16, test.reference_output_utf8);
+    ASSERT_TRUE(test(procedure));
+    ASSERT_TRUE(test.check_size(size_procedure));
+  }
+}
+
+TEST_LOOP(trials, convert_into_1_or_2_or_3_UTF8_bytes) {
+  // range for 1, 2 or 3 UTF-8 bytes
+  simdutf::tests::helpers::RandomIntRanges random(
+      {{0x0000, 0x007f}, {0x0080, 0x07ff}, {0x0800, 0xd7ff}, {0xe000, 0xffff}},
+      seed);
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
+                                     char *utf8) -> size_t {
+    return simdutf::convert_utf16_to_utf8_safe(
+        utf16, size, utf8, simdutf::utf8_length_from_utf16(utf16, size));
+  };
+  auto size_procedure = [&implementation](const char16_t *utf16,
+                                          size_t size) -> size_t {
+    return simdutf::utf8_length_from_utf16(utf16, size);
+  };
+  for (size_t size : input_size) {
+    transcode_utf16_to_utf8_test_base test(BE, random, size);
+    verify_subset(test.input_utf16, test.reference_output_utf8);
+    ASSERT_TRUE(test(procedure));
+    ASSERT_TRUE(test.check_size(size_procedure));
+  }
+}
+
+TEST_LOOP(trials, convert_into_3_or_4_UTF8_bytes) {
+  // range for 3 or 4 UTF-8 bytes
+  simdutf::tests::helpers::RandomIntRanges random(
+      {{0x0800, 0xd800 - 1}, {0xe000, 0x10ffff}}, seed);
+
+  auto procedure = [&implementation](const char16_t *utf16, size_t size,
+                                     char *utf8) -> size_t {
+    return simdutf::convert_utf16_to_utf8_safe(
+        utf16, size, utf8, simdutf::utf8_length_from_utf16(utf16, size));
+  };
+  auto size_procedure = [&implementation](const char16_t *utf16,
+                                          size_t size) -> size_t {
+    return simdutf::utf8_length_from_utf16(utf16, size);
+  };
+  for (size_t size : input_size) {
+    transcode_utf16_to_utf8_test_base test(BE, random, size);
+    verify_subset(test.input_utf16, test.reference_output_utf8);
+    ASSERT_TRUE(test(procedure));
+    ASSERT_TRUE(test.check_size(size_procedure));
+  }
+}
+
+TEST_MAIN


### PR DESCRIPTION
Effectively, allows us to transcode from UTF-16 to UTF-8 with a limit on the number of bytes that we are allowed to write. We try to write as many bytes as possible before exiting.

Fixes https://github.com/simdutf/simdutf/issues/725 described by @syg

I have not experimented with the implementation but I have added benchmarks and the performance looks quite good with the simple implementation that I have provided.