### PR TITLE
add lifetime and no escape macros

### DIFF
--- a/include/simdutf/common_defs.h
+++ b/include/simdutf/common_defs.h
@@ -183,4 +183,47 @@
   #define simdutf_maybe_unused
 #endif
 
+// Currently there is no use case for lifebound annotation is simdutf.
+// But we define it here for future use.
+#ifndef __has_cpp_attribute
+  #define simdutf_lifetime_bound
+#elif __has_cpp_attribute(msvc::lifetimebound)
+  #define simdutf_lifetime_bound [[msvc::lifetimebound]]
+#elif __has_cpp_attribute(clang::lifetimebound)
+  #define simdutf_lifetime_bound [[clang::lifetimebound]]
+#elif __has_cpp_attribute(lifetimebound)
+  #define simdutf_lifetime_bound [[lifetimebound]]
+#else
+  #define simdutf_lifetime_bound
+#endif
+
+// The noescape attribute is used to indicate that pointer parameters
+// do not escape the function. That is, we do not track the pointer beyond
+// the function scope.
+// Examples:
+//
+//    char f(simdutf_noescape const char * p) {
+//      return p[0];  // Valid: the pointer is only used locally within the
+//      function
+//    }
+//
+//    const char * p2;  // Global variable
+//    char * g(simdutf_noescape const char * p) {
+//       p2 = p;  // Invalid: storing the pointer globally allows it to escape
+//       the function scope return (char *)p;  // Also invalid if the returned
+//       pointer enables post-return access
+//     }
+//
+// This attribute is currently supported only by clang.
+// It is declarative only, clang does not appear to perform any checking.
+// It only applies to pointer parameters.
+//
+#ifndef __has_cpp_attribute
+  #define simdutf_noescape
+#elif __has_cpp_attribute(clang::noescape)
+  #define simdutf_noescape [[clang::noescape]]
+#else
+  #define simdutf_noescape
+#endif
+
 #endif // SIMDUTF_COMMON_DEFS_H


### PR DESCRIPTION
Add lifetimebound and noescape attribute macros

Although simdutf currently has no use cases for the lifetimebound attribute, define a cross-compiler macro for it to enable potential future usage. This follows the evolving C++ lifetime profile proposals and provides compatibility with MSVC and Clang attributes where available.

Additionally, introduce a macro for Clang's noescape attribute. This attribute indicates that a pointer parameter does not escape the function scope, allowing optimizers to make stronger assumptions. Include detailed explanatory comments describing its purpose, valid and invalid usage examples, current limitations (Clang-only support, declarative only with no static enforcement), and restriction to pointer parameters.

These macros fall back to empty definitions on unsupported compilers to ensure portability.


Add lifetimebound and noescape attribute macros

Although simdutf currently has no use cases for the lifetimebound attribute, define a cross-compiler macro for it to enable potential future usage. This follows the evolving C++ lifetime profile proposals and provides compatibility with MSVC and Clang attributes where available.

The lifetimebound attribute indicates that a pointer (or reference) parameter or return value does not outlive the object it refers to. It helps compilers detect potential lifetime issues, such as dangling pointers or references, by enforcing that the lifetime of the pointed-to object extends at least as long as the function's result or any derived pointers. For example, it could be applied to a function returning a pointer into an input buffer:

```cpp
const char* find_char([[clang::lifetimebound]] const std::string& s, char c) {
  return std::find(s.begin(), s.end(), c);
}  // Valid if the returned pointer's lifetime is bound to s
```

An invalid use might return a pointer to a local variable, which the compiler could warn about if the attribute is present.


The noescape attribute signals that the function does not store the pointer (or anything derived from it) in a location accessible after the function returns, such as globals or heap allocations. This enables better optimizations, like assuming the pointer remains valid only within the call. A valid example is local access only:

```cpp
char f(simdutf_noescape const char* p) {
  return p[0];  // Valid: pointer used transiently
}
```

An invalid example stores it globally:

```cpp
const char* global_ptr;
void g(simdutf_noescape const char* p) {
  global_ptr = p;  // Invalid: pointer escapes via global
}
```

These macros fall back to empty definitions on unsupported compilers to ensure portability.