### PR TITLE
adding a length computation benchmark

### DIFF
--- a/benchmarks/base64/benchmark_base64.cpp
+++ b/benchmarks/base64/benchmark_base64.cpp
@@ -66,7 +66,7 @@ int base64_decode_skip_spaces(const char *src, size_t srclen, char *out,
   return !state.bytes;
 }
 
-enum class BenchmarkMode { roundtrip, decode, encode, bun, roundtripurl, list };
+enum class BenchmarkMode { roundtrip, decode, encode, bun, roundtripurl, lengths, list };
 
 const char *name(BenchmarkMode bm) {
   switch (bm) {
@@ -80,6 +80,8 @@ const char *name(BenchmarkMode bm) {
     return "roundtrip-url";
   case BenchmarkMode::bun:
     return "bun";
+  case BenchmarkMode::lengths:
+    return "lengths";
   case BenchmarkMode::list:
     return "list";
   default:
@@ -139,6 +141,7 @@ void show_help() {
          "passed strings\n");
   printf("  -l                 List implementations\n");
   printf("  -b, --bench-bun    Bun benchmark\n");
+  printf("  -L, --lengths      Benchmark only base64 length functions (maximal & exact)\n");
 
   printf(" See https://github.com/lemire/base64data for test data.\n");
 }
@@ -314,6 +317,9 @@ public:
     case BenchmarkMode::encode:
       encode();
       break;
+    case BenchmarkMode::lengths:
+      lengths();
+      break;
     case BenchmarkMode::bun:
       bench_bun();
       break;
@@ -336,11 +342,12 @@ private:
   }
 
   void list() {
-    std::array<BenchmarkMode, 4> modes = {
+    std::array<BenchmarkMode, 5> modes = {
         BenchmarkMode::roundtrip,
         BenchmarkMode::roundtripurl,
         BenchmarkMode::encode,
         BenchmarkMode::decode,
+        BenchmarkMode::lengths,
     };
 
     for (const auto bm : modes) {
@@ -358,6 +365,9 @@ private:
         break;
       case BenchmarkMode::encode:
         encode();
+        break;
+      case BenchmarkMode::lengths:
+        lengths();
         break;
       default:
         break;
@@ -625,6 +635,33 @@ private:
 #endif
     }
   }
+
+  void lengths() {
+    if (benchmark_mode != BenchmarkMode::list) {
+      printf("# lengths\n");
+      printf("# Benchmark only simdutf length functions (maximal and exact)\n");
+    }
+
+    for (auto &e : simdutf::get_available_implementations()) {
+      if (!e->supported_by_runtime_system()) {
+        continue;
+      }
+      simdutf::get_active_implementation() = e;
+
+      volatile size_t len = 0;
+      summarize("simdutf::" + e->name() + "_maximal_binary_length_from_base64", [this, &e, &len]() {
+        for (const std::vector<char> &source : data) {
+          len = e->maximal_binary_length_from_base64(source.data(), source.size());
+        }
+      });
+
+      summarize("simdutf::" + e->name() + "_binary_length_from_base64", [this, &e, &len]() {
+        for (const std::vector<char> &source : data) {
+          len = e->binary_length_from_base64(source.data(), source.size());
+        }
+      });
+    }
+  }
 };
 
 void bench_bun() {
@@ -722,6 +759,9 @@ struct Options {
       } else if ((arg == "-b") || (arg == "--bun")) {
         benchmark_mode = BenchmarkMode::bun;
         collect_files = true;
+      } else if ((arg == "-L") || (arg == "--lengths")) {
+        benchmark_mode = BenchmarkMode::lengths;
+        collect_files = true;
       } else if (arg == "-l") {
         benchmark_mode = BenchmarkMode::list;
         collect_files = true;
@@ -747,6 +787,7 @@ struct Options {
     case BenchmarkMode::roundtripurl:
     case BenchmarkMode::decode:
     case BenchmarkMode::encode:
+    case BenchmarkMode::lengths:
       if (files.empty()) {
         fprintf(stderr, "option %s: no files were given\n",
                 name(benchmark_mode));


### PR DESCRIPTION
This is a PR *ON TOP* of @anonrig's PR https://github.com/simdutf/simdutf/pull/887

The purpose here is to anchor the discussion with respect to performance. So that everyone understands what is happening.


To test this out, do the following:

```
cmake -B build -D SIMDUTF_BENCHMARKS=ON -D CMAKE_BUILD_TYPE=Release
cmake --build build --target benchmark_base64
```

Use a test file. Any would not, but you can create one like so:

```
 base64 -i ./README.md -b 76 > test.base64
```

Next run the benchmarks, first the decoding benchmark:

```
./build/benchmarks/base64/benchmark_base64 -d test.base64 -f simdutf
```

Here `-f simdutf` applies a filter so we only run the simdutf functions.

Then benchmark the length functions:

```
 ./build/benchmarks/base64/benchmark_base64 -L test.base64
```


Here is what I get on my macbook...

```
./build/benchmarks/base64/benchmark_base64 -d test.base64 -f simdutf

# current system detected as arm64.
# loading files: .
# volume: 182408 bytes
# max length: 182408 bytes
# number of inputs: 1
# decode
# the base64 data contains spaces, so we cannot use straight libbase64::base64_decode directly
simdutf::arm64                                :  15.82 GB/s  7.27 % 
simdutf::arm64 (accept garbage)               :  13.77 GB/s  6.65 % 

 ./build/benchmarks/base64/benchmark_base64 -L test.base64         

# current system detected as arm64.
# loading files: .
# volume: 182409 bytes
# max length: 182409 bytes
# number of inputs: 1
# lengths
# Benchmark only simdutf length functions (maximal and exact)
simdutf::arm64_maximal_binary_length_from_base64 :  10838.88 GB/s  inf % 
simdutf::arm64_binary_length_from_base64      :   8.31 GB/s  3.06 % 
```


So you see here that `maximal_binary_length_from_base64` is effectively free, while `binary_length_from_base64` is not.

Suppose you combine the decoding function with the maximal function... then we get `15.82 GB/s` (unchanged).

But if you combine it with the new function you get 1/(1/8.31 + 1/15.82) or `5.5 GB/s`. That is, we reduce by a factor of three the speed. It is not a small effect.

