### PR TITLE
Add `simdutf_utf8_length_from_utf32` to C API

### DIFF
--- a/include/simdutf_c.h
+++ b/include/simdutf_c.h
@@ -115,6 +115,7 @@ size_t simdutf_latin1_length_from_utf32(size_t length);
 size_t simdutf_utf16_length_from_utf8(const char *input, size_t length);
 size_t simdutf_utf32_length_from_utf8(const char *input, size_t length);
 size_t simdutf_utf8_length_from_utf16(const char16_t *input, size_t length);
+size_t simdutf_utf8_length_from_utf32(const char32_t *input, size_t length);
 simdutf_result
 simdutf_utf8_length_from_utf16_with_replacement(const char16_t *input,
                                                 size_t length);

--- a/src/simdutf_c.cpp
+++ b/src/simdutf_c.cpp
@@ -145,6 +145,10 @@ size_t simdutf_utf8_length_from_utf16(const char16_t *input, size_t length) {
   return simdutf::utf8_length_from_utf16(
       reinterpret_cast<const char16_t *>(input), length);
 }
+size_t simdutf_utf8_length_from_utf32(const char32_t *input, size_t length) {
+  return simdutf::utf8_length_from_utf32(
+      reinterpret_cast<const char32_t *>(input), length);
+}
 simdutf_result
 simdutf_utf8_length_from_utf16_with_replacement(const char16_t *input,
                                                 size_t length) {


### PR DESCRIPTION
Short title (summary): Add `simdutf_utf8_length_from_utf32` to C API

Description
- What did you change and why? (1-3 sentences) 
  Added `simdutf_utf8_length_from_utf32` to the C API, it appears to have been missed when the header was introduced
- Issue reproduced / related issue: None

Type of change
- [ ] Bug fix
- [ ] Optimization
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

Checklist before submitting
- [x] I added/updated tests covering my change (if applicable)
  Don't think adding a test is necessary as this is a simple wrapper
- [x] Code builds locally and passes my check
- [x] Documentation / README updated if needed
  Don't think this is needed
- [x] Commits are atomic and messages are clear
- [x] I linked the related issue (if applicable)
       None
