### PR TITLE
fixing issue 921

### DIFF
--- a/scripts/check_feature_macros.py
+++ b/scripts/check_feature_macros.py
@@ -131,7 +131,7 @@ def main():
     files = get_git_files(args.limit)
     if not files:
         print("No .cpp or .h files found in the Git repository" + (" in src/ or include/" if args.limit else "") + ".")
-        sys.exit(0)  # Exit with success code if no files are found, see https://github.com/simdutf/simdutf/issues/921
+        sys.exit(142)  # Exit with special code if no files are found, see https://github.com/simdutf/simdutf/issues/921
 
     all_errors = []
     statistics = {'if': 0, 'ifdef': 0, 'ifndef': 0, 'endif': 0}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -475,4 +475,5 @@ if(Python3_FOUND AND GIT_EXECUTABLE)
     COMMAND ${Python3_EXECUTABLE} ${SIMDUTF_SOURCE_DIR}/scripts/check_feature_macros.py
     WORKING_DIRECTORY ${SIMDUTF_SOURCE_DIR}
   )
+  set_tests_properties(check_feature_macros PROPERTIES SKIP_RETURN_CODE 142) # Skip if no relevant files are found
 endif()


### PR DESCRIPTION
When git fails to return the files (i.e., when we are not under git control), we should just have the `check_feature_macros` test succeed (with a warning message).

Fixes: https://github.com/simdutf/simdutf/issues/921
