### PR TITLE
utf16fix_block_rvv: improve mask shift

### DIFF
--- a/src/rvv/rvv_find.cpp
+++ b/src/rvv/rvv_find.cpp
@@ -1,5 +1,5 @@
-simdutf_really_inline const char *util_find(const char *start, const char *end,
-                                            char character) noexcept {
+const char *implementation::find(const char *start, const char *end,
+                                 char character) const noexcept {
   const char *src = start;
   for (size_t len = end - start, vl; len > 0; len -= vl, src += vl) {
     vl = __riscv_vsetvl_e8m8(len);
@@ -12,9 +12,8 @@ simdutf_really_inline const char *util_find(const char *start, const char *end,
   return end;
 }
 
-simdutf_really_inline const char16_t *util_find(const char16_t *start,
-                                                const char16_t *end,
-                                                char16_t character) noexcept {
+const char16_t *implementation::find(const char16_t *start, const char16_t *end,
+                                     char16_t character) const noexcept {
   const char16_t *src = start;
   for (size_t len = end - start, vl; len > 0; len -= vl, src += vl) {
     vl = __riscv_vsetvl_e16m8(len);


### PR DESCRIPTION
This shifts the mask register directly, instead of shifting the vector elements and recomputing the mask.
It allows us to operate on a reduced LMUL, instead of the original 4 LMUL=8 instructions, it's now 3 LMUL=1/2, which should be a lot faster: https://godbolt.org/z/5Wc11z7f6

Sadly there are no dedicated mask shift instructions in RVV yet, so we have to emulate it with element slide and element-wise bit-shifts.
While this works, for right shifts it requires vl=vlmax, otherwise the vslide1down may shift in undefined bits.
So I adjusted the code to use the mask shift in the inner loop and handle the tail with the old behavior.

I also moved the `implementation::*` functions to the respective `rvv_*.cpp` files to keep the coding style consistent.