### PR TITLE
Return more information from utf8_length_from_utf16_with_replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,9 @@ enum error_code {
   SURROGATE, // The decoded character must be not be in U+D800...DFFF (UTF-8 or
              // UTF-32) OR a high surrogate must be followed by a low surrogate
              // and a low surrogate must be preceded by a high surrogate
-             // (UTF-16) OR there must be no surrogate at all (Latin1)
+             // (UTF-16) OR there must be no surrogate at all (Latin1) OR
+             // a surrogate has been detected without this being an error
+             // (utf8_length_from_utf16_with_replacement).
   INVALID_BASE64_CHARACTER, // Found a character that cannot be part of a valid
                             // base64 string. This may include a misplaced padding character ('=').
   BASE64_INPUT_REMAINDER,   // The base64 input terminates with a single
@@ -912,9 +914,10 @@ simdutf_warn_unused size_t utf8_length_from_utf16(const char16_t * input, size_t
  *
  * @param input         the UTF-16 string to convert
  * @param length        the length of the string in 2-byte code units (char16_t)
- * @return the number of bytes required to encode the UTF-16LE string as UTF-8
+ * @return the number of bytes required to encode the UTF-16 string as UTF-8
+ * @return a result pair struct (of type simdutf::result containing the two fields error and count) where the count is the number of bytes required to encode the UTF-16 string as UTF-8, and the error code is either SUCCESS or SURROGATE. The count is correct regardless of the error field.
  */
-simdutf_warn_unused size_t utf8_length_from_utf16_with_replacement(const char16_t *input,
+simdutf_warn_unused result utf8_length_from_utf16_with_replacement(const char16_t *input,
                                                   size_t length) noexcept;
 /**
  * Compute the number of bytes that this UTF-16LE string would require in UTF-8 format.
@@ -948,9 +951,10 @@ simdutf_warn_unused size_t utf8_length_from_utf16be(const char16_t * input, size
  * @param input         the UTF-16LE string to convert
  * @param length        the length of the string in 2-byte code units (char16_t)
  * @return the number of bytes required to encode the UTF-16LE string as UTF-8
+ * @return a result pair struct (of type simdutf::result containing the two fields error and count) where the count is the number of bytes required to encode the UTF-16LE string as UTF-8, and the error code is either SUCCESS or SURROGATE. The count is correct regardless of the error field.
  */
 
-simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
     const char16_t *input, size_t length) noexcept;
 
 
@@ -961,10 +965,10 @@ simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
  *
  * @param input         the UTF-16BE string to convert
  * @param length        the length of the string in 2-byte code units (char16_t)
- * @return the number of bytes required to encode the UTF-16BE string as UTF-8
+ * @return a result pair struct (of type simdutf::result containing the two fields error and count) where the count is the number of bytes required to encode the UTF-16LE string as UTF-8, and the error code is either SUCCESS or SURROGATE. The count is correct regardless of the error field.
  */
 
-simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
     const char16_t *input, size_t length) noexcept;
 
 /**
@@ -974,9 +978,9 @@ simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
  *
  * @param input         the UTF-16LE string to convert
  * @param length        the length of the string in 2-byte code units (char16_t)
- * @return the number of bytes required to encode the UTF-16LE string as UTF-8
+ * @return a result pair struct (of type simdutf::result containing the two fields error and count) where the count is the number of bytes required to encode the UTF-16LE string as UTF-8, and the error code is either SUCCESS or SURROGATE. The count is correct regardless of the error field.
  */
-simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
     const char16_t *input, size_t length) noexcept;
 
 /**
@@ -986,9 +990,9 @@ simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
  *
  * @param input         the UTF-16BE string to convert
  * @param length        the length of the string in 2-byte code units (char16_t)
- * @return the number of bytes required to encode the UTF-16BE string as UTF-8
+ * @return a result pair struct (of type simdutf::result containing the two fields error and count) where the count is the number of bytes required to encode the UTF-16LE string as UTF-8, and the error code is either SUCCESS or SURROGATE. The count is correct regardless of the error field.
  */
-simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
     const char16_t *input, size_t length) noexcept;
 
 

--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -864,7 +864,8 @@ void Benchmark::run_utf8_length_from_utf16le_with_replacement(
   volatile size_t sink{0};
 
   auto proc = [&implementation, data, size, &sink]() {
-    sink = implementation.utf8_length_from_utf16le_with_replacement(data, size);
+    auto r = implementation.utf8_length_from_utf16le_with_replacement(data, size);
+    sink = r.count;
   };
   count_events(proc, iterations); // warming up!
   const auto result = count_events(proc, iterations);
@@ -878,7 +879,8 @@ void Benchmark::run_utf8_length_from_utf16be_with_replacement(
   volatile size_t sink{0};
 
   auto proc = [&implementation, data, size, &sink]() {
-    sink = implementation.utf8_length_from_utf16be_with_replacement(data, size);
+    auto r = implementation.utf8_length_from_utf16be_with_replacement(data, size);
+    sink = r.count;
   };
   count_events(proc, iterations); // warming up!
   const auto result = count_events(proc, iterations);

--- a/include/simdutf/error.h
+++ b/include/simdutf/error.h
@@ -19,7 +19,9 @@ enum error_code {
   SURROGATE, // The decoded character must be not be in U+D800...DFFF (UTF-8 or
              // UTF-32) OR a high surrogate must be followed by a low surrogate
              // and a low surrogate must be preceded by a high surrogate
-             // (UTF-16) OR there must be no surrogate at all (Latin1)
+             // (UTF-16) OR there must be no surrogate at all (Latin1) OR
+             // a surrogate has been detected without this being an error
+             // (utf8_length_from_utf16_with_replacement).
   INVALID_BASE64_CHARACTER, // Found a character that cannot be part of a valid
                             // base64 string. This may include a misplaced
                             // padding character ('=').

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -779,13 +779,13 @@ convert_utf8_to_utf16(const detail::input_span_of_byte_like auto &input,
  *
  * @param input         the UTF-16LE string to convert
  * @param length        the length of the string in 2-byte code units (char16_t)
- * @return the number of bytes required to encode the UTF-16LE string as UTF-8
+ * @return a result pair struct (of type simdutf::result containing the two fields error and count) where the count is the number of bytes required to encode the UTF-16LE string as UTF-8, and the error code is either SUCCESS or SURROGATE. The count is correct regardless of the error field.
  */
 
-simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
     const char16_t *input, size_t length) noexcept;
   #if SIMDUTF_SPAN
-simdutf_really_inline simdutf_warn_unused size_t
+simdutf_really_inline simdutf_warn_unused result
 utf8_length_from_utf16le_with_replacement(
     std::span<const char16_t> valid_utf16_input) noexcept {
   return utf8_length_from_utf16le_with_replacement(valid_utf16_input.data(),
@@ -800,13 +800,13 @@ utf8_length_from_utf16le_with_replacement(
  *
  * @param input         the UTF-16BE string to convert
  * @param length        the length of the string in 2-byte code units (char16_t)
- * @return the number of bytes required to encode the UTF-16BE string as UTF-8
+ * @return a result pair struct (of type simdutf::result containing the two fields error and count) where the count is the number of bytes required to encode the UTF-16BE string as UTF-8, and the error code is either SUCCESS or SURROGATE. The count is correct regardless of the error field.
  */
 
-simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
     const char16_t *input, size_t length) noexcept;
   #if SIMDUTF_SPAN
-simdutf_really_inline simdutf_warn_unused size_t
+simdutf_really_inline simdutf_warn_unused result
 utf8_length_from_utf16be_with_replacement(
     std::span<const char16_t> valid_utf16_input) noexcept {
   return utf8_length_from_utf16be_with_replacement(valid_utf16_input.data(),
@@ -2120,12 +2120,12 @@ utf8_length_from_utf16(std::span<const char16_t> valid_utf16_input) noexcept {
  *
  * @param input         the UTF-16 string to convert
  * @param length        the length of the string in 2-byte code units (char16_t)
- * @return the number of bytes required to encode the UTF-16LE string as UTF-8
+ * @return a result pair struct (of type simdutf::result containing the two fields error and count) where the count is the number of bytes required to encode the UTF-16 string as UTF-8, and the error code is either SUCCESS or SURROGATE. The count is correct regardless of the error field.
  */
-simdutf_warn_unused size_t utf8_length_from_utf16_with_replacement(
+simdutf_warn_unused result utf8_length_from_utf16_with_replacement(
     const char16_t *input, size_t length) noexcept;
   #if SIMDUTF_SPAN
-simdutf_really_inline simdutf_warn_unused size_t
+simdutf_really_inline simdutf_warn_unused result
 utf8_length_from_utf16_with_replacement(
     std::span<const char16_t> valid_utf16_input) noexcept {
   return utf8_length_from_utf16_with_replacement(valid_utf16_input.data(),
@@ -4152,9 +4152,9 @@ public:
    * @param input         the UTF-16LE string to convert
    * @param length        the length of the string in 2-byte code units
    * (char16_t)
-   * @return the number of bytes required to encode the UTF-16LE string as UTF-8
+   * @return a result pair struct (of type simdutf::result containing the two fields error and count) where the count is the number of bytes required to encode the UTF-16LE string as UTF-8, and the error code is either SUCCESS or SURROGATE. The count is correct regardless of the error field.
    */
-  virtual simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+  virtual simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
       const char16_t *input, size_t length) const noexcept = 0;
 
   /**
@@ -4165,9 +4165,9 @@ public:
    * @param input         the UTF-16BE string to convert
    * @param length        the length of the string in 2-byte code units
    * (char16_t)
-   * @return the number of bytes required to encode the UTF-16BE string as UTF-8
+   * @return a result pair struct (of type simdutf::result containing the two fields error and count) where the count is the number of bytes required to encode the UTF-16BE string as UTF-8, and the error code is either SUCCESS or SURROGATE. The count is correct regardless of the error field.
    */
-  virtual simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+  virtual simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
       const char16_t *input, size_t length) const noexcept = 0;
 
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16

--- a/src/arm64/arm_convert_utf16_to_utf8.cpp
+++ b/src/arm64/arm_convert_utf16_to_utf8.cpp
@@ -649,7 +649,7 @@ arm64_utf8_length_from_utf16_bytemask(const char16_t *in, size_t size) {
 }
 
 template <endianness big_endian>
-simdutf_really_inline size_t
+simdutf_really_inline result
 arm64_utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
   constexpr size_t N =
       16; // we process 16 char16_t at a time, this is NEON specific
@@ -659,6 +659,7 @@ arm64_utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
         in, size);
   } // special case for short input
   size_t count = 0;
+  bool any_surrogates = false;
   const auto one = vmovq_n_u8(1);
 
   // The general strategy is as follows:
@@ -682,6 +683,7 @@ arm64_utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
   size_t number_of_unpaired_surrogates = 0;
   if (scalar::utf16::is_low_surrogate<big_endian>(in[0])) {
     number_of_unpaired_surrogates += 1;
+    any_surrogates = true;
   }
   size_t pos = 0;
   // We will go through the input at least once.
@@ -697,6 +699,7 @@ arm64_utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
     // We count on the fact that most inputs do not have surrogates.
     if (vmaxvq_u32(vreinterpretq_u32_u8(is_surrogate)) ||
         scalar::utf16::is_low_surrogate<big_endian>(in[pos + N])) {
+      any_surrogates = true;
       // there is at least one surrogate in the block
       // We use this to check that surrogates are paired correctly.
       // It is the input shifted by one code unit (two bytes).
@@ -753,6 +756,7 @@ arm64_utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
   // the unpaired low surrogate.
   //!!!!!!!!!!!!!!!
   if (scalar::utf16::is_low_surrogate<big_endian>(in[pos])) {
+    any_surrogates = true;
     if (!scalar::utf16::is_high_surrogate<big_endian>(in[pos - 1])) {
       number_of_unpaired_surrogates -= 1;
       count += 2;
@@ -764,6 +768,7 @@ arm64_utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
   // If we end with a high surrogate, it might be unpaired or not, we
   // don't know. It counts as a pair suggarate for now.
   if (scalar::utf16::is_high_surrogate<big_endian>(in[pos - 1])) {
+    any_surrogates = true;
     if (pos == size) {
       count += 2;
     } else if (scalar::utf16::is_low_surrogate<big_endian>(in[pos])) {
@@ -771,7 +776,9 @@ arm64_utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
       count += 2;
     }
   }
-  return count +
-         scalar::utf16::utf8_length_from_utf16_with_replacement<big_endian>(
-             in + pos, size - pos);
+  result scalar_result = 
+      scalar::utf16::utf8_length_from_utf16_with_replacement<big_endian>(
+          in + pos, size - pos);
+  return { any_surrogates ? SURROGATE : scalar_result.error,
+           count + scalar_result.count };
 }

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -1175,14 +1175,14 @@ simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
     const char *input, size_t length) const noexcept {
   return utf8::utf16_length_from_utf8(input, length);
 }
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16le_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return arm64_utf8_length_from_utf16_with_replacement<endianness::LITTLE>(
       input, length);
 }
 
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16be_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return arm64_utf8_length_from_utf16_with_replacement<endianness::BIG>(input,

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -504,14 +504,14 @@ simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
     const char *input, size_t length) const noexcept {
   return scalar::utf8::utf16_length_from_utf8(input, length);
 }
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16le_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return scalar::utf16::utf8_length_from_utf16_with_replacement<
       endianness::LITTLE>(input, length);
 }
 
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16be_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return scalar::utf16::utf8_length_from_utf16_with_replacement<

--- a/src/generic/utf16/utf8_length_from_utf16_bytemask.h
+++ b/src/generic/utf16/utf8_length_from_utf16_bytemask.h
@@ -85,7 +85,7 @@ simdutf_really_inline size_t utf8_length_from_utf16_bytemask(const char16_t *in,
 }
 
 template <endianness big_endian>
-simdutf_really_inline size_t
+simdutf_really_inline result
 utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
   using vector_u16 = simd16<uint16_t>;
   constexpr size_t N = vector_u16::ELEMENTS;
@@ -94,6 +94,7 @@ utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
         in, size);
   } // special case for short inputs
   size_t pos = 0;
+  bool any_surrogates = false;
 
   const auto one = vector_u16::splat(1);
 
@@ -109,6 +110,7 @@ utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
   size_t iteration = max_iterations;
 
   if (scalar::utf16::is_low_surrogate<big_endian>(in[0])) {
+    any_surrogates = true;
     mismatched_count += 1;
   }
 
@@ -130,17 +132,9 @@ utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
     v_count += c0;
     v_count += c1;
     v_count += vector_u16(is_surrogate);
-    //
-    // In theory, we should go faster by avoiding the cost of the coming
-    // branch when there is no surrogate. However, the benefit in practice
-    // are unclear.
-    // This should be revisited in the future for better performance.
-    // It might be possible to batch several iterations together to make
-    // this check worth it.
-    // if(is_surrogate.to_bitmask() != 0 ||
-    // scalar::utf16::is_low_surrogate<big_endian>(in[pos])) {
-    //
-    if (true) { // deliberately always true
+    if(is_surrogate.to_bitmask() != 0 ||
+       scalar::utf16::is_low_surrogate<big_endian>(in[pos + N])) {
+      any_surrogates = true;
       auto input_next =
           vector_u16::load(reinterpret_cast<const uint16_t *>(in + pos + 1));
       if (!match_system(big_endian)) {
@@ -174,6 +168,7 @@ utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
   }
 
   if (scalar::utf16::is_low_surrogate<big_endian>(in[pos])) {
+    any_surrogates = true;
     if (!scalar::utf16::is_high_surrogate<big_endian>(in[pos - 1])) {
       mismatched_count -= 1;
       count += 2;
@@ -183,6 +178,7 @@ utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
   count += pos;
   count += mismatched_count;
   if (scalar::utf16::is_high_surrogate<big_endian>(in[pos - 1])) {
+    any_surrogates = true;
     if (pos == size) {
       count += 2;
     } else if (scalar::utf16::is_low_surrogate<big_endian>(in[pos])) {
@@ -190,9 +186,11 @@ utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
       count += 2;
     }
   }
-  return count +
-         scalar::utf16::utf8_length_from_utf16_with_replacement<big_endian>(
-             in + pos, size - pos);
+  result scalar_result =
+      scalar::utf16::utf8_length_from_utf16_with_replacement<big_endian>(
+          in + pos, size - pos);
+  return { any_surrogates ? SURROGATE : scalar_result.error,
+           count + scalar_result.count };
 }
 
 } // namespace utf16

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -1154,14 +1154,14 @@ simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
     const char *input, size_t length) const noexcept {
   return utf8::utf16_length_from_utf8_bytemask(input, length);
 }
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16le_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return utf16::utf8_length_from_utf16_with_replacement<endianness::LITTLE>(
       input, length);
 }
 
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16be_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return utf16::utf8_length_from_utf16_with_replacement<endianness::BIG>(

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -1613,14 +1613,14 @@ simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
   return count +
          scalar::utf8::utf16_length_from_utf8(input + pos, length - pos);
 }
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16le_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return icelake_utf8_length_from_utf16_with_replacement<endianness::LITTLE>(
       input, length);
 }
 
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16be_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return icelake_utf8_length_from_utf16_with_replacement<endianness::BIG>(

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -395,12 +395,12 @@ public:
       char16_t *utf16_output) const noexcept final override {
     return set_best()->convert_valid_utf8_to_utf16be(buf, len, utf16_output);
   }
-  simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
       const char16_t *input, size_t length) const noexcept final override {
     return set_best()->utf8_length_from_utf16le_with_replacement(input, length);
   }
 
-  simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
       const char16_t *input, size_t length) const noexcept final override {
     return set_best()->utf8_length_from_utf16be_with_replacement(input, length);
   }
@@ -1002,14 +1002,14 @@ public:
       const char *, size_t, char16_t *) const noexcept final override {
     return 0;
   }
-  simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
       const char16_t *, size_t) const noexcept final override {
-    return 0; // Not supported
+    return { OTHER, 0 }; // Not supported
   }
 
-  simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
       const char16_t *, size_t) const noexcept final override {
-    return 0; // Not supported
+    return { OTHER, 0 }; // Not supported
   }
 
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
@@ -2161,15 +2161,16 @@ simdutf_warn_unused size_t utf8_length_from_latin1(const char *buf,
 simdutf_warn_unused size_t utf8_length_from_utf16(const char16_t *input,
                                                   size_t length) noexcept {
   #if SIMDUTF_IS_BIG_ENDIAN
-  return utf8_length_from_utf16be(input, length);
+  result r = utf8_length_from_utf16be_with_replacement(input, length);
+  return r.count;
   #else
   return utf8_length_from_utf16le(input, length);
   #endif
 }
-simdutf_warn_unused size_t utf8_length_from_utf16_with_replacement(
+simdutf_warn_unused result utf8_length_from_utf16_with_replacement(
     const char16_t *input, size_t length) noexcept {
   #if SIMDUTF_IS_BIG_ENDIAN
-  return utf8_length_from_utf16be(input, length);
+  return utf8_length_from_utf16be_with_replacement(input, length);
   #else
   return utf8_length_from_utf16le_with_replacement(input, length);
   #endif
@@ -2208,13 +2209,13 @@ simdutf_warn_unused size_t utf16_length_from_utf8(const char *input,
                                                   size_t length) noexcept {
   return get_default_implementation()->utf16_length_from_utf8(input, length);
 }
-simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
     const char16_t *input, size_t length) noexcept {
   return get_default_implementation()
       ->utf8_length_from_utf16le_with_replacement(input, length);
 }
 
-simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
     const char16_t *input, size_t length) noexcept {
   return get_default_implementation()
       ->utf8_length_from_utf16be_with_replacement(input, length);

--- a/src/lasx/implementation.cpp
+++ b/src/lasx/implementation.cpp
@@ -1301,14 +1301,14 @@ simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
     const char *input, size_t length) const noexcept {
   return utf8::utf16_length_from_utf8_bytemask(input, length);
 }
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16le_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return scalar::utf16::utf8_length_from_utf16_with_replacement<
       endianness::LITTLE>(input, length);
 }
 
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16be_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return scalar::utf16::utf8_length_from_utf16_with_replacement<

--- a/src/lsx/implementation.cpp
+++ b/src/lsx/implementation.cpp
@@ -1187,14 +1187,14 @@ simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
     const char *input, size_t length) const noexcept {
   return utf8::utf16_length_from_utf8_bytemask(input, length);
 }
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16le_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return scalar::utf16::utf8_length_from_utf16_with_replacement<
       endianness::LITTLE>(input, length);
 }
 
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16be_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return scalar::utf16::utf8_length_from_utf16_with_replacement<

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -752,14 +752,14 @@ simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
     const char *input, size_t length) const noexcept {
   return utf8::utf16_length_from_utf8(input, length);
 }
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16le_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return scalar::utf16::utf8_length_from_utf16_with_replacement<
       endianness::LITTLE>(input, length);
 }
 
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16be_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return scalar::utf16::utf8_length_from_utf16_with_replacement<

--- a/src/rvv/implementation.cpp
+++ b/src/rvv/implementation.cpp
@@ -102,14 +102,14 @@ size_t implementation::binary_to_base64_with_lines(
 }
 #endif // SIMDUTF_FEATURE_BASE64
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16le_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return scalar::utf16::utf8_length_from_utf16_with_replacement<
       endianness::LITTLE>(input, length);
 }
 
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16be_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return scalar::utf16::utf8_length_from_utf16_with_replacement<

--- a/src/simdutf/arm64/implementation.h
+++ b/src/simdutf/arm64/implementation.h
@@ -229,10 +229,10 @@ public:
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
   simdutf_warn_unused size_t
   utf16_length_from_utf8(const char *input, size_t length) const noexcept;
-  simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
-  simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16

--- a/src/simdutf/fallback/implementation.h
+++ b/src/simdutf/fallback/implementation.h
@@ -251,10 +251,10 @@ public:
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
   simdutf_warn_unused size_t
   utf16_length_from_utf8(const char *input, size_t length) const noexcept;
-  simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
-  simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16

--- a/src/simdutf/haswell/implementation.h
+++ b/src/simdutf/haswell/implementation.h
@@ -254,10 +254,10 @@ public:
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
   simdutf_warn_unused size_t
   utf16_length_from_utf8(const char *input, size_t length) const noexcept;
-  simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
-  simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16

--- a/src/simdutf/icelake/implementation.h
+++ b/src/simdutf/icelake/implementation.h
@@ -262,10 +262,10 @@ public:
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
   simdutf_warn_unused size_t
   utf16_length_from_utf8(const char *input, size_t length) const noexcept;
-  simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
-  simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16

--- a/src/simdutf/lasx/implementation.h
+++ b/src/simdutf/lasx/implementation.h
@@ -232,10 +232,10 @@ public:
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
   simdutf_warn_unused size_t
   utf16_length_from_utf8(const char *input, size_t length) const noexcept;
-  simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
-  simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16

--- a/src/simdutf/lsx/implementation.h
+++ b/src/simdutf/lsx/implementation.h
@@ -231,10 +231,10 @@ public:
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
   simdutf_warn_unused size_t
   utf16_length_from_utf8(const char *input, size_t length) const noexcept;
-  simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
-  simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16

--- a/src/simdutf/ppc64/implementation.h
+++ b/src/simdutf/ppc64/implementation.h
@@ -254,10 +254,10 @@ public:
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
   simdutf_warn_unused size_t
   utf16_length_from_utf8(const char *input, size_t length) const noexcept;
-  simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
-  simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16

--- a/src/simdutf/rvv/implementation.h
+++ b/src/simdutf/rvv/implementation.h
@@ -236,10 +236,10 @@ public:
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
   simdutf_warn_unused size_t
   utf16_length_from_utf8(const char *input, size_t length) const noexcept;
-  simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
-  simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16

--- a/src/simdutf/westmere/implementation.h
+++ b/src/simdutf/westmere/implementation.h
@@ -254,10 +254,10 @@ public:
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
   simdutf_warn_unused size_t
   utf16_length_from_utf8(const char *input, size_t length) const noexcept;
-  simdutf_warn_unused size_t utf8_length_from_utf16le_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
-  simdutf_warn_unused size_t utf8_length_from_utf16be_with_replacement(
+  simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
       const char16_t *input, size_t length) const noexcept;
   ;
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -1242,14 +1242,14 @@ simdutf_warn_unused size_t implementation::utf16_length_from_utf8(
     const char *input, size_t length) const noexcept {
   return utf8::utf16_length_from_utf8_bytemask(input, length);
 }
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16le_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return utf16::utf8_length_from_utf16_with_replacement<endianness::LITTLE>(
       input, length);
 }
 
-simdutf_warn_unused size_t
+simdutf_warn_unused result
 implementation::utf8_length_from_utf16be_with_replacement(
     const char16_t *input, size_t length) const noexcept {
   return utf16::utf8_length_from_utf16_with_replacement<endianness::BIG>(

--- a/tests/to_well_formed_utf16_tests.cpp
+++ b/tests/to_well_formed_utf16_tests.cpp
@@ -26,10 +26,11 @@ TEST_LOOP(trials, to_well_formed_utf16le_single_surrogate) {
   std::vector<char16_t> surrogates = {0xD800, 0xDC00, 0xDFFF, 0xD800, 0xDC00};
 #endif
   std::vector<char16_t> output(length);
+  for (size_t j = 0; j < length; j++) utf16[j] = 0;
   for (size_t j = 0; j < length; j++) {
     for (char16_t surrogate : surrogates) {
       utf16[j] = surrogate;
-      size_t utf8_length =
+      simdutf::result utf8_length =
           implementation.utf8_length_from_utf16le_with_replacement(
               (const char16_t *)utf16.data(), utf16.size());
       std::fill(output.begin(), output.end(), 0);
@@ -38,7 +39,7 @@ TEST_LOOP(trials, to_well_formed_utf16le_single_surrogate) {
       size_t utf8_length_check = implementation.utf8_length_from_utf16le(
           (const char16_t *)output.data(), utf16.size());
       ASSERT_EQUAL(output[j], replacement_le);
-      ASSERT_EQUAL(utf8_length, utf8_length_check);
+      ASSERT_EQUAL(utf8_length.count, utf8_length_check);
 
       utf16[j] = 0x0000; // Reset to a valid character
     }
@@ -57,7 +58,7 @@ TEST_LOOP(trials, to_well_formed_utf16be_single_surrogate) {
   for (size_t j = 0; j < length; j++) {
     for (char16_t surrogate : surrogates) {
       utf16[j] = surrogate;
-      size_t utf8_length =
+      simdutf::result utf8_length =
           implementation.utf8_length_from_utf16be_with_replacement(
               (const char16_t *)utf16.data(), utf16.size());
       std::fill(output.begin(), output.end(), 0);
@@ -66,7 +67,8 @@ TEST_LOOP(trials, to_well_formed_utf16be_single_surrogate) {
       size_t utf8_length_check = implementation.utf8_length_from_utf16be(
           (const char16_t *)output.data(), utf16.size());
       ASSERT_EQUAL(output[j], replacement_be);
-      ASSERT_EQUAL(utf8_length, utf8_length_check);
+      ASSERT_EQUAL(utf8_length.count, utf8_length_check);
+      ASSERT_EQUAL(utf8_length.error, simdutf::SURROGATE);
       utf16[j] = 0x0000; // Reset to a valid character
     }
   }
@@ -79,13 +81,13 @@ TEST_LOOP(trials,
   const auto utf16{generator.generate_le(8)};
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
-  size_t utf8_length = implementation.utf8_length_from_utf16le_with_replacement(
+  simdutf::result utf8_length = implementation.utf8_length_from_utf16le_with_replacement(
       utf16.data(), len);
   implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
   size_t utf8_length_check =
       implementation.utf8_length_from_utf16le(output.data(), len);
   ASSERT_EQUAL(output, utf16);
-  ASSERT_EQUAL(utf8_length, utf8_length_check);
+  ASSERT_EQUAL(utf8_length.count, utf8_length_check);
 }
 
 TEST_LOOP(trials,
@@ -94,13 +96,13 @@ TEST_LOOP(trials,
   const auto utf16{generator.generate_be(8)};
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
-  size_t utf8_length = implementation.utf8_length_from_utf16be_with_replacement(
+  simdutf::result utf8_length = implementation.utf8_length_from_utf16be_with_replacement(
       utf16.data(), len);
   implementation.to_well_formed_utf16be(utf16.data(), len, output.data());
   size_t utf8_length_check =
       implementation.utf8_length_from_utf16be(output.data(), len);
   ASSERT_EQUAL(output, utf16);
-  ASSERT_EQUAL(utf8_length, utf8_length_check);
+  ASSERT_EQUAL(utf8_length.count, utf8_length_check);
 }
 
 TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_surrogate_pairs_long) {
@@ -108,13 +110,13 @@ TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_surrogate_pairs_long) {
   const auto utf16{generator.generate_le(512)};
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
-  size_t utf8_length = implementation.utf8_length_from_utf16le_with_replacement(
+  simdutf::result utf8_length = implementation.utf8_length_from_utf16le_with_replacement(
       utf16.data(), len);
   implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
   size_t utf8_length_check =
       implementation.utf8_length_from_utf16le(output.data(), len);
   ASSERT_EQUAL(output, utf16);
-  ASSERT_EQUAL(utf8_length, utf8_length_check);
+  ASSERT_EQUAL(utf8_length.count, utf8_length_check);
 }
 
 TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_surrogate_pairs_long) {
@@ -122,13 +124,13 @@ TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_surrogate_pairs_long) {
   const auto utf16{generator.generate_be(512)};
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
-  size_t utf8_length = implementation.utf8_length_from_utf16be_with_replacement(
+  simdutf::result utf8_length = implementation.utf8_length_from_utf16be_with_replacement(
       utf16.data(), len);
   implementation.to_well_formed_utf16be(utf16.data(), len, output.data());
   size_t utf8_length_check =
       implementation.utf8_length_from_utf16be(output.data(), len);
   ASSERT_EQUAL(output, utf16);
-  ASSERT_EQUAL(utf8_length, utf8_length_check);
+  ASSERT_EQUAL(utf8_length.count, utf8_length_check);
 }
 
 TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_mixed_long) {
@@ -136,13 +138,13 @@ TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_mixed_long) {
   const auto utf16{generator.generate_le(512)};
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
-  size_t utf8_length = implementation.utf8_length_from_utf16le_with_replacement(
+  simdutf::result utf8_length = implementation.utf8_length_from_utf16le_with_replacement(
       utf16.data(), len);
   implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
   size_t utf8_length_check =
       implementation.utf8_length_from_utf16le(output.data(), len);
   ASSERT_EQUAL(output, utf16);
-  ASSERT_EQUAL(utf8_length, utf8_length_check);
+  ASSERT_EQUAL(utf8_length.count, utf8_length_check);
 }
 
 TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_mixed_long) {
@@ -150,13 +152,13 @@ TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_mixed_long) {
   const auto utf16{generator.generate_be(512)};
   const auto len = utf16.size();
   std::vector<char16_t> output(len);
-  size_t utf8_length = implementation.utf8_length_from_utf16be_with_replacement(
+  simdutf::result utf8_length = implementation.utf8_length_from_utf16be_with_replacement(
       utf16.data(), len);
   implementation.to_well_formed_utf16be(utf16.data(), len, output.data());
   size_t utf8_length_check =
       implementation.utf8_length_from_utf16be(output.data(), len);
   ASSERT_EQUAL(output, utf16);
-  ASSERT_EQUAL(utf8_length, utf8_length_check);
+  ASSERT_EQUAL(utf8_length.count, utf8_length_check);
 }
 
 TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_mixed_long_self) {
@@ -164,13 +166,13 @@ TEST_LOOP(trials, to_well_formed_utf16le_for_valid_input_mixed_long_self) {
   const auto utf16{generator.generate_le(512)};
   const auto len = utf16.size();
   std::vector<char16_t> output = utf16;
-  size_t utf8_length = implementation.utf8_length_from_utf16le_with_replacement(
+  simdutf::result utf8_length = implementation.utf8_length_from_utf16le_with_replacement(
       output.data(), len);
   implementation.to_well_formed_utf16le(output.data(), len, output.data());
   size_t utf8_length_check =
       implementation.utf8_length_from_utf16le(output.data(), len);
   ASSERT_EQUAL(output, utf16);
-  ASSERT_EQUAL(utf8_length, utf8_length_check);
+  ASSERT_EQUAL(utf8_length.count, utf8_length_check);
 }
 
 TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_mixed_long_self) {
@@ -178,13 +180,13 @@ TEST_LOOP(trials, to_well_formed_utf16be_for_valid_input_mixed_long_self) {
   const auto utf16{generator.generate_be(512)};
   const auto len = utf16.size();
   std::vector<char16_t> output = utf16;
-  size_t utf8_length = implementation.utf8_length_from_utf16be_with_replacement(
+  simdutf::result utf8_length = implementation.utf8_length_from_utf16be_with_replacement(
       output.data(), len);
   implementation.to_well_formed_utf16be(output.data(), len, output.data());
   size_t utf8_length_check =
       implementation.utf8_length_from_utf16be(output.data(), len);
   ASSERT_EQUAL(output, utf16);
-  ASSERT_EQUAL(utf8_length, utf8_length_check);
+  ASSERT_EQUAL(utf8_length.count, utf8_length_check);
 }
 
 std::vector<char16_t> random_testcase(size_t n, std::mt19937 &rng) {
@@ -213,19 +215,20 @@ TEST(to_well_formed_utf16le_bad_input) {
     auto utf16 = random_testcase(512, gen);
     auto len = utf16.size();
     std::vector<char16_t> output(len);
-    size_t utf8_length =
+    simdutf::result utf8_length =
         implementation.utf8_length_from_utf16le_with_replacement(utf16.data(),
                                                                  len);
     implementation.to_well_formed_utf16le(utf16.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
         ASSERT_EQUAL(output[j], replacement_le);
+        ASSERT_EQUAL(utf8_length.error, simdutf::SURROGATE);
       }
     }
     size_t utf8_length_check =
         implementation.utf8_length_from_utf16le(output.data(), len);
     ASSERT_TRUE(implementation.validate_utf16le(output.data(), len));
-    ASSERT_EQUAL(utf8_length, utf8_length_check);
+    ASSERT_EQUAL(utf8_length.count, utf8_length_check);
   }
 }
 
@@ -235,19 +238,20 @@ TEST(to_well_formed_utf16be_bad_input) {
     auto utf16 = random_testcase(512, gen);
     auto len = utf16.size();
     std::vector<char16_t> output(len);
-    size_t utf8_length =
+    simdutf::result utf8_length =
         implementation.utf8_length_from_utf16be_with_replacement(utf16.data(),
                                                                  len);
     implementation.to_well_formed_utf16be(utf16.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
         ASSERT_EQUAL(output[j], replacement_be);
+        ASSERT_EQUAL(utf8_length.error, simdutf::SURROGATE);
       }
     }
     size_t utf8_length_check =
         implementation.utf8_length_from_utf16be(output.data(), len);
     ASSERT_TRUE(implementation.validate_utf16be(output.data(), len));
-    ASSERT_EQUAL(utf8_length, utf8_length_check);
+    ASSERT_EQUAL(utf8_length.count, utf8_length_check);
   }
 }
 
@@ -257,19 +261,20 @@ TEST(to_well_formed_utf16le_bad_input_self) {
     auto utf16 = random_testcase(512, gen);
     auto len = utf16.size();
     std::vector<char16_t> output = utf16;
-    size_t utf8_length =
+    simdutf::result utf8_length =
         implementation.utf8_length_from_utf16le_with_replacement(output.data(),
                                                                  len);
     implementation.to_well_formed_utf16le(output.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
         ASSERT_EQUAL(output[j], replacement_le);
+        ASSERT_EQUAL(utf8_length.error, simdutf::SURROGATE);
       }
     }
     size_t utf8_length_check =
         implementation.utf8_length_from_utf16le(output.data(), len);
     ASSERT_TRUE(implementation.validate_utf16le(output.data(), len));
-    ASSERT_EQUAL(utf8_length, utf8_length_check);
+    ASSERT_EQUAL(utf8_length.count, utf8_length_check);
   }
 }
 
@@ -279,19 +284,20 @@ TEST(to_well_formed_utf16be_bad_input_self) {
     auto utf16 = random_testcase(512, gen);
     auto len = utf16.size();
     std::vector<char16_t> output = utf16;
-    size_t utf8_length =
+    simdutf::result utf8_length =
         implementation.utf8_length_from_utf16be_with_replacement(output.data(),
                                                                  len);
     implementation.to_well_formed_utf16be(output.data(), len, output.data());
     for (size_t j = 0; j < len; j++) {
       if (utf16[j] != output[j]) {
         ASSERT_EQUAL(output[j], replacement_be);
+        ASSERT_EQUAL(utf8_length.error, simdutf::SURROGATE);
       }
     }
     size_t utf8_length_check =
         implementation.utf8_length_from_utf16be(output.data(), len);
     ASSERT_TRUE(implementation.validate_utf16be(output.data(), len));
-    ASSERT_EQUAL(utf8_length, utf8_length_check);
+    ASSERT_EQUAL(utf8_length.count, utf8_length_check);
   }
 }
 

--- a/tests/utf8_length_from_utf16_tests.cpp
+++ b/tests/utf8_length_from_utf16_tests.cpp
@@ -24,10 +24,11 @@ TEST(utf16le_surrogate_pair) {
 
     ASSERT_EQUAL(want, got);
 
-    const size_t got_with_replacement =
+    const simdutf::result got_with_replacement =
         implementation.utf8_length_from_utf16le_with_replacement(
             reinterpret_cast<const char16_t *>(input.data()), input.size() / 2);
-    ASSERT_EQUAL(want, got_with_replacement);
+    ASSERT_EQUAL(want, got_with_replacement.count);
+    ASSERT_EQUAL(simdutf::SURROGATE, got_with_replacement.error);
   }
 }
 
@@ -49,10 +50,11 @@ TEST(utf16be_surrogate_pair) {
 
     ASSERT_EQUAL(want, got);
 
-    const size_t got_with_replacement =
+    const simdutf::result got_with_replacement =
         implementation.utf8_length_from_utf16be_with_replacement(
             reinterpret_cast<const char16_t *>(input.data()), input.size() / 2);
-    ASSERT_EQUAL(want, got_with_replacement);
+    ASSERT_EQUAL(want, got_with_replacement.count);
+    ASSERT_EQUAL(simdutf::SURROGATE, got_with_replacement.error);
   }
 }
 


### PR DESCRIPTION
The next step after utf8_length_from_utf16_with_replacement is almost always going to be to allocate a UTF-8 buffer and then convert the string. Sadly, we have to insert a third pass, to_well_formed_utf16, which converts the unpaired surrogates.

Since surrogates are relatively rare, and the _with_replacement functions have already scanned the input, we could skip the conversion if we were given this information along with the utf-8 length.

In my measurements on Icelake this doesn't slow down utf8_length_from_utf16_with_replacement at all.