### PR TITLE
Implement lsx + lasx find function

### DIFF
--- a/src/lasx/implementation.cpp
+++ b/src/lasx/implementation.cpp
@@ -167,6 +167,7 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 #if SIMDUTF_FEATURE_BASE64
   #include "lasx/lasx_base64.cpp"
+  #include "lasx/lasx_find.cpp"
 #endif // SIMDUTF_FEATURE_BASE64
 
 } // namespace
@@ -1451,12 +1452,12 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
 
 const char *implementation::find(const char *start, const char *end,
                                  char character) const noexcept {
-  return std::find(start, end, character);
+  return util_find(start, end, character);
 }
 
 const char16_t *implementation::find(const char16_t *start, const char16_t *end,
                                      char16_t character) const noexcept {
-  return std::find(start, end, character);
+  return util_find(start, end, character);
 }
 #endif // SIMDUTF_FEATURE_BASE64
 

--- a/src/lasx/lasx_find.cpp
+++ b/src/lasx/lasx_find.cpp
@@ -1,0 +1,64 @@
+simdutf_really_inline const char *util_find(const char *start, const char *end,
+                                            char character) noexcept {
+  if (start >= end)
+    return end;
+
+  const int step = 32;
+  __m256i char_vec = __lasx_xvreplgr2vr_b(static_cast<uint16_t>(character));
+
+  while (end - start >= step) {
+    __m256i data = __lasx_xvld(reinterpret_cast<const __m256i *>(start), 0);
+    __m256i cmp = __lasx_xvseq_b(data, char_vec);
+    if (__lasx_xbnz_v(cmp)) {
+      __m256i res = __lasx_xvmsknz_b(cmp);
+      uint32_t mask0 = __lasx_xvpickve2gr_wu(res, 0);
+      uint32_t mask1 = __lasx_xvpickve2gr_wu(res, 4);
+      uint32_t mask = (mask0 | (mask1 << 16));
+      return start + trailing_zeroes(mask);
+    }
+
+    start += step;
+  }
+
+  // Handle remaining bytes with scalar loop
+  for (; start < end; ++start) {
+    if (*start == character) {
+      return start;
+    }
+  }
+
+  return end;
+}
+
+simdutf_really_inline const char16_t *util_find(const char16_t *start,
+                                                const char16_t *end,
+                                                char16_t character) noexcept {
+  if (start >= end)
+    return end;
+
+  const int step = 16;
+  __m256i char_vec = __lasx_xvreplgr2vr_h(static_cast<uint16_t>(character));
+
+  while (end - start >= step) {
+    __m256i data = __lasx_xvld(reinterpret_cast<const __m256i *>(start), 0);
+    __m256i cmp = __lasx_xvseq_h(data, char_vec);
+    if (__lasx_xbnz_v(cmp)) {
+      __m256i res = __lasx_xvmsknz_b(cmp);
+      uint32_t mask0 = __lasx_xvpickve2gr_wu(res, 0);
+      uint32_t mask1 = __lasx_xvpickve2gr_wu(res, 4);
+      uint32_t mask = (mask0 | (mask1 << 16));
+      return start + trailing_zeroes(mask) / 2;
+    }
+
+    start += step;
+  }
+
+  // Handle remaining elements with scalar loop
+  for (; start < end; ++start) {
+    if (*start == character) {
+      return start;
+    }
+  }
+
+  return end;
+}

--- a/src/lsx/implementation.cpp
+++ b/src/lsx/implementation.cpp
@@ -164,6 +164,7 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 #if SIMDUTF_FEATURE_BASE64
   #include "lsx/lsx_base64.cpp"
+  #include "lsx/lsx_find.cpp"
 #endif // SIMDUTF_FEATURE_BASE64
 
 } // namespace
@@ -1336,12 +1337,12 @@ size_t implementation::binary_to_base64(const char *input, size_t length,
 }
 const char *implementation::find(const char *start, const char *end,
                                  char character) const noexcept {
-  return std::find(start, end, character);
+  return util_find(start, end, character);
 }
 
 const char16_t *implementation::find(const char16_t *start, const char16_t *end,
                                      char16_t character) const noexcept {
-  return std::find(start, end, character);
+  return util_find(start, end, character);
 }
 #endif // SIMDUTF_FEATURE_BASE64
 

--- a/src/lsx/lsx_find.cpp
+++ b/src/lsx/lsx_find.cpp
@@ -1,0 +1,58 @@
+simdutf_really_inline const char *util_find(const char *start, const char *end,
+                                            char character) noexcept {
+  if (start >= end)
+    return end;
+
+  const int step = 16;
+  __m128i char_vec = __lsx_vreplgr2vr_b(static_cast<uint8_t>(character));
+
+  while (end - start >= step) {
+    __m128i data = __lsx_vld(reinterpret_cast<const __m128i *>(start), 0);
+    __m128i cmp = __lsx_vseq_b(data, char_vec);
+    if (__lsx_bnz_v(cmp)) {
+        uint16_t mask = static_cast<uint16_t>(__lsx_vpickve2gr_hu(__lsx_vmsknz_b(cmp), 0));
+        return start + trailing_zeroes(mask);
+    }
+
+    start += step;
+  }
+
+  // Handle remaining bytes with scalar loop
+  for (; start < end; ++start) {
+    if (*start == character) {
+      return start;
+    }
+  }
+
+  return end;
+}
+
+simdutf_really_inline const char16_t *util_find(const char16_t *start,
+                                                const char16_t *end,
+                                                char16_t character) noexcept {
+  if (start >= end)
+    return end;
+
+  const int step = 8;
+  __m128i char_vec = __lsx_vreplgr2vr_h(static_cast<uint16_t>(character));
+
+  while (end - start >= step) {
+    __m128i data = __lsx_vld(reinterpret_cast<const __m128i *>(start), 0);
+    __m128i cmp = __lsx_vseq_h(data, char_vec);
+    if (__lsx_bnz_v(cmp)) {
+        uint16_t mask = static_cast<uint16_t>(__lsx_vpickve2gr_hu(__lsx_vmsknz_b(cmp), 0));
+        return start + trailing_zeroes(mask) / 2;
+    }
+
+    start += step;
+  }
+
+  // Handle remaining elements with scalar loop
+  for (; start < end; ++start) {
+    if (*start == character) {
+      return start;
+    }
+  }
+
+  return end;
+}

--- a/src/simdutf/lasx/bitmanipulation.h
+++ b/src/simdutf/lasx/bitmanipulation.h
@@ -13,9 +13,9 @@ simdutf_really_inline int count_ones(uint64_t input_num) {
 }
 
 #if SIMDUTF_NEED_TRAILING_ZEROES
-// simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
-//   return __builtin_ctzll(input_num);
-// }
+simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
+  return __builtin_ctzll(input_num);
+}
 #endif
 
 } // unnamed namespace

--- a/src/simdutf/lsx/bitmanipulation.h
+++ b/src/simdutf/lsx/bitmanipulation.h
@@ -13,9 +13,9 @@ simdutf_really_inline int count_ones(uint64_t input_num) {
 }
 
 #if SIMDUTF_NEED_TRAILING_ZEROES
-// simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
-//   return __builtin_ctzll(input_num);
-// }
+simdutf_really_inline int trailing_zeroes(uint64_t input_num) {
+  return __builtin_ctzll(input_num);
+}
 #endif
 
 } // unnamed namespace


### PR DESCRIPTION
Implemented the `find` function similar to the x86 kernels. 
Verified that the unit tests for `find_tests` are passing under QEMU.
This should address #793 