### PR TITLE
Treat C++20 char8_t as byte-like

### DIFF
--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -52,9 +52,9 @@ namespace detail {
  * are all distinct types.
  */
 template <typename T>
-concept byte_like = std::is_same_v<T, std::byte> ||   //
-                    std::is_same_v<T, char> ||        //
-                    std::is_same_v<T, signed char> || //
+concept byte_like = std::is_same_v<T, std::byte> ||     //
+                    std::is_same_v<T, char> ||          //
+                    std::is_same_v<T, signed char> ||   //
                     std::is_same_v<T, unsigned char> || //
                     std::is_same_v<T, char8_t>;
 

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -70,7 +70,8 @@ TEST(autodect_can_use_containers_and_views) {
   std::u8string u8stringdata{1, 2, 3, 4, 5};
   auto r10a = simdutf::autodetect_encoding(u8stringdata);
   auto r10b = simdutf::autodetect_encoding(std::span{u8stringdata});
-  auto r10c = simdutf::autodetect_encoding(std::span{std::as_const(u8stringdata)});
+  auto r10c =
+      simdutf::autodetect_encoding(std::span{std::as_const(u8stringdata)});
   auto r10d = simdutf::autodetect_encoding(std::as_const(u8stringdata));
 
   std::u8string_view u8stringview_data{u8stringdata};


### PR DESCRIPTION
Adds `char8_t` as a byte-like type, which in turn enables C++20 `std::u8string` and `std::u8string_view` (aliases for `std::basic_string<char8_t>` and `std::basic_string_view<char8_t>`) objects to be passed in as spans. Right now, simdutf fails to compile if users pass these objects.

[cppreference states](https://en.cppreference.com/w/cpp/language/types.html#char8_t) (emphasis mine):

>char8_t — type for UTF-8 character representation, required to be large enough to represent any UTF-8 code unit (8 bits). **It has the same size, signedness, and alignment as unsigned char (and therefore, the same size and alignment as char and signed char),** but is a distinct type. _(since C++20)_

This is enabled in >=C++20 only, and it won't affect older versions.