### PR TITLE
Fix MSVC noexcept analysis warnings

### DIFF
--- a/include/simdutf/error.h
+++ b/include/simdutf/error.h
@@ -32,7 +32,7 @@ enum error_code {
   OTHER                     // Not related to validation/transcoding.
 };
 #if SIMDUTF_CPLUSPLUS17
-inline std::string_view error_to_string(error_code code) {
+inline std::string_view error_to_string(error_code code) noexcept {
   switch (code) {
   case SUCCESS:
     return "SUCCESS";
@@ -68,16 +68,17 @@ struct result {
                 // case of success, indicates the number of code units
                 // validated/written.
 
-  simdutf_really_inline result() : error{error_code::SUCCESS}, count{0} {}
+  simdutf_really_inline result() noexcept
+      : error{error_code::SUCCESS}, count{0} {}
 
-  simdutf_really_inline result(error_code err, size_t pos)
+  simdutf_really_inline result(error_code err, size_t pos) noexcept
       : error{err}, count{pos} {}
 
-  simdutf_really_inline bool is_ok() const {
+  simdutf_really_inline bool is_ok() const noexcept {
     return error == error_code::SUCCESS;
   }
 
-  simdutf_really_inline bool is_err() const {
+  simdutf_really_inline bool is_err() const noexcept {
     return error != error_code::SUCCESS;
   }
 };
@@ -89,14 +90,14 @@ struct full_result {
   bool padding_error = false; // true if the error is due to padding, only
                               // meaningful when error is not SUCCESS
 
-  simdutf_really_inline full_result()
+  simdutf_really_inline full_result() noexcept
       : error{error_code::SUCCESS}, input_count{0}, output_count{0} {}
 
   simdutf_really_inline full_result(error_code err, size_t pos_in,
-                                    size_t pos_out)
+                                    size_t pos_out) noexcept
       : error{err}, input_count{pos_in}, output_count{pos_out} {}
   simdutf_really_inline full_result(error_code err, size_t pos_in,
-                                    size_t pos_out, bool padding_err)
+                                    size_t pos_out, bool padding_err) noexcept
       : error{err}, input_count{pos_in}, output_count{pos_out},
         padding_error{padding_err} {}
 


### PR DESCRIPTION
Enabling `C++ Core Guidelines` analysis warnings for function rules in MSVC reports C26440, C26455 and C26447 warnings in `error.h` header when `simdutf.h` is included from user code.

Marking the problematic functions as `noexcept` resolves the issue and as far as I could see, there's no reason for them to not be marked as such.