### PR TITLE
optimise simdutf for short strings

### DIFF
--- a/include/simdutf/common_defs.h
+++ b/include/simdutf/common_defs.h
@@ -183,4 +183,8 @@
   #define simdutf_maybe_unused
 #endif
 
+#ifndef SIMDUTF_SHORT_INPUT_THRESH
+  #define SIMDUTF_SHORT_INPUT_THRESH 16
+#endif
+
 #endif // SIMDUTF_COMMON_DEFS_H

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1427,20 +1427,32 @@ internal::atomic_ptr<const implementation> &get_default_implementation() {
 
 #if SIMDUTF_FEATURE_UTF8
 simdutf_warn_unused bool validate_utf8(const char *buf, size_t len) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8::validate(buf, len);
+  }
   return get_default_implementation()->validate_utf8(buf, len);
 }
 simdutf_warn_unused result validate_utf8_with_errors(const char *buf,
                                                      size_t len) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8::validate_with_errors(buf, len);
+  }
   return get_default_implementation()->validate_utf8_with_errors(buf, len);
 }
 #endif // SIMDUTF_FEATURE_UTF8
 
 #if SIMDUTF_FEATURE_ASCII
 simdutf_warn_unused bool validate_ascii(const char *buf, size_t len) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::ascii::validate(buf, len);
+  }
   return get_default_implementation()->validate_ascii(buf, len);
 }
 simdutf_warn_unused result validate_ascii_with_errors(const char *buf,
                                                       size_t len) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::ascii::validate_with_errors(buf, len);
+  }
   return get_default_implementation()->validate_ascii_with_errors(buf, len);
 }
 #endif // SIMDUTF_FEATURE_ASCII
@@ -1448,10 +1460,16 @@ simdutf_warn_unused result validate_ascii_with_errors(const char *buf,
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_ASCII
 simdutf_warn_unused bool validate_utf16le_as_ascii(const char16_t *buf,
                                                    size_t len) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16::validate_as_ascii<endianness::LITTLE>(buf, len);
+  }
   return get_default_implementation()->validate_utf16le_as_ascii(buf, len);
 }
 simdutf_warn_unused bool validate_utf16be_as_ascii(const char16_t *buf,
                                                    size_t len) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16::validate_as_ascii<endianness::BIG>(buf, len);
+  }
   return get_default_implementation()->validate_utf16be_as_ascii(buf, len);
 }
 simdutf_warn_unused bool validate_utf16_as_ascii(const char16_t *input,
@@ -1478,6 +1496,9 @@ simdutf_warn_unused size_t convert_utf8_to_utf16(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t convert_latin1_to_utf8(const char *buf, size_t len,
                                                   char *utf8_output) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::latin1_to_utf8::convert(buf, len, utf8_output);
+  }
   return get_default_implementation()->convert_latin1_to_utf8(buf, len,
                                                               utf8_output);
 }
@@ -1486,11 +1507,19 @@ simdutf_warn_unused size_t convert_latin1_to_utf8(const char *buf, size_t len,
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t convert_latin1_to_utf16le(
     const char *buf, size_t len, char16_t *utf16_output) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::latin1_to_utf16::convert<endianness::LITTLE>(buf, len,
+                                                                utf16_output);
+  }
   return get_default_implementation()->convert_latin1_to_utf16le(buf, len,
                                                                  utf16_output);
 }
 simdutf_warn_unused size_t convert_latin1_to_utf16be(
     const char *buf, size_t len, char16_t *utf16_output) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::latin1_to_utf16::convert<endianness::BIG>(buf, len,
+                                                             utf16_output);
+  }
   return get_default_implementation()->convert_latin1_to_utf16be(buf, len,
                                                                  utf16_output);
 }
@@ -1499,6 +1528,9 @@ simdutf_warn_unused size_t convert_latin1_to_utf16be(
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t convert_latin1_to_utf32(
     const char *buf, size_t len, char32_t *latin1_output) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::latin1_to_utf32::convert(buf, len, latin1_output);
+  }
   return get_default_implementation()->convert_latin1_to_utf32(buf, len,
                                                                latin1_output);
 }
@@ -1510,16 +1542,25 @@ simdutf_warn_unused size_t convert_latin1_to_utf32(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t convert_utf8_to_latin1(
     const char *buf, size_t len, char *latin1_output) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8_to_latin1::convert(buf, len, latin1_output);
+  }
   return get_default_implementation()->convert_utf8_to_latin1(buf, len,
                                                               latin1_output);
 }
 simdutf_warn_unused result convert_utf8_to_latin1_with_errors(
     const char *buf, size_t len, char *latin1_output) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8_to_latin1::convert_with_errors(buf, len, latin1_output);
+  }
   return get_default_implementation()->convert_utf8_to_latin1_with_errors(
       buf, len, latin1_output);
 }
 simdutf_warn_unused size_t convert_valid_utf8_to_latin1(
     const char *buf, size_t len, char *latin1_output) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8_to_latin1::convert_valid(buf, len, latin1_output);
+  }
   return get_default_implementation()->convert_valid_utf8_to_latin1(
       buf, len, latin1_output);
 }
@@ -1528,11 +1569,19 @@ simdutf_warn_unused size_t convert_valid_utf8_to_latin1(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t convert_utf8_to_utf16le(
     const char *input, size_t length, char16_t *utf16_output) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8_to_utf16::convert<endianness::LITTLE>(input, length,
+                                                              utf16_output);
+  }
   return get_default_implementation()->convert_utf8_to_utf16le(input, length,
                                                                utf16_output);
 }
 simdutf_warn_unused size_t convert_utf8_to_utf16be(
     const char *input, size_t length, char16_t *utf16_output) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8_to_utf16::convert<endianness::BIG>(input, length,
+                                                           utf16_output);
+  }
   return get_default_implementation()->convert_utf8_to_utf16be(input, length,
                                                                utf16_output);
 }
@@ -1546,11 +1595,19 @@ simdutf_warn_unused result convert_utf8_to_utf16_with_errors(
 }
 simdutf_warn_unused result convert_utf8_to_utf16le_with_errors(
     const char *input, size_t length, char16_t *utf16_output) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8_to_utf16::convert_with_errors<endianness::LITTLE>(
+        input, length, utf16_output);
+  }
   return get_default_implementation()->convert_utf8_to_utf16le_with_errors(
       input, length, utf16_output);
 }
 simdutf_warn_unused result convert_utf8_to_utf16be_with_errors(
     const char *input, size_t length, char16_t *utf16_output) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8_to_utf16::convert_with_errors<endianness::BIG>(
+        input, length, utf16_output);
+  }
   return get_default_implementation()->convert_utf8_to_utf16be_with_errors(
       input, length, utf16_output);
 }
@@ -1559,11 +1616,18 @@ simdutf_warn_unused result convert_utf8_to_utf16be_with_errors(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t convert_utf8_to_utf32(
     const char *input, size_t length, char32_t *utf32_output) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8_to_utf32::convert(input, length, utf32_output);
+  }
   return get_default_implementation()->convert_utf8_to_utf32(input, length,
                                                              utf32_output);
 }
 simdutf_warn_unused result convert_utf8_to_utf32_with_errors(
     const char *input, size_t length, char32_t *utf32_output) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8_to_utf32::convert_with_errors(input, length,
+                                                      utf32_output);
+  }
   return get_default_implementation()->convert_utf8_to_utf32_with_errors(
       input, length, utf32_output);
 }
@@ -1580,11 +1644,17 @@ simdutf_warn_unused bool validate_utf16(const char16_t *buf,
 }
 void to_well_formed_utf16be(const char16_t *input, size_t len,
                             char16_t *output) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    scalar::utf16::to_well_formed_utf16<endianness::BIG>(input, len, output);
+  }
   return get_default_implementation()->to_well_formed_utf16be(input, len,
                                                               output);
 }
 void to_well_formed_utf16le(const char16_t *input, size_t len,
                             char16_t *output) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    scalar::utf16::to_well_formed_utf16<endianness::LITTLE>(input, len, output);
+  }
   return get_default_implementation()->to_well_formed_utf16le(input, len,
                                                               output);
 }
@@ -1601,6 +1671,9 @@ void to_well_formed_utf16(const char16_t *input, size_t len,
 #if SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
 simdutf_warn_unused bool validate_utf16le(const char16_t *buf,
                                           size_t len) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16::validate<endianness::LITTLE>(buf, len);
+  }
   return get_default_implementation()->validate_utf16le(buf, len);
 }
 #endif // SIMDUTF_FEATURE_UTF16 || SIMDUTF_FEATURE_DETECT_ENCODING
@@ -1700,6 +1773,9 @@ simdutf_warn_unused result atomic_base64_to_binary_safe(
 #if SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused bool validate_utf16be(const char16_t *buf,
                                           size_t len) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16::validate<endianness::BIG>(buf, len);
+  }
   return get_default_implementation()->validate_utf16be(buf, len);
 }
 simdutf_warn_unused result validate_utf16_with_errors(const char16_t *buf,
@@ -1712,10 +1788,16 @@ simdutf_warn_unused result validate_utf16_with_errors(const char16_t *buf,
 }
 simdutf_warn_unused result validate_utf16le_with_errors(const char16_t *buf,
                                                         size_t len) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16::validate_with_errors<endianness::LITTLE>(buf, len);
+  }
   return get_default_implementation()->validate_utf16le_with_errors(buf, len);
 }
 simdutf_warn_unused result validate_utf16be_with_errors(const char16_t *buf,
                                                         size_t len) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16::validate_with_errors<endianness::BIG>(buf, len);
+  }
   return get_default_implementation()->validate_utf16be_with_errors(buf, len);
 }
 #endif // SIMDUTF_FEATURE_UTF16
@@ -1723,10 +1805,16 @@ simdutf_warn_unused result validate_utf16be_with_errors(const char16_t *buf,
 #if SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused bool validate_utf32(const char32_t *buf,
                                         size_t len) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32::validate(buf, len);
+  }
   return get_default_implementation()->validate_utf32(buf, len);
 }
 simdutf_warn_unused result validate_utf32_with_errors(const char32_t *buf,
                                                       size_t len) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32::validate_with_errors(buf, len);
+  }
   return get_default_implementation()->validate_utf32_with_errors(buf, len);
 }
 #endif // SIMDUTF_FEATURE_UTF32
@@ -1742,11 +1830,19 @@ simdutf_warn_unused size_t convert_valid_utf8_to_utf16(
 }
 simdutf_warn_unused size_t convert_valid_utf8_to_utf16le(
     const char *input, size_t length, char16_t *utf16_buffer) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8_to_utf16::convert_valid<endianness::LITTLE>(
+        input, length, utf16_buffer);
+  }
   return get_default_implementation()->convert_valid_utf8_to_utf16le(
       input, length, utf16_buffer);
 }
 simdutf_warn_unused size_t convert_valid_utf8_to_utf16be(
     const char *input, size_t length, char16_t *utf16_buffer) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8_to_utf16::convert_valid<endianness::BIG>(input, length,
+                                                                 utf16_buffer);
+  }
   return get_default_implementation()->convert_valid_utf8_to_utf16be(
       input, length, utf16_buffer);
 }
@@ -1755,6 +1851,9 @@ simdutf_warn_unused size_t convert_valid_utf8_to_utf16be(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t convert_valid_utf8_to_utf32(
     const char *input, size_t length, char32_t *utf32_buffer) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8_to_utf32::convert_valid(input, length, utf32_buffer);
+  }
   return get_default_implementation()->convert_valid_utf8_to_utf32(
       input, length, utf32_buffer);
 }
@@ -1847,31 +1946,55 @@ simdutf_warn_unused size_t convert_latin1_to_utf16(
 }
 simdutf_warn_unused size_t convert_utf16be_to_latin1(
     const char16_t *buf, size_t len, char *latin1_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_latin1::convert<endianness::BIG>(buf, len,
+                                                             latin1_buffer);
+  }
   return get_default_implementation()->convert_utf16be_to_latin1(buf, len,
                                                                  latin1_buffer);
 }
 simdutf_warn_unused size_t convert_utf16le_to_latin1(
     const char16_t *buf, size_t len, char *latin1_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_latin1::convert<endianness::LITTLE>(buf, len,
+                                                                latin1_buffer);
+  }
   return get_default_implementation()->convert_utf16le_to_latin1(buf, len,
                                                                  latin1_buffer);
 }
 simdutf_warn_unused size_t convert_valid_utf16be_to_latin1(
     const char16_t *buf, size_t len, char *latin1_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_latin1::convert_valid<endianness::BIG>(
+        buf, len, latin1_buffer);
+  }
   return get_default_implementation()->convert_valid_utf16be_to_latin1(
       buf, len, latin1_buffer);
 }
 simdutf_warn_unused size_t convert_valid_utf16le_to_latin1(
     const char16_t *buf, size_t len, char *latin1_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_latin1::convert_valid<endianness::LITTLE>(
+        buf, len, latin1_buffer);
+  }
   return get_default_implementation()->convert_valid_utf16le_to_latin1(
       buf, len, latin1_buffer);
 }
 simdutf_warn_unused result convert_utf16le_to_latin1_with_errors(
     const char16_t *buf, size_t len, char *latin1_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_latin1::convert_with_errors<endianness::LITTLE>(
+        buf, len, latin1_buffer);
+  }
   return get_default_implementation()->convert_utf16le_to_latin1_with_errors(
       buf, len, latin1_buffer);
 }
 simdutf_warn_unused result convert_utf16be_to_latin1_with_errors(
     const char16_t *buf, size_t len, char *latin1_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_latin1::convert_with_errors<endianness::BIG>(
+        buf, len, latin1_buffer);
+  }
   return get_default_implementation()->convert_utf16be_to_latin1_with_errors(
       buf, len, latin1_buffer);
 }
@@ -1884,12 +2007,20 @@ simdutf_warn_unused result convert_utf16be_to_latin1_with_errors(
 simdutf_warn_unused size_t convert_utf16le_to_utf8(const char16_t *buf,
                                                    size_t len,
                                                    char *utf8_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_utf8::convert<endianness::LITTLE>(buf, len,
+                                                              utf8_buffer);
+  }
   return get_default_implementation()->convert_utf16le_to_utf8(buf, len,
                                                                utf8_buffer);
 }
 simdutf_warn_unused size_t convert_utf16be_to_utf8(const char16_t *buf,
                                                    size_t len,
                                                    char *utf8_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_utf8::convert<endianness::BIG>(buf, len,
+                                                           utf8_buffer);
+  }
   return get_default_implementation()->convert_utf16be_to_utf8(buf, len,
                                                                utf8_buffer);
 }
@@ -1917,11 +2048,19 @@ simdutf_warn_unused result convert_utf16_to_latin1_with_errors(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused result convert_utf16le_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_utf8::convert_with_errors<endianness::LITTLE>(
+        buf, len, utf8_buffer);
+  }
   return get_default_implementation()->convert_utf16le_to_utf8_with_errors(
       buf, len, utf8_buffer);
 }
 simdutf_warn_unused result convert_utf16be_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_utf8::convert_with_errors<endianness::BIG>(
+        buf, len, utf8_buffer);
+  }
   return get_default_implementation()->convert_utf16be_to_utf8_with_errors(
       buf, len, utf8_buffer);
 }
@@ -1949,11 +2088,19 @@ simdutf_warn_unused size_t convert_valid_utf16_to_latin1(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t convert_valid_utf16le_to_utf8(
     const char16_t *buf, size_t len, char *utf8_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_utf8::convert_valid<endianness::LITTLE>(
+        buf, len, utf8_buffer);
+  }
   return get_default_implementation()->convert_valid_utf16le_to_utf8(
       buf, len, utf8_buffer);
 }
 simdutf_warn_unused size_t convert_valid_utf16be_to_utf8(
     const char16_t *buf, size_t len, char *utf8_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_utf8::convert_valid<endianness::BIG>(buf, len,
+                                                                 utf8_buffer);
+  }
   return get_default_implementation()->convert_valid_utf16be_to_utf8(
       buf, len, utf8_buffer);
 }
@@ -1963,16 +2110,25 @@ simdutf_warn_unused size_t convert_valid_utf16be_to_utf8(
 simdutf_warn_unused size_t convert_utf32_to_utf8(const char32_t *buf,
                                                  size_t len,
                                                  char *utf8_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32_to_utf8::convert(buf, len, utf8_buffer);
+  }
   return get_default_implementation()->convert_utf32_to_utf8(buf, len,
                                                              utf8_buffer);
 }
 simdutf_warn_unused result convert_utf32_to_utf8_with_errors(
     const char32_t *buf, size_t len, char *utf8_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32_to_utf8::convert_with_errors(buf, len, utf8_buffer);
+  }
   return get_default_implementation()->convert_utf32_to_utf8_with_errors(
       buf, len, utf8_buffer);
 }
 simdutf_warn_unused size_t convert_valid_utf32_to_utf8(
     const char32_t *buf, size_t len, char *utf8_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32_to_utf8::convert_valid(buf, len, utf8_buffer);
+  }
   return get_default_implementation()->convert_valid_utf32_to_utf8(buf, len,
                                                                    utf8_buffer);
 }
@@ -1992,16 +2148,26 @@ simdutf_warn_unused size_t convert_utf32_to_utf16(
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t convert_utf32_to_latin1(
     const char32_t *input, size_t length, char *latin1_output) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32_to_latin1::convert(input, length, latin1_output);
+  }
   return get_default_implementation()->convert_utf32_to_latin1(input, length,
                                                                latin1_output);
 }
 simdutf_warn_unused result convert_utf32_to_latin1_with_errors(
     const char32_t *input, size_t length, char *latin1_buffer) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32_to_latin1::convert_with_errors(input, length,
+                                                        latin1_buffer);
+  }
   return get_default_implementation()->convert_utf32_to_latin1_with_errors(
       input, length, latin1_buffer);
 }
 simdutf_warn_unused size_t convert_valid_utf32_to_latin1(
     const char32_t *input, size_t length, char *latin1_buffer) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32_to_latin1::convert_valid(input, length, latin1_buffer);
+  }
   return get_default_implementation()->convert_valid_utf32_to_latin1(
       input, length, latin1_buffer);
 }
@@ -2010,11 +2176,19 @@ simdutf_warn_unused size_t convert_valid_utf32_to_latin1(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t convert_utf32_to_utf16le(
     const char32_t *buf, size_t len, char16_t *utf16_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32_to_utf16::convert<endianness::LITTLE>(buf, len,
+                                                               utf16_buffer);
+  }
   return get_default_implementation()->convert_utf32_to_utf16le(buf, len,
                                                                 utf16_buffer);
 }
 simdutf_warn_unused size_t convert_utf32_to_utf16be(
     const char32_t *buf, size_t len, char16_t *utf16_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32_to_utf16::convert<endianness::BIG>(buf, len,
+                                                            utf16_buffer);
+  }
   return get_default_implementation()->convert_utf32_to_utf16be(buf, len,
                                                                 utf16_buffer);
 }
@@ -2028,11 +2202,19 @@ simdutf_warn_unused result convert_utf32_to_utf16_with_errors(
 }
 simdutf_warn_unused result convert_utf32_to_utf16le_with_errors(
     const char32_t *buf, size_t len, char16_t *utf16_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32_to_utf16::convert_with_errors<endianness::LITTLE>(
+        buf, len, utf16_buffer);
+  }
   return get_default_implementation()->convert_utf32_to_utf16le_with_errors(
       buf, len, utf16_buffer);
 }
 simdutf_warn_unused result convert_utf32_to_utf16be_with_errors(
     const char32_t *buf, size_t len, char16_t *utf16_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32_to_utf16::convert_with_errors<endianness::BIG>(
+        buf, len, utf16_buffer);
+  }
   return get_default_implementation()->convert_utf32_to_utf16be_with_errors(
       buf, len, utf16_buffer);
 }
@@ -2046,11 +2228,19 @@ simdutf_warn_unused size_t convert_valid_utf32_to_utf16(
 }
 simdutf_warn_unused size_t convert_valid_utf32_to_utf16le(
     const char32_t *buf, size_t len, char16_t *utf16_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32_to_utf16::convert_valid<endianness::LITTLE>(
+        buf, len, utf16_buffer);
+  }
   return get_default_implementation()->convert_valid_utf32_to_utf16le(
       buf, len, utf16_buffer);
 }
 simdutf_warn_unused size_t convert_valid_utf32_to_utf16be(
     const char32_t *buf, size_t len, char16_t *utf16_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32_to_utf16::convert_valid<endianness::BIG>(buf, len,
+                                                                  utf16_buffer);
+  }
   return get_default_implementation()->convert_valid_utf32_to_utf16be(
       buf, len, utf16_buffer);
 }
@@ -2064,11 +2254,19 @@ simdutf_warn_unused size_t convert_utf16_to_utf32(
 }
 simdutf_warn_unused size_t convert_utf16le_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_utf32::convert<endianness::LITTLE>(buf, len,
+                                                               utf32_buffer);
+  }
   return get_default_implementation()->convert_utf16le_to_utf32(buf, len,
                                                                 utf32_buffer);
 }
 simdutf_warn_unused size_t convert_utf16be_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_utf32::convert<endianness::BIG>(buf, len,
+                                                            utf32_buffer);
+  }
   return get_default_implementation()->convert_utf16be_to_utf32(buf, len,
                                                                 utf32_buffer);
 }
@@ -2082,11 +2280,19 @@ simdutf_warn_unused result convert_utf16_to_utf32_with_errors(
 }
 simdutf_warn_unused result convert_utf16le_to_utf32_with_errors(
     const char16_t *buf, size_t len, char32_t *utf32_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_utf32::convert_with_errors<endianness::LITTLE>(
+        buf, len, utf32_buffer);
+  }
   return get_default_implementation()->convert_utf16le_to_utf32_with_errors(
       buf, len, utf32_buffer);
 }
 simdutf_warn_unused result convert_utf16be_to_utf32_with_errors(
     const char16_t *buf, size_t len, char32_t *utf32_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_utf32::convert_with_errors<endianness::BIG>(
+        buf, len, utf32_buffer);
+  }
   return get_default_implementation()->convert_utf16be_to_utf32_with_errors(
       buf, len, utf32_buffer);
 }
@@ -2100,11 +2306,19 @@ simdutf_warn_unused size_t convert_valid_utf16_to_utf32(
 }
 simdutf_warn_unused size_t convert_valid_utf16le_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_utf32::convert_valid<endianness::LITTLE>(
+        buf, len, utf32_buffer);
+  }
   return get_default_implementation()->convert_valid_utf16le_to_utf32(
       buf, len, utf32_buffer);
 }
 simdutf_warn_unused size_t convert_valid_utf16be_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_buffer) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16_to_utf32::convert_valid<endianness::BIG>(buf, len,
+                                                                  utf32_buffer);
+  }
   return get_default_implementation()->convert_valid_utf16be_to_utf32(
       buf, len, utf32_buffer);
 }
@@ -2113,6 +2327,9 @@ simdutf_warn_unused size_t convert_valid_utf16be_to_utf32(
 #if SIMDUTF_FEATURE_UTF16
 void change_endianness_utf16(const char16_t *input, size_t length,
                              char16_t *output) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16::change_endianness_utf16(input, length, output);
+  }
   get_default_implementation()->change_endianness_utf16(input, length, output);
 }
 simdutf_warn_unused size_t count_utf16(const char16_t *input,
@@ -2125,10 +2342,16 @@ simdutf_warn_unused size_t count_utf16(const char16_t *input,
 }
 simdutf_warn_unused size_t count_utf16le(const char16_t *input,
                                          size_t length) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16::count_code_points<endianness::LITTLE>(input, length);
+  }
   return get_default_implementation()->count_utf16le(input, length);
 }
 simdutf_warn_unused size_t count_utf16be(const char16_t *input,
                                          size_t length) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16::count_code_points<endianness::BIG>(input, length);
+  }
   return get_default_implementation()->count_utf16be(input, length);
 }
 #endif // SIMDUTF_FEATURE_UTF16
@@ -2136,6 +2359,9 @@ simdutf_warn_unused size_t count_utf16be(const char16_t *input,
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t count_utf8(const char *input,
                                       size_t length) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8::count_code_points(input, length);
+  }
   return get_default_implementation()->count_utf8(input, length);
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
@@ -2143,6 +2369,9 @@ simdutf_warn_unused size_t count_utf8(const char *input,
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t latin1_length_from_utf8(const char *buf,
                                                    size_t len) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8::count_code_points(buf, len);
+  }
   return get_default_implementation()->latin1_length_from_utf8(buf, len);
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
@@ -2150,6 +2379,9 @@ simdutf_warn_unused size_t latin1_length_from_utf8(const char *buf,
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t utf8_length_from_latin1(const char *buf,
                                                    size_t len) noexcept {
+  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::latin1_to_utf8::utf8_length_from_latin1(buf, len);
+  }
   return get_default_implementation()->utf8_length_from_latin1(buf, len);
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
@@ -2173,10 +2405,18 @@ simdutf_warn_unused result utf8_length_from_utf16_with_replacement(
 }
 simdutf_warn_unused size_t utf8_length_from_utf16le(const char16_t *input,
                                                     size_t length) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16::utf8_length_from_utf16<endianness::LITTLE>(input,
+                                                                     length);
+  }
   return get_default_implementation()->utf8_length_from_utf16le(input, length);
 }
 simdutf_warn_unused size_t utf8_length_from_utf16be(const char16_t *input,
                                                     size_t length) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16::utf8_length_from_utf16<endianness::BIG>(input,
+                                                                  length);
+  }
   return get_default_implementation()->utf8_length_from_utf16be(input, length);
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
@@ -2192,10 +2432,18 @@ simdutf_warn_unused size_t utf32_length_from_utf16(const char16_t *input,
 }
 simdutf_warn_unused size_t utf32_length_from_utf16le(const char16_t *input,
                                                      size_t length) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16::utf32_length_from_utf16<endianness::LITTLE>(input,
+                                                                      length);
+  }
   return get_default_implementation()->utf32_length_from_utf16le(input, length);
 }
 simdutf_warn_unused size_t utf32_length_from_utf16be(const char16_t *input,
                                                      size_t length) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16::utf32_length_from_utf16<endianness::BIG>(input,
+                                                                   length);
+  }
   return get_default_implementation()->utf32_length_from_utf16be(input, length);
 }
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
@@ -2203,16 +2451,27 @@ simdutf_warn_unused size_t utf32_length_from_utf16be(const char16_t *input,
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t utf16_length_from_utf8(const char *input,
                                                   size_t length) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8::utf16_length_from_utf8(input, length);
+  }
   return get_default_implementation()->utf16_length_from_utf8(input, length);
 }
 simdutf_warn_unused result utf8_length_from_utf16le_with_replacement(
     const char16_t *input, size_t length) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16::utf8_length_from_utf16_with_replacement<
+        endianness::LITTLE>(input, length);
+  }
   return get_default_implementation()
       ->utf8_length_from_utf16le_with_replacement(input, length);
 }
 
 simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
     const char16_t *input, size_t length) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf16::utf8_length_from_utf16_with_replacement<
+        endianness::BIG>(input, length);
+  }
   return get_default_implementation()
       ->utf8_length_from_utf16be_with_replacement(input, length);
 }
@@ -2222,6 +2481,9 @@ simdutf_warn_unused result utf8_length_from_utf16be_with_replacement(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t utf8_length_from_utf32(const char32_t *input,
                                                   size_t length) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32::utf8_length_from_utf32(input, length);
+  }
   return get_default_implementation()->utf8_length_from_utf32(input, length);
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
@@ -2229,6 +2491,9 @@ simdutf_warn_unused size_t utf8_length_from_utf32(const char32_t *input,
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t utf16_length_from_utf32(const char32_t *input,
                                                    size_t length) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf32::utf16_length_from_utf32(input, length);
+  }
   return get_default_implementation()->utf16_length_from_utf32(input, length);
 }
 #endif // SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
@@ -2236,6 +2501,9 @@ simdutf_warn_unused size_t utf16_length_from_utf32(const char32_t *input,
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t utf32_length_from_utf8(const char *input,
                                                   size_t length) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::utf8::count_code_points(input, length);
+  }
   return get_default_implementation()->utf32_length_from_utf8(input, length);
 }
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
@@ -2253,11 +2521,17 @@ simdutf_warn_unused size_t utf32_length_from_utf8(const char *input,
 
 simdutf_warn_unused const char *detail::find(const char *start, const char *end,
                                              char character) noexcept {
+  if ((end - start) < SIMDUTF_SHORT_INPUT_THRESH) {
+    return std::find(start, end, character);
+  }
   return get_default_implementation()->find(start, end, character);
 }
 simdutf_warn_unused const char16_t *detail::find(const char16_t *start,
                                                  const char16_t *end,
                                                  char16_t character) noexcept {
+  if (2 * (end - start) < SIMDUTF_SHORT_INPUT_THRESH) {
+    return std::find(start, end, character);
+  }
   return get_default_implementation()->find(start, end, character);
 }
 
@@ -2270,6 +2544,10 @@ maximal_binary_length_from_base64(const char *input, size_t length) noexcept {
 simdutf_warn_unused result base64_to_binary(
     const char *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_handling_options) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return simdutf::scalar::base64::base64_to_binary_details_impl(
+        input, length, output, options, last_chunk_handling_options);
+  }
   return get_default_implementation()->base64_to_binary(
       input, length, output, options, last_chunk_handling_options);
 }
@@ -2283,6 +2561,10 @@ simdutf_warn_unused size_t maximal_binary_length_from_base64(
 simdutf_warn_unused result base64_to_binary(
     const char16_t *input, size_t length, char *output, base64_options options,
     last_chunk_handling_options last_chunk_handling_options) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return simdutf::scalar::base64::base64_to_binary_details_impl(
+        input, length, output, options, last_chunk_handling_options);
+  }
   return get_default_implementation()->base64_to_binary(
       input, length, output, options, last_chunk_handling_options);
 }
@@ -2380,6 +2662,9 @@ base64_to_binary_safe(const char16_t *input, size_t length, char *output,
 
 size_t binary_to_base64(const char *input, size_t length, char *output,
                         base64_options options) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::base64::tail_encode_base64(output, input, length, options);
+  }
   return get_default_implementation()->binary_to_base64(input, length, output,
                                                         options);
 }
@@ -2387,6 +2672,10 @@ size_t binary_to_base64(const char *input, size_t length, char *output,
 size_t binary_to_base64_with_lines(const char *input, size_t length,
                                    char *output, size_t line_length,
                                    base64_options options) noexcept {
+  if (length < SIMDUTF_SHORT_INPUT_THRESH) {
+    return scalar::base64::tail_encode_base64_impl<true>(output, input, length,
+                                                         options, line_length);
+  }
   return get_default_implementation()->binary_to_base64_with_lines(
       input, length, output, line_length, options);
 }


### PR DESCRIPTION
Related to https://github.com/simdutf/simdutf/issues/925

Started with a straightforward implementation, modifying the public API's defination in this way, 
```cpp
simdutf_warn_unused bool validate_utf8(const char *buf, size_t len) noexcept {
  if (len < SIMDUTF_SHORT_INPUT_THRESH) {
    return scalar::utf8::validate(buf, len);
  }
  return get_default_implementation()->validate_utf8(buf, len);
}
```
Which was before,
https://github.com/simdutf/simdutf/blob/bcfbae9fad23aa5c0f893a72ed013416a8567608/src/implementation.cpp#L1429-L1431

Using the `benchmark` utiltiy, got 0 improvements. But when benchmarked using google-benchmark for input sizes from 1 to 15, these are the results for `validate_utf8` procedure - 

Old: 
```
Running ./bench_utf8
Run on (10 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x10)
Load Average: 2.50, 2.81, 2.65
------------------------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------
BM_validate_utf8_small/1      840503 ns       839682 ns          755 bytes_per_second=93.0412Mi/s
BM_validate_utf8_small/2      846647 ns       842714 ns          830 bytes_per_second=185.41Mi/s
BM_validate_utf8_small/3      951668 ns       948250 ns          741 bytes_per_second=247.16Mi/s
BM_validate_utf8_small/4      944975 ns       942727 ns          743 bytes_per_second=331.473Mi/s
BM_validate_utf8_small/5      942938 ns       940954 ns          735 bytes_per_second=415.117Mi/s
BM_validate_utf8_small/6      841230 ns       839293 ns          833 bytes_per_second=558.472Mi/s
BM_validate_utf8_small/7      891388 ns       889915 ns          786 bytes_per_second=614.48Mi/s
BM_validate_utf8_small/8      663682 ns       662348 ns         1054 bytes_per_second=943.532Mi/s
BM_validate_utf8_small/9      841233 ns       839826 ns          834 bytes_per_second=837.145Mi/s
BM_validate_utf8_small/10     849720 ns       846173 ns          833 bytes_per_second=923.173Mi/s
BM_validate_utf8_small/11     957664 ns       949415 ns          731 bytes_per_second=905.053Mi/s
BM_validate_utf8_small/12     962141 ns       953108 ns          741 bytes_per_second=983.492Mi/s
BM_validate_utf8_small/13     959022 ns       948287 ns          743 bytes_per_second=1.04576Gi/s
BM_validate_utf8_small/14     848028 ns       843355 ns          833 bytes_per_second=1.26631Gi/s
BM_validate_utf8_small/15     902333 ns       893884 ns          784 bytes_per_second=1.28005Gi/s
```

New:
```
Running ./bench_utf8
Run on (10 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x10)
Load Average: 1.71, 2.77, 2.64
------------------------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------
BM_validate_utf8_small/1      102941 ns       102369 ns         6844 bytes_per_second=763.171Mi/s
BM_validate_utf8_small/2      178957 ns       178164 ns         3880 bytes_per_second=876.988Mi/s
BM_validate_utf8_small/3      206253 ns       205535 ns         3313 bytes_per_second=1.11356Gi/s
BM_validate_utf8_small/4      229331 ns       228903 ns         3060 bytes_per_second=1.33316Gi/s
BM_validate_utf8_small/5      257787 ns       255509 ns         2751 bytes_per_second=1.49291Gi/s
BM_validate_utf8_small/6      290960 ns       284772 ns         2488 bytes_per_second=1.60738Gi/s
BM_validate_utf8_small/7      306497 ns       305387 ns         2265 bytes_per_second=1.74866Gi/s
BM_validate_utf8_small/8      331329 ns       330753 ns         2114 bytes_per_second=1.84518Gi/s
BM_validate_utf8_small/9      357335 ns       356322 ns         1968 bytes_per_second=1.92685Gi/s
BM_validate_utf8_small/10     381890 ns       381156 ns         1833 bytes_per_second=2.00143Gi/s
BM_validate_utf8_small/11     412080 ns       410937 ns         1722 bytes_per_second=2.042Gi/s
BM_validate_utf8_small/12     433322 ns       432472 ns         1620 bytes_per_second=2.11668Gi/s
BM_validate_utf8_small/13     458809 ns       457936 ns         1526 bytes_per_second=2.16553Gi/s
BM_validate_utf8_small/14     483932 ns       483006 ns         1448 bytes_per_second=2.21104Gi/s
BM_validate_utf8_small/15     509209 ns       508381 ns         1367 bytes_per_second=2.2507Gi/s
```
Seeing a greater than 2x improvement.