### PR TITLE
CMake: Guard shell-based tests with SIMDUTF_TESTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ endif()
 
 
 
-if(NOT SIMDUTF_SANITIZE)
+if(SIMDUTF_TESTS AND NOT SIMDUTF_SANITIZE)
   find_program(GREP grep)
   find_program(NM nm)
   if((NOT GREP) OR (NOT NM))


### PR DESCRIPTION
When using FetchContent to include the project, these tests should not be included in the user's CTest suite unless explicitly enabled.