### PR TITLE
support reproducibility for debug sources

### DIFF
--- a/singleheader/amalgamate.py
+++ b/singleheader/amalgamate.py
@@ -385,7 +385,8 @@ def filter_features(file):
                 current_features = None
             elif enabled:
                 if context.args.debug_sources and not prev_line.endswith('\\'):
-                    yield f"// {file}:{lineno}"
+                    RELFILE = os.path.relpath(file, PROJECTPATH)
+                    yield f"// {RELFILE}:{lineno}"
 
                 if line or (not line and prev_line):
                     yield line


### PR DESCRIPTION
While option --debug-sources is used, the generated source file contains build path comments which caused the build is not reproducible [1] 
...subprojects/simdutf/simdutf.h...
 1 /* auto-generated on 2025-03-17 16:13:41 -0400. Do not edit! */
 2 /* begin file include/simdutf.h */
 3 // /build-dir/vte-0.82.1/subprojects/simdutf/include/simdutf.h:1
 4 #ifndef SIMDUTF_H
...subprojects/simdutf/simdutf.h...

After apply this commit, use relative path to instead
...subprojects/simdutf/simdutf.h...
 1 /* auto-generated on 2025-03-17 16:13:41 -0400. Do not edit! */
 2 /* begin file include/simdutf.h */
 3 // include/simdutf.h:1
 4 #ifndef SIMDUTF_H
...subprojects/simdutf/simdutf.h...

[1] https://reproducible-builds.org/