### PR TITLE
inlining get_default_implementation and get_single_implementation

### DIFF
--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1419,7 +1419,8 @@ simdutf_really_inline const implementation *get_default_implementation() {
   return internal::get_single_implementation();
 }
 #else
-simdutf_really_inline internal::atomic_ptr<const implementation> &get_default_implementation() {
+simdutf_really_inline internal::atomic_ptr<const implementation> &
+get_default_implementation() {
   return get_active_implementation();
 }
 #endif


### PR DESCRIPTION
The the get_default_implementation and get_single_implementation functions should be inlined, for best performance. (They appear in the profiling data.)
