### PR TITLE
New define SIMDUTF_NO_LIBCXX to build with no libc++ or libc++abi

### DIFF
--- a/.github/workflows/no-libcxx.yml
+++ b/.github/workflows/no-libcxx.yml
@@ -1,0 +1,68 @@
+name: no-libcxx ABI contract
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  no-libcxx:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify no-libcxx ABI contract
+        run: ./scripts/check_no_libcxx_abi.sh
+      - name: Verify no-libcxx single-header build with -nostdinc++ and -nostdlib++
+        run: |
+          tmpdir=$(mktemp -d /tmp/simdutf-no-libcxx-amalgam.XXXXXX)
+          python3 singleheader/amalgamate.py \
+            --no-zip \
+            --no-readme \
+            --source-dir=src \
+            --include-dir=include \
+            --output-dir "$tmpdir"
+          c++ -std=c++17 -nostdinc++ \
+            -DSIMDUTF_NO_LIBCXX=1 -fno-exceptions -fno-rtti \
+            -I"$tmpdir" \
+            -c "$tmpdir/simdutf.cpp" \
+            -o "$tmpdir/simdutf-nostdincxx.o"
+          cat > "$tmpdir/amalgam_smoke.cpp" <<'EOF'
+          #include "simdutf.h"
+          #include <string.h>
+
+          int main() {
+            if (simdutf::get_available_implementations().size() < 1) {
+              return 1;
+            }
+            const simdutf::implementation *active_before =
+                simdutf::get_active_implementation();
+            if (active_before == nullptr) {
+              return 2;
+            }
+            if (!simdutf::validate_utf8("abc", 3)) {
+              return 3;
+            }
+            const simdutf::implementation *active_after =
+                simdutf::get_active_implementation();
+            if (active_after == nullptr) {
+              return 4;
+            }
+            if (strlen(active_after->name()) == 0) {
+              return 5;
+            }
+            return 0;
+          }
+          EOF
+          c++ -std=c++17 -nostdinc++ \
+            -DSIMDUTF_NO_LIBCXX=1 -fno-exceptions -fno-rtti \
+            -I"$tmpdir" \
+            -c "$tmpdir/amalgam_smoke.cpp" \
+            -o "$tmpdir/amalgam_smoke.o"
+          c++ -std=c++17 -nostdlib++ \
+            "$tmpdir/amalgam_smoke.o" "$tmpdir/simdutf-nostdincxx.o" \
+            -o "$tmpdir/amalgam_smoke_nostdlibxx"
+          "$tmpdir/amalgam_smoke_nostdlibxx"
+          ldd "$tmpdir/amalgam_smoke_nostdlibxx" > "$tmpdir/amalgam_smoke_nostdlibxx.deps"
+          ! rg -i '(libc\+\+|libc\+\+abi|libstdc\+\+|libsupc\+\+)' \
+            "$tmpdir/amalgam_smoke_nostdlibxx.deps"

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -93,7 +93,6 @@ target_link_libraries(benchmark_to_well_formed_utf16 PUBLIC simdutf::benchmarks:
 set_property(TARGET benchmark_to_well_formed_utf16 PROPERTY CXX_STANDARD 17)
 set_property(TARGET benchmark_to_well_formed_utf16 PROPERTY CXX_STANDARD_REQUIRED ON)
 
-
 add_executable(shortbench shortbench.cpp)
 target_link_libraries(shortbench PUBLIC simdutf::benchmarks::benchmark)
 target_compile_features(shortbench PRIVATE cxx_std_20)

--- a/benchmarks/alignment.cpp
+++ b/benchmarks/alignment.cpp
@@ -119,8 +119,9 @@ void run_from_utf8_output(const std::vector<char> &input_data) {
 }
 
 int main(int argc, char **argv) {
-  printf("# current system detected as %s.\n",
-         simdutf::get_active_implementation()->name().c_str());
+  printf(
+      "# current system detected as %s.\n",
+      simdutf::internal::c_str(simdutf::get_active_implementation()->name()));
   if (argc < 2) {
     std::cerr << "Please provide a file argument." << std::endl;
     return EXIT_FAILURE;
@@ -137,7 +138,7 @@ int main(int argc, char **argv) {
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
   printf("# input detected as %s.\n",
-         simdutf::to_string(detected_encoding).c_str());
+         simdutf::internal::c_str(simdutf::to_string(detected_encoding)));
   if (detected_encoding == simdutf::encoding_type::UTF8) {
     run_from_utf8_output(input_data);
     std::cout << "----" << std::endl;

--- a/benchmarks/base64/benchmark_base64.cpp
+++ b/benchmarks/base64/benchmark_base64.cpp
@@ -170,6 +170,13 @@ void pretty_print(size_t, size_t bytes, std::string name, event_aggregate agg) {
   }
   printf("\n");
 }
+
+static std::string benchmark_name(const char *prefix,
+                                  const simdutf::implementation &impl,
+                                  const char *suffix = "") {
+  return std::string(prefix) + simdutf::internal::c_str(impl.name()) + suffix;
+}
+
 bool can_decode_all(std::vector<std::vector<char>> &data) {
   for (const std::vector<char> &source : data) {
     std::vector<char> buffer(simdutf::maximal_binary_length_from_base64(
@@ -408,7 +415,7 @@ private:
         continue;
       }
       simdutf::get_active_implementation() = e;
-      summarize("simdutf::" + e->name(), [this, &e]() {
+      summarize(benchmark_name("simdutf::", *e), [this, &e]() {
         for (const std::vector<char> &source : data) {
           size_t base64_size =
               e->binary_to_base64(source.data(), source.size(), buffer1.data(),
@@ -455,14 +462,14 @@ private:
         continue;
       }
       simdutf::get_active_implementation() = e;
-      summarize("simdutf::" + e->name() + "_standard", [this, &e,
-                                                        &base64_size]() {
+      summarize(benchmark_name("simdutf::", *e, "_standard"), [this, &e,
+                                                               &base64_size]() {
         for (const std::vector<char> &source : data) {
           base64_size =
               e->binary_to_base64(source.data(), source.size(), buffer1.data());
         }
       });
-      summarize("simdutf::" + e->name() + "_with_lines",
+      summarize(benchmark_name("simdutf::", *e, "_with_lines"),
                 [this, &e, &base64_size]() {
                   for (const std::vector<char> &source : data) {
                     base64_size = e->binary_to_base64_with_lines(
@@ -470,8 +477,8 @@ private:
                   }
                 });
 #if SIMDUTF_COMPILED_CXX_VERSION >= 20
-      summarize("simdutf::atomic_binary_to_base64_" +
-                    (simdutf::get_active_implementation() = e)->name(),
+      summarize(benchmark_name("simdutf::atomic_binary_to_base64_",
+                               *(simdutf::get_active_implementation() = e)),
                 [this, &base64_size]() {
                   for (const std::vector<char> &source : data) {
                     base64_size = simdutf::atomic_binary_to_base64(
@@ -494,7 +501,7 @@ private:
         continue;
       }
       simdutf::get_active_implementation() = e;
-      summarize("simdutf::" + e->name(), [this, &e]() {
+      summarize(benchmark_name("simdutf::", *e), [this, &e]() {
         for (const std::vector<char> &source : data) {
           size_t base64_size =
               e->binary_to_base64(source.data(), source.size(), buffer1.data(),
@@ -580,7 +587,7 @@ private:
       }
       simdutf::get_active_implementation() = e;
 
-      summarize("simdutf::" + e->name(), [this, &e]() {
+      summarize(benchmark_name("simdutf::", *e), [this, &e]() {
         for (const std::vector<char> &source : data) {
           auto err =
               e->base64_to_binary(source.data(), source.size(), buffer1.data());
@@ -598,7 +605,8 @@ private:
         }
       });
 
-      summarize("simdutf::" + e->name() + " (accept garbage)", [this, &e]() {
+      summarize(benchmark_name("simdutf::", *e, " (accept garbage)"), [this,
+                                                                       &e]() {
         for (const std::vector<char> &source : data) {
           auto err =
               e->base64_to_binary(source.data(), source.size(), buffer1.data(),
@@ -618,8 +626,8 @@ private:
       });
 
 #if SIMDUTF_COMPILED_CXX_VERSION >= 20
-      summarize("simdutf::atomic_base64_to_binary_" +
-                    (simdutf::get_active_implementation() = e)->name(),
+      summarize(benchmark_name("simdutf::atomic_base64_to_binary_",
+                               *(simdutf::get_active_implementation() = e)),
                 [this]() {
                   for (const std::vector<char> &source : data) {
                     size_t len = buffer1.size();
@@ -656,15 +664,16 @@ private:
       simdutf::get_active_implementation() = e;
 
       volatile size_t len = 0;
-      summarize("simdutf::" + e->name() + "_maximal_binary_length_from_base64",
-                [this, &e, &len]() {
-                  for (const std::vector<char> &source : data) {
-                    len = e->maximal_binary_length_from_base64(source.data(),
-                                                               source.size());
-                  }
-                });
+      summarize(
+          benchmark_name("simdutf::", *e, "_maximal_binary_length_from_base64"),
+          [this, &e, &len]() {
+            for (const std::vector<char> &source : data) {
+              len = e->maximal_binary_length_from_base64(source.data(),
+                                                         source.size());
+            }
+          });
 
-      summarize("simdutf::" + e->name() + "_binary_length_from_base64",
+      summarize(benchmark_name("simdutf::", *e, "_binary_length_from_base64"),
                 [this, &e, &len]() {
                   for (const std::vector<char> &source : data) {
                     len = e->binary_length_from_base64(source.data(),
@@ -723,7 +732,7 @@ void bench_bun() {
         continue;
       }
       simdutf::get_active_implementation() = e;
-      pretty_print(1, source.size(), "simdutf::" + e->name(),
+      pretty_print(1, source.size(), benchmark_name("simdutf::", *e),
                    bench([&source, &buffer1, &e, &base64_size]() {
                      base64_size = e->binary_to_base64(
                          source.data(), source.size(), buffer1.data());
@@ -838,8 +847,9 @@ int main(int argc, char **argv) {
     return EXIT_SUCCESS;
   }
 
-  printf("# current system detected as %s.\n",
-         simdutf::get_active_implementation()->name().c_str());
+  printf(
+      "# current system detected as %s.\n",
+      simdutf::internal::c_str(simdutf::get_active_implementation()->name()));
 
   std::vector<std::vector<char>> input;
   if (options.benchmark_mode != BenchmarkMode::bun and

--- a/benchmarks/shortbench.cpp
+++ b/benchmarks/shortbench.cpp
@@ -11,7 +11,6 @@
 #include <fstream>
 #include <functional>
 #include <iostream>
-#include <span>
 #include <stdexcept>
 #include <vector>
 
@@ -19,28 +18,34 @@
 
 #include "event_counter.h"
 
+template <typename T> using benchmark_span = simdutf::internal::span<T>;
+
 struct BenchmarkFunc {
   std::string name;
-  std::function<std::function<size_t()>(std::span<const char>, std::span<char>)>
+  std::function<std::function<size_t()>(benchmark_span<const char>,
+                                        benchmark_span<char>)>
       maker;
 };
 
 // Benchmarked functions.
 std::vector<BenchmarkFunc> available_functions = {
     {"validate_ascii",
-     [](std::span<const char> input, [[maybe_unused]] std::span<char> output) {
+     [](benchmark_span<const char> input,
+        [[maybe_unused]] benchmark_span<char> output) {
        return [input]() -> size_t {
          return simdutf::validate_ascii(input.data(), input.size());
        };
      }},
     {"validate_utf8",
-     [](std::span<const char> input, [[maybe_unused]] std::span<char> output) {
+     [](benchmark_span<const char> input,
+        [[maybe_unused]] benchmark_span<char> output) {
        return [input]() -> size_t {
          return simdutf::validate_utf8(input.data(), input.size());
        };
      }},
     {"utf8_length_from_latin1",
-     [](std::span<const char> input, [[maybe_unused]] std::span<char> output) {
+     [](benchmark_span<const char> input,
+        [[maybe_unused]] benchmark_span<char> output) {
        return [input]() -> size_t {
          size_t len =
              simdutf::utf8_length_from_latin1(input.data(), input.size());
@@ -48,7 +53,8 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"utf16_length_from_utf8",
-     [](std::span<const char> input, [[maybe_unused]] std::span<char> output) {
+     [](benchmark_span<const char> input,
+        [[maybe_unused]] benchmark_span<char> output) {
        return [input]() -> size_t {
          size_t len =
              simdutf::utf16_length_from_utf8(input.data(), input.size());
@@ -56,7 +62,8 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"utf32_length_from_utf8",
-     [](std::span<const char> input, [[maybe_unused]] std::span<char> output) {
+     [](benchmark_span<const char> input,
+        [[maybe_unused]] benchmark_span<char> output) {
        return [input]() -> size_t {
          size_t len =
              simdutf::utf32_length_from_utf8(input.data(), input.size());
@@ -64,14 +71,16 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"count_utf8",
-     [](std::span<const char> input, [[maybe_unused]] std::span<char> output) {
+     [](benchmark_span<const char> input,
+        [[maybe_unused]] benchmark_span<char> output) {
        return [input]() -> size_t {
          size_t count = simdutf::count_utf8(input.data(), input.size());
          return count;
        };
      }},
     {"count_utf16",
-     [](std::span<const char> input, [[maybe_unused]] std::span<char> output) {
+     [](benchmark_span<const char> input,
+        [[maybe_unused]] benchmark_span<char> output) {
        return [input]() -> size_t {
          size_t count = simdutf::count_utf16(
              reinterpret_cast<const char16_t *>(input.data()),
@@ -80,7 +89,8 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"utf8_length_from_utf16",
-     [](std::span<const char> input, [[maybe_unused]] std::span<char> output) {
+     [](benchmark_span<const char> input,
+        [[maybe_unused]] benchmark_span<char> output) {
        return [input]() -> size_t {
          size_t len = simdutf::utf8_length_from_utf16(
              reinterpret_cast<const char16_t *>(input.data()),
@@ -89,7 +99,8 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"utf16_length_from_utf32",
-     [](std::span<const char> input, [[maybe_unused]] std::span<char> output) {
+     [](benchmark_span<const char> input,
+        [[maybe_unused]] benchmark_span<char> output) {
        return [input]() -> size_t {
          size_t len = simdutf::utf16_length_from_utf32(
              reinterpret_cast<const char32_t *>(input.data()),
@@ -98,7 +109,8 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"utf32_length_from_utf16",
-     [](std::span<const char> input, [[maybe_unused]] std::span<char> output) {
+     [](benchmark_span<const char> input,
+        [[maybe_unused]] benchmark_span<char> output) {
        return [input]() -> size_t {
          size_t len = simdutf::utf32_length_from_utf16(
              reinterpret_cast<const char16_t *>(input.data()),
@@ -107,7 +119,8 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"utf8_length_from_utf32",
-     [](std::span<const char> input, [[maybe_unused]] std::span<char> output) {
+     [](benchmark_span<const char> input,
+        [[maybe_unused]] benchmark_span<char> output) {
        return [input]() -> size_t {
          size_t len = simdutf::utf8_length_from_utf32(
              reinterpret_cast<const char32_t *>(input.data()),
@@ -116,7 +129,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_latin1_to_utf8",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_latin1_to_utf8(
              input.data(), input.size(), output.data());
@@ -124,7 +137,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_latin1_to_utf16le",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_latin1_to_utf16le(
              input.data(), input.size(),
@@ -133,7 +146,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_latin1_to_utf16be",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_latin1_to_utf16be(
              input.data(), input.size(),
@@ -142,7 +155,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_latin1_to_utf32",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_latin1_to_utf32(
              input.data(), input.size(),
@@ -151,7 +164,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_utf8_to_latin1",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_utf8_to_latin1(
              input.data(), input.size(), output.data());
@@ -159,7 +172,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_utf8_to_utf16le",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_utf8_to_utf16le(
              input.data(), input.size(),
@@ -168,7 +181,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_utf8_to_utf16be",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_utf8_to_utf16be(
              input.data(), input.size(),
@@ -177,7 +190,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_utf8_to_utf32",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_utf8_to_utf32(
              input.data(), input.size(),
@@ -186,7 +199,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_utf16le_to_latin1",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_utf16le_to_latin1(
              reinterpret_cast<const char16_t *>(input.data()), input.size() / 2,
@@ -195,7 +208,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_utf16le_to_utf8",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_utf16le_to_utf8(
              reinterpret_cast<const char16_t *>(input.data()), input.size() / 2,
@@ -204,7 +217,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_utf16le_to_utf32",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_utf16le_to_utf32(
              reinterpret_cast<const char16_t *>(input.data()), input.size() / 2,
@@ -213,7 +226,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_utf16be_to_latin1",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_utf16be_to_latin1(
              reinterpret_cast<const char16_t *>(input.data()), input.size() / 2,
@@ -222,7 +235,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_utf16be_to_utf8",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_utf16be_to_utf8(
              reinterpret_cast<const char16_t *>(input.data()), input.size() / 2,
@@ -231,7 +244,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_utf16be_to_utf32",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_utf16be_to_utf32(
              reinterpret_cast<const char16_t *>(input.data()), input.size() / 2,
@@ -240,7 +253,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_utf32_to_latin1",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_utf32_to_latin1(
              reinterpret_cast<const char32_t *>(input.data()), input.size() / 4,
@@ -249,7 +262,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_utf32_to_utf8",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_utf32_to_utf8(
              reinterpret_cast<const char32_t *>(input.data()), input.size() / 4,
@@ -258,7 +271,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_utf32_to_utf16le",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_utf32_to_utf16le(
              reinterpret_cast<const char32_t *>(input.data()), input.size() / 4,
@@ -267,7 +280,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"convert_utf32_to_utf16be",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::convert_utf32_to_utf16be(
              reinterpret_cast<const char32_t *>(input.data()), input.size() / 4,
@@ -276,7 +289,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"binary_to_base64",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          size_t len = simdutf::binary_to_base64(input.data(), input.size(),
                                                 output.data());
@@ -284,7 +297,7 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"base64_to_binary",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
          auto result = simdutf::base64_to_binary(input.data(), input.size(),
                                                  output.data());
@@ -292,14 +305,20 @@ std::vector<BenchmarkFunc> available_functions = {
        };
      }},
     {"base64_to_binary_safe",
-     [](std::span<const char> input, std::span<char> output) {
+     [](benchmark_span<const char> input, benchmark_span<char> output) {
        return [input, output]() -> size_t {
-         auto result = simdutf::base64_to_binary_safe(input, output);
-         return std::get<1>(result);
+         size_t outlen = output.size();
+         auto result = simdutf::base64_to_binary_safe(
+             input.data(), input.size(), output.data(), outlen);
+         if (result.error != simdutf::error_code::SUCCESS) {
+           return 0;
+         }
+         return outlen;
        };
      }},
     {"find_equal",
-     [](std::span<const char> input, [[maybe_unused]] std::span<char> output) {
+     [](benchmark_span<const char> input,
+        [[maybe_unused]] benchmark_span<char> output) {
        return [input]() -> size_t {
          auto it =
              simdutf::find(input.data(), input.data() + input.size(), '=');
@@ -511,15 +530,16 @@ int main(int argc, char *argv[]) {
         printf("# Input size: %zu bytes\n", file_size);
         printf("# Max benchmark size: %zu bytes\n", actual_max);
         printf("# Current system: %s\n",
-               simdutf::get_active_implementation()->name().c_str());
+               simdutf::internal::c_str(
+                   simdutf::get_active_implementation()->name()));
         printf("\n");
 
         print_table_header(has_events);
 
         for (size_t size = 1; size <= actual_max; size += step) {
           auto benchmark_lambda =
-              func.maker(std::span<const char>(data.data(), size),
-                         std::span<char>(output.data(), output.size()));
+              func.maker(benchmark_span<const char>(data.data(), size),
+                         benchmark_span<char>(output.data(), output.size()));
           time_stats stats = bench(benchmark_lambda);
 
           print_table_row(size, stats, has_events);
@@ -532,15 +552,16 @@ int main(int argc, char *argv[]) {
       printf("# Input size: %zu bytes\n", file_size);
       printf("# Max benchmark size: %zu bytes\n", actual_max);
       printf("# Current system: %s\n",
-             simdutf::get_active_implementation()->name().c_str());
+             simdutf::internal::c_str(
+                 simdutf::get_active_implementation()->name()));
       printf("\n");
 
       print_table_header(has_events);
 
       for (size_t size = 1; size <= actual_max; size += step) {
-        auto benchmark_lambda =
-            selected_func->maker(std::span<const char>(data.data(), size),
-                                 std::span<char>(output.data(), output.size()));
+        auto benchmark_lambda = selected_func->maker(
+            benchmark_span<const char>(data.data(), size),
+            benchmark_span<char>(output.data(), output.size()));
         time_stats stats = bench(benchmark_lambda);
 
         print_table_row(size, stats, has_events);

--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -572,7 +572,8 @@ void Benchmark::run(const std::string &procedure_name, size_t iterations) {
     const std::string name{procedure_name.substr(0, p)};
     const std::string impl{procedure_name.substr(p + 1)};
 
-    auto implementation = simdutf::get_available_implementations()[impl];
+    auto implementation =
+        simdutf::get_available_implementations()[impl.c_str()];
     if (implementation == nullptr) {
       throw std::runtime_error("Wrong implementation " + impl);
     }

--- a/benchmarks/src/benchmark_base.cpp
+++ b/benchmarks/src/benchmark_base.cpp
@@ -23,7 +23,7 @@ void BenchmarkBase::run(const input::Testcase &testcase) {
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
   printf("input detected as %s\n",
-         simdutf::to_string(detected_encoding).c_str());
+         simdutf::internal::c_str(simdutf::to_string(detected_encoding)));
   printf("===========================\n");
 
   const auto &known_procedures = all_procedures();

--- a/benchmarks/stream.cpp
+++ b/benchmarks/stream.cpp
@@ -178,8 +178,9 @@ void run_from_utf16(const std::vector<char> &input_data,
 }
 
 int main(int argc, char **argv) {
-  printf("# current system detected as %s.\n",
-         simdutf::get_active_implementation()->name().c_str());
+  printf(
+      "# current system detected as %s.\n",
+      simdutf::internal::c_str(simdutf::get_active_implementation()->name()));
   if (argc < 2) {
     std::cerr << "Please provide a file argument." << std::endl;
     std::cerr << "The file should contain either UTF-8 or UTF-16 text."
@@ -199,7 +200,7 @@ int main(int argc, char **argv) {
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
   printf("# input detected as %s.\n",
-         simdutf::to_string(detected_encoding).c_str());
+         simdutf::internal::c_str(simdutf::to_string(detected_encoding)));
   if (detected_encoding == simdutf::encoding_type::UTF16_LE) {
     run_from_utf16(input_data);
   } else if (detected_encoding == simdutf::encoding_type::UTF8) {

--- a/benchmarks/threaded.cpp
+++ b/benchmarks/threaded.cpp
@@ -94,8 +94,9 @@ void run_from_utf8(const std::vector<char> &input_data) {
 }
 
 int main(int argc, char **argv) {
-  printf("# current system detected as %s.\n",
-         simdutf::get_active_implementation()->name().c_str());
+  printf(
+      "# current system detected as %s.\n",
+      simdutf::internal::c_str(simdutf::get_active_implementation()->name()));
   if (argc < 2) {
     std::cerr << "Please provide a file argument." << std::endl;
     return EXIT_FAILURE;
@@ -112,7 +113,7 @@ int main(int argc, char **argv) {
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
   printf("# input detected as %s.\n",
-         simdutf::to_string(detected_encoding).c_str());
+         simdutf::internal::c_str(simdutf::to_string(detected_encoding)));
   if (detected_encoding == simdutf::encoding_type::UTF8) {
 
     run_from_utf8(input_data);

--- a/include/simdutf.h
+++ b/include/simdutf.h
@@ -1,6 +1,5 @@
 #ifndef SIMDUTF_H
 #define SIMDUTF_H
-#include <cstring>
 
 #include "simdutf/compiler_check.h"
 #include "simdutf/common_defs.h"

--- a/include/simdutf/base64_implementation.h
+++ b/include/simdutf/base64_implementation.h
@@ -59,8 +59,8 @@ simdutf_warn_unused simdutf_constexpr23 result base64_to_binary_safe_impl(
     base64_options options,
     last_chunk_handling_options last_chunk_handling_options,
     bool decode_up_to_bad_char) noexcept {
-  static_assert(std::is_same<chartype, char>::value ||
-                    std::is_same<chartype, char16_t>::value,
+  static_assert(internal::is_same<chartype, char>::value ||
+                    internal::is_same<chartype, char16_t>::value,
                 "Only char and char16_t are supported.");
   size_t remaining_input_length = length;
   size_t remaining_output_length = outlen;
@@ -68,7 +68,7 @@ simdutf_warn_unused simdutf_constexpr23 result base64_to_binary_safe_impl(
   size_t output_position = 0;
 
   // We also do a first pass using the fast path to decode as much as possible
-  size_t safe_input = (std::min)(
+  size_t safe_input = internal::min_value(
       remaining_input_length,
       base64_length_from_binary(remaining_output_length / 3 * 3, options));
   bool done_with_partial = (safe_input == remaining_input_length);

--- a/include/simdutf/base64_tables.h
+++ b/include/simdutf/base64_tables.h
@@ -1,6 +1,10 @@
 #ifndef SIMDUTF_BASE64_TABLES_H
 #define SIMDUTF_BASE64_TABLES_H
-#include <cstdint>
+#ifdef SIMDUTF_NO_LIBCXX
+  #include <stdint.h>
+#else
+  #include <cstdint>
+#endif
 
 namespace simdutf {
 namespace {

--- a/include/simdutf/common_defs.h
+++ b/include/simdutf/common_defs.h
@@ -7,18 +7,36 @@
 // Sometimes logging is useful, but we want it disabled by default
 // and free of any logging code in release builds.
 #ifdef SIMDUTF_LOGGING
-  #include <iostream>
-  #define simdutf_log(msg)                                                     \
-    std::cout << "[" << __FUNCTION__ << "]: " << msg << std::endl              \
-              << "\t" << __FILE__ << ":" << __LINE__ << std::endl;
-  #define simdutf_log_assert(cond, msg)                                        \
-    do {                                                                       \
-      if (!(cond)) {                                                           \
-        std::cerr << "[" << __FUNCTION__ << "]: " << msg << std::endl          \
-                  << "\t" << __FILE__ << ":" << __LINE__ << std::endl;         \
-        std::abort();                                                          \
-      }                                                                        \
-    } while (0)
+  #ifdef SIMDUTF_NO_LIBCXX
+    #include <stdio.h>
+    #define simdutf_log(msg)                                                   \
+      do {                                                                     \
+        printf("[%s]: %s\n\t%s:%d\n", __FUNCTION__, msg, __FILE__, __LINE__);  \
+        fflush(stdout);                                                        \
+      } while (0)
+    #define simdutf_log_assert(cond, msg)                                      \
+      do {                                                                     \
+        if (!(cond)) {                                                         \
+          fprintf(stderr, "[%s]: %s\n\t%s:%d\n", __FUNCTION__, msg, __FILE__,  \
+                  __LINE__);                                                   \
+          fflush(stderr);                                                      \
+          abort();                                                             \
+        }                                                                      \
+      } while (0)
+  #else
+    #include <iostream>
+    #define simdutf_log(msg)                                                   \
+      std::cout << "[" << __FUNCTION__ << "]: " << msg << std::endl            \
+                << "\t" << __FILE__ << ":" << __LINE__ << std::endl;
+    #define simdutf_log_assert(cond, msg)                                      \
+      do {                                                                     \
+        if (!(cond)) {                                                         \
+          std::cerr << "[" << __FUNCTION__ << "]: " << msg << std::endl        \
+                    << "\t" << __FILE__ << ":" << __LINE__ << std::endl;       \
+          std::abort();                                                        \
+        }                                                                      \
+      } while (0)
+  #endif
 #else
   #define simdutf_log(msg)
   #define simdutf_log_assert(cond, msg)

--- a/include/simdutf/encoding_types.h
+++ b/include/simdutf/encoding_types.h
@@ -1,13 +1,15 @@
 #ifndef SIMDUTF_ENCODING_TYPES_H
 #define SIMDUTF_ENCODING_TYPES_H
-#include <string>
 #include "simdutf/portability.h"
 #include "simdutf/common_defs.h"
 
-#if !defined(SIMDUTF_NO_STD_TEXT_ENCODING) &&                                  \
-    defined(__cpp_lib_text_encoding) && __cpp_lib_text_encoding >= 202306L
-  #define SIMDUTF_HAS_STD_TEXT_ENCODING 1
-  #include <text_encoding>
+#ifndef SIMDUTF_NO_LIBCXX
+  #include <string>
+  #if !defined(SIMDUTF_NO_STD_TEXT_ENCODING) &&                                \
+      defined(__cpp_lib_text_encoding) && __cpp_lib_text_encoding >= 202306L
+    #define SIMDUTF_HAS_STD_TEXT_ENCODING 1
+    #include <text_encoding>
+  #endif
 #endif
 
 namespace simdutf {
@@ -43,7 +45,11 @@ match_system(endianness e) {
   return e == endianness::NATIVE;
 }
 
+#ifdef SIMDUTF_NO_LIBCXX
+simdutf_warn_unused const char *to_string(encoding_type bom);
+#else
 simdutf_warn_unused std::string to_string(encoding_type bom);
+#endif
 
 // Note that BOM for UTF8 is discouraged.
 namespace BOM {
@@ -67,7 +73,7 @@ simdutf_warn_unused size_t bom_byte_size(encoding_type bom);
 
 } // namespace BOM
 
-#ifdef SIMDUTF_HAS_STD_TEXT_ENCODING
+#if defined(SIMDUTF_HAS_STD_TEXT_ENCODING) && !defined(SIMDUTF_NO_LIBCXX)
 /**
  * Convert a simdutf encoding type to a std::text_encoding.
  *
@@ -183,7 +189,7 @@ from_std_encoding_native(const std::text_encoding &enc) noexcept {
     return unspecified;
   }
 }
-#endif // SIMDUTF_HAS_STD_TEXT_ENCODING
+#endif // defined(SIMDUTF_HAS_STD_TEXT_ENCODING) && !defined(SIMDUTF_NO_LIBCXX)
 
 } // namespace simdutf
 #endif

--- a/include/simdutf/error.h
+++ b/include/simdutf/error.h
@@ -41,7 +41,8 @@ enum error_code {
   OUTPUT_BUFFER_TOO_SMALL,  // The provided buffer is too small.
   OTHER                     // Not related to validation/transcoding.
 };
-#if SIMDUTF_CPLUSPLUS17
+
+#if SIMDUTF_CPLUSPLUS17 && !defined(SIMDUTF_NO_LIBCXX)
 inline std::string_view error_to_string(error_code code) noexcept {
   switch (code) {
   case SUCCESS:

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -1,25 +1,38 @@
 #ifndef SIMDUTF_IMPLEMENTATION_H
 #define SIMDUTF_IMPLEMENTATION_H
+#include "simdutf/common_defs.h"
+#include "simdutf/compiler_check.h"
+
+#if defined(SIMDUTF_INTERNAL_TESTS) && defined(SIMDUTF_NO_LIBCXX)
+  #error "SIMDUTF_INTERNAL_TESTS is unsupported with SIMDUTF_NO_LIBCXX"
+#endif
+
+#include <string.h>
+
 #if !defined(SIMDUTF_NO_THREADS)
   #include <atomic>
 #endif
-#include <string>
+#ifndef SIMDUTF_NO_LIBCXX
+  #include <string>
+#endif
 #ifdef SIMDUTF_INTERNAL_TESTS
   #include <vector>
 #endif
-#include "simdutf/common_defs.h"
-#include "simdutf/compiler_check.h"
 #include "simdutf/encoding_types.h"
 #include "simdutf/error.h"
+#include "simdutf/internal/stl_compat.h"
 #include "simdutf/internal/isadetection.h"
 
-#if SIMDUTF_SPAN
+#if SIMDUTF_CPLUSPLUS20
   #include <concepts>
   #include <type_traits>
+#endif
+
+#if SIMDUTF_SPAN
   #include <span>
   #include <tuple>
 #endif
-#if SIMDUTF_CPLUSPLUS17
+#if SIMDUTF_CPLUSPLUS17 && !defined(SIMDUTF_NO_LIBCXX)
   #include <string_view>
 #endif
 // The following defines are conditionally enabled/disabled during amalgamation.
@@ -53,11 +66,11 @@
   #define SIMDUTF_FEATURE_BASE64 1
 #endif
 
-#if SIMDUTF_CPLUSPLUS23
+#if SIMDUTF_SPAN && SIMDUTF_CPLUSPLUS23
   #include <simdutf/constexpr_ptr.h>
 #endif
 
-#if SIMDUTF_SPAN
+#if SIMDUTF_CPLUSPLUS20
 /// helpers placed in namespace detail are not a part of the public API
 namespace simdutf {
 namespace detail {
@@ -66,11 +79,14 @@ namespace detail {
  * are all distinct types.
  */
 template <typename T>
-concept byte_like = std::is_same_v<T, std::byte> ||     //
-                    std::is_same_v<T, char> ||          //
-                    std::is_same_v<T, signed char> ||   //
-                    std::is_same_v<T, unsigned char> || //
-                    std::is_same_v<T, char8_t>;
+concept byte_like =
+  #ifndef SIMDUTF_NO_LIBCXX
+    std::is_same_v<T, std::byte> || //
+  #endif
+    std::is_same_v<T, char> ||          //
+    std::is_same_v<T, signed char> ||   //
+    std::is_same_v<T, unsigned char> || //
+    std::is_same_v<T, char8_t>;
 
 template <typename T>
 concept is_byte_like = byte_like<std::remove_cvref_t<T>>;
@@ -85,7 +101,7 @@ concept is_pointer = std::is_pointer_v<T>;
  */
 template <typename T>
 concept input_span_of_byte_like = requires(const T &t) {
-  { t.size() } noexcept -> std::convertible_to<std::size_t>;
+  { t.size() } noexcept -> std::convertible_to<size_t>;
   { t.data() } noexcept -> is_pointer;
   { *t.data() } noexcept -> is_byte_like;
 };
@@ -98,7 +114,7 @@ concept is_mutable = !std::is_const_v<std::remove_reference_t<T>>;
  */
 template <typename T>
 concept output_span_of_byte_like = requires(T &t) {
-  { t.size() } noexcept -> std::convertible_to<std::size_t>;
+  { t.size() } noexcept -> std::convertible_to<size_t>;
   { t.data() } noexcept -> is_pointer;
   { *t.data() } noexcept -> is_byte_like;
   { *t.data() } noexcept -> is_mutable;
@@ -137,38 +153,42 @@ concept indexes_into_uint32 = requires(InputPtr p) {
 };
 } // namespace detail
 } // namespace simdutf
-#endif // SIMDUTF_SPAN
+#endif // SIMDUTF_CPLUSPLUS20
 
-// these includes are needed for constexpr support. they are
-// not part of the public api.
-#include <simdutf/scalar/swap_bytes.h>
-#include <simdutf/scalar/ascii.h>
-#include <simdutf/scalar/atomic_util.h>
-#include <simdutf/scalar/latin1.h>
-#include <simdutf/scalar/latin1_to_utf16/latin1_to_utf16.h>
-#include <simdutf/scalar/latin1_to_utf32/latin1_to_utf32.h>
-#include <simdutf/scalar/latin1_to_utf8/latin1_to_utf8.h>
-#include <simdutf/scalar/utf16.h>
-#include <simdutf/scalar/utf16_to_latin1/utf16_to_latin1.h>
-#include <simdutf/scalar/utf16_to_latin1/valid_utf16_to_latin1.h>
-#include <simdutf/scalar/utf16_to_utf32/utf16_to_utf32.h>
-#include <simdutf/scalar/utf16_to_utf32/valid_utf16_to_utf32.h>
-#include <simdutf/scalar/utf16_to_utf8/utf16_to_utf8.h>
-#include <simdutf/scalar/utf16_to_utf8/valid_utf16_to_utf8.h>
-#include <simdutf/scalar/utf32.h>
-#include <simdutf/scalar/utf32_to_latin1/utf32_to_latin1.h>
-#include <simdutf/scalar/utf32_to_latin1/valid_utf32_to_latin1.h>
-#include <simdutf/scalar/utf32_to_utf16/utf32_to_utf16.h>
-#include <simdutf/scalar/utf32_to_utf16/valid_utf32_to_utf16.h>
-#include <simdutf/scalar/utf32_to_utf8/utf32_to_utf8.h>
-#include <simdutf/scalar/utf32_to_utf8/valid_utf32_to_utf8.h>
-#include <simdutf/scalar/utf8.h>
-#include <simdutf/scalar/utf8_to_latin1/utf8_to_latin1.h>
-#include <simdutf/scalar/utf8_to_latin1/valid_utf8_to_latin1.h>
-#include <simdutf/scalar/utf8_to_utf16/utf8_to_utf16.h>
-#include <simdutf/scalar/utf8_to_utf16/valid_utf8_to_utf16.h>
-#include <simdutf/scalar/utf8_to_utf32/utf8_to_utf32.h>
-#include <simdutf/scalar/utf8_to_utf32/valid_utf8_to_utf32.h>
+#if SIMDUTF_SPAN || defined(SIMDUTF_NO_LIBCXX)
+  // These helpers back the span-based constexpr wrappers in the public header
+  // and the reduced no-libcxx amalgamated implementation path.
+  #include <simdutf/scalar/swap_bytes.h>
+  #include <simdutf/scalar/ascii.h>
+  #if SIMDUTF_ATOMIC_REF
+    #include <simdutf/scalar/atomic_util.h>
+  #endif
+  #include <simdutf/scalar/latin1.h>
+  #include <simdutf/scalar/latin1_to_utf16/latin1_to_utf16.h>
+  #include <simdutf/scalar/latin1_to_utf32/latin1_to_utf32.h>
+  #include <simdutf/scalar/latin1_to_utf8/latin1_to_utf8.h>
+  #include <simdutf/scalar/utf16.h>
+  #include <simdutf/scalar/utf16_to_latin1/utf16_to_latin1.h>
+  #include <simdutf/scalar/utf16_to_latin1/valid_utf16_to_latin1.h>
+  #include <simdutf/scalar/utf16_to_utf32/utf16_to_utf32.h>
+  #include <simdutf/scalar/utf16_to_utf32/valid_utf16_to_utf32.h>
+  #include <simdutf/scalar/utf16_to_utf8/utf16_to_utf8.h>
+  #include <simdutf/scalar/utf16_to_utf8/valid_utf16_to_utf8.h>
+  #include <simdutf/scalar/utf32.h>
+  #include <simdutf/scalar/utf32_to_latin1/utf32_to_latin1.h>
+  #include <simdutf/scalar/utf32_to_latin1/valid_utf32_to_latin1.h>
+  #include <simdutf/scalar/utf32_to_utf16/utf32_to_utf16.h>
+  #include <simdutf/scalar/utf32_to_utf16/valid_utf32_to_utf16.h>
+  #include <simdutf/scalar/utf32_to_utf8/utf32_to_utf8.h>
+  #include <simdutf/scalar/utf32_to_utf8/valid_utf32_to_utf8.h>
+  #include <simdutf/scalar/utf8.h>
+  #include <simdutf/scalar/utf8_to_latin1/utf8_to_latin1.h>
+  #include <simdutf/scalar/utf8_to_latin1/valid_utf8_to_latin1.h>
+  #include <simdutf/scalar/utf8_to_utf16/utf8_to_utf16.h>
+  #include <simdutf/scalar/utf8_to_utf16/valid_utf8_to_utf16.h>
+  #include <simdutf/scalar/utf8_to_utf32/utf8_to_utf32.h>
+  #include <simdutf/scalar/utf8_to_utf32/valid_utf8_to_utf32.h>
+#endif
 
 namespace simdutf {
 
@@ -4179,8 +4199,12 @@ find(const char16_t *start, const char16_t *end, char16_t character) noexcept {
 
 namespace simdutf {
 
-  #if SIMDUTF_CPLUSPLUS17
-inline std::string_view to_string(base64_options options) {
+  #if SIMDUTF_CPLUSPLUS17 || defined(SIMDUTF_NO_LIBCXX)
+    #ifdef SIMDUTF_NO_LIBCXX
+inline const char *to_string(base64_options options) noexcept {
+    #else
+inline std::string_view to_string(base64_options options) noexcept {
+    #endif
   switch (options) {
   case base64_default:
     return "base64_default";
@@ -4201,10 +4225,15 @@ inline std::string_view to_string(base64_options options) {
   }
   return "<unknown>";
 }
-  #endif // SIMDUTF_CPLUSPLUS17
+  #endif // SIMDUTF_CPLUSPLUS17 || defined(SIMDUTF_NO_LIBCXX)
 
-  #if SIMDUTF_CPLUSPLUS17
-inline std::string_view to_string(last_chunk_handling_options options) {
+  #if SIMDUTF_CPLUSPLUS17 || defined(SIMDUTF_NO_LIBCXX)
+    #ifdef SIMDUTF_NO_LIBCXX
+inline const char *to_string(last_chunk_handling_options options) noexcept {
+    #else
+inline std::string_view
+to_string(last_chunk_handling_options options) noexcept {
+    #endif
   switch (options) {
   case loose:
     return "loose";
@@ -4217,7 +4246,7 @@ inline std::string_view to_string(last_chunk_handling_options options) {
   }
   return "<unknown>";
 }
-  #endif
+  #endif // SIMDUTF_CPLUSPLUS17 || defined(SIMDUTF_NO_LIBCXX)
 
 /**
  * Provide the maximal binary length in bytes given the base64 input.
@@ -5093,7 +5122,11 @@ public:
    *
    * @return the name of the implementation, e.g. "haswell", "westmere", "arm64"
    */
+#ifdef SIMDUTF_NO_LIBCXX
+  virtual const char *name() const { return _name; }
+#else
   virtual std::string name() const { return std::string(_name); }
+#endif
 
   /**
    * The description of this implementation.
@@ -5104,7 +5137,11 @@ public:
    *
    * @return the name of the implementation, e.g. "haswell", "westmere", "arm64"
    */
+#ifdef SIMDUTF_NO_LIBCXX
+  virtual const char *description() const { return _description; }
+#else
   virtual std::string description() const { return std::string(_description); }
+#endif
 
   /**
    * The instruction sets this implementation is compiled against
@@ -7004,7 +7041,8 @@ public:
   // framework.
   //
   // Regular users should not use it, the tests of the public
-  // API are enough.
+  // API are enough. This developer-only surface intentionally remains
+  // unavailable in Phase 1 SIMDUTF_NO_LIBCXX builds.
 
   struct TestProcedure {
     // display name
@@ -7076,6 +7114,23 @@ public:
    * @param name the implementation to find, e.g. "westmere", "haswell", "arm64"
    * @return the implementation, or nullptr if the parse failed.
    */
+  const implementation *operator[](const char *name) const noexcept {
+    if (name == nullptr) {
+      return nullptr;
+    }
+    for (const implementation *impl : *this) {
+#ifdef SIMDUTF_NO_LIBCXX
+      if (strcmp(impl->name(), name) == 0) {
+#else
+      if (impl->name() == name) {
+#endif
+        return impl;
+      }
+    }
+    return nullptr;
+  }
+
+#ifndef SIMDUTF_NO_LIBCXX
   const implementation *operator[](const std::string &name) const noexcept {
     for (const implementation *impl : *this) {
       if (impl->name() == name) {
@@ -7084,6 +7139,7 @@ public:
     }
     return nullptr;
   }
+#endif
 
   /**
    * Detect the most advanced implementation supported by the current host.
@@ -7253,7 +7309,7 @@ namespace detail {
 // the detail namespace is not part of the public api
 
 template <std::size_t N> struct base64_literal_helper {
-  std::array<char, N - 1> storage{};
+  simdutf::internal::array<char, N - 1> storage{};
   static constexpr std::size_t size() noexcept { return N - 1; }
   consteval base64_literal_helper(const char (&str)[N]) {
     for (std::size_t i = 0; i < size(); i++) {
@@ -7264,7 +7320,7 @@ template <std::size_t N> struct base64_literal_helper {
 
 template <std::size_t InputLen> struct base64_decode_result {
   static constexpr std::size_t max_out = (InputLen + 3) / 4 * 3;
-  std::array<char, max_out> buffer{};
+  simdutf::internal::array<char, max_out> buffer{};
   std::size_t output_count{};
 };
 
@@ -7282,7 +7338,7 @@ consteval auto base64_decode_literal(const char *str) {
 
 template <base64_literal_helper a> consteval auto base64_make_array() {
   constexpr auto decoded = base64_decode_literal<a.size()>(a.storage.data());
-  std::array<char, decoded.output_count> ret{};
+  simdutf::internal::array<char, decoded.output_count> ret{};
   for (std::size_t i = 0; i < decoded.output_count; i++) {
     ret[i] = decoded.buffer[i];
   }
@@ -7297,7 +7353,7 @@ template <base64_literal_helper a> consteval auto base64_make_array() {
  * Usage:
  *   using namespace simdutf::literals;
  *   constexpr auto decoded = "SGVsbG8gV29ybGQh"_base64;
- *   // decoded is a std::array<char, 12> containing "Hello World!"
+ *   // decoded is an array-like object containing "Hello World!"
  *
  * The input must be valid base64. Whitepace is allowed and ignored.
  * A compilation error occurs if the input is invalid.
@@ -7310,5 +7366,4 @@ template <detail::base64_literal_helper a> consteval auto operator""_base64() {
 } // namespace simdutf
 
 #endif // SIMDUTF_CPLUSPLUS23 && SIMDUTF_FEATURE_BASE64
-
 #endif // SIMDUTF_IMPLEMENTATION_H

--- a/include/simdutf/internal/isadetection.h
+++ b/include/simdutf/internal/isadetection.h
@@ -46,8 +46,13 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef SIMDutf_INTERNAL_ISADETECTION_H
 #define SIMDutf_INTERNAL_ISADETECTION_H
 
-#include <cstdint>
-#include <cstdlib>
+#ifdef SIMDUTF_NO_LIBCXX
+  #include <stdint.h>
+  #include <stdlib.h>
+#else
+  #include <cstdint>
+  #include <cstdlib>
+#endif
 #if defined(_MSC_VER)
   #include <intrin.h>
 #elif defined(HAVE_GCC_GET_CPUID) && defined(USE_GCC_GET_CPUID)

--- a/include/simdutf/internal/stl_compat.h
+++ b/include/simdutf/internal/stl_compat.h
@@ -1,0 +1,428 @@
+#ifndef SIMDUTF_INTERNAL_STL_COMPAT_H
+#define SIMDUTF_INTERNAL_STL_COMPAT_H
+
+#include "simdutf/common_defs.h"
+
+#ifndef SIMDUTF_NO_LIBCXX
+  #include <algorithm>
+  #include <array>
+  #include <cstddef>
+  #include <cstring>
+  #include <iterator>
+  #if SIMDUTF_CPLUSPLUS20
+    #include <span>
+  #endif
+  #include <string>
+  #include <tuple>
+  #include <type_traits>
+  #include <utility>
+#else
+  #include <stddef.h>
+  #include <string.h>
+#endif
+
+namespace simdutf {
+namespace internal {
+
+//--------------------------------------------------------------------
+// Pair
+//--------------------------------------------------------------------
+#ifndef SIMDUTF_NO_LIBCXX
+template <typename First, typename Second>
+using pair = std::pair<First, Second>;
+
+using std::make_pair;
+
+template <size_t Index, typename First, typename Second>
+using pair_get_impl = std::tuple_element<Index, pair<First, Second>>;
+#else
+template <typename First, typename Second> struct pair {
+  First first;
+  Second second;
+};
+
+template <size_t Index, typename First, typename Second> struct pair_get_impl {
+  static_assert(Index < 2, "pair index out of bounds");
+  using type = First;
+};
+
+template <typename First, typename Second>
+struct pair_get_impl<0, First, Second> {
+  using type = First;
+
+  simdutf_really_inline static constexpr type &
+  get(pair<First, Second> &value) noexcept {
+    return value.first;
+  }
+
+  simdutf_really_inline static constexpr const type &
+  get(const pair<First, Second> &value) noexcept {
+    return value.first;
+  }
+};
+
+template <typename First, typename Second>
+struct pair_get_impl<1, First, Second> {
+  using type = Second;
+
+  simdutf_really_inline static constexpr type &
+  get(pair<First, Second> &value) noexcept {
+    return value.second;
+  }
+
+  simdutf_really_inline static constexpr const type &
+  get(const pair<First, Second> &value) noexcept {
+    return value.second;
+  }
+};
+
+template <typename First, typename Second>
+simdutf_really_inline constexpr pair<First, Second>
+make_pair(First first, Second second) noexcept {
+  return {first, second};
+}
+
+template <size_t Index, typename First, typename Second>
+simdutf_really_inline constexpr
+    typename pair_get_impl<Index, First, Second>::type &
+    get(pair<First, Second> &value) noexcept {
+  return pair_get_impl<Index, First, Second>::get(value);
+}
+
+template <size_t Index, typename First, typename Second>
+simdutf_really_inline constexpr const typename pair_get_impl<Index, First,
+                                                             Second>::type &
+get(const pair<First, Second> &value) noexcept {
+  return pair_get_impl<Index, First, Second>::get(value);
+}
+#endif
+
+//--------------------------------------------------------------------
+// Tuple
+//--------------------------------------------------------------------
+#ifndef SIMDUTF_NO_LIBCXX
+using std::get;
+
+template <typename First, typename Second, typename Third>
+using tuple = std::tuple<First, Second, Third>;
+
+using std::make_tuple;
+
+template <size_t Index, typename First, typename Second, typename Third>
+using tuple_get_impl = std::tuple_element<Index, tuple<First, Second, Third>>;
+#else
+template <typename First, typename Second, typename Third> struct tuple {
+  First first;
+  Second second;
+  Third third;
+};
+
+template <size_t Index, typename First, typename Second, typename Third>
+struct tuple_get_impl {
+  static_assert(Index < 3, "tuple index out of bounds");
+  using type = First;
+};
+
+template <typename First, typename Second, typename Third>
+struct tuple_get_impl<0, First, Second, Third> {
+  using type = First;
+
+  simdutf_really_inline static constexpr type &
+  get(tuple<First, Second, Third> &value) noexcept {
+    return value.first;
+  }
+
+  simdutf_really_inline static constexpr const type &
+  get(const tuple<First, Second, Third> &value) noexcept {
+    return value.first;
+  }
+};
+
+template <typename First, typename Second, typename Third>
+struct tuple_get_impl<1, First, Second, Third> {
+  using type = Second;
+
+  simdutf_really_inline static constexpr type &
+  get(tuple<First, Second, Third> &value) noexcept {
+    return value.second;
+  }
+
+  simdutf_really_inline static constexpr const type &
+  get(const tuple<First, Second, Third> &value) noexcept {
+    return value.second;
+  }
+};
+
+template <typename First, typename Second, typename Third>
+struct tuple_get_impl<2, First, Second, Third> {
+  using type = Third;
+
+  simdutf_really_inline static constexpr type &
+  get(tuple<First, Second, Third> &value) noexcept {
+    return value.third;
+  }
+
+  simdutf_really_inline static constexpr const type &
+  get(const tuple<First, Second, Third> &value) noexcept {
+    return value.third;
+  }
+};
+
+template <typename First, typename Second, typename Third>
+simdutf_really_inline constexpr tuple<First, Second, Third>
+make_tuple(First first, Second second, Third third) noexcept {
+  return {first, second, third};
+}
+
+template <size_t Index, typename First, typename Second, typename Third>
+simdutf_really_inline constexpr
+    typename tuple_get_impl<Index, First, Second, Third>::type &
+    get(tuple<First, Second, Third> &value) noexcept {
+  return tuple_get_impl<Index, First, Second, Third>::get(value);
+}
+
+template <size_t Index, typename First, typename Second, typename Third>
+simdutf_really_inline constexpr const typename tuple_get_impl<
+    Index, First, Second, Third>::type &
+get(const tuple<First, Second, Third> &value) noexcept {
+  return tuple_get_impl<Index, First, Second, Third>::get(value);
+}
+#endif
+
+//--------------------------------------------------------------------
+// Array
+//--------------------------------------------------------------------
+#ifndef SIMDUTF_NO_LIBCXX
+template <typename T, size_t N> using array = std::array<T, N>;
+#else
+template <typename T, size_t N> struct array {
+  // Keep zero-sized instantiations well-formed without changing size().
+  T storage[N == 0 ? 1 : N];
+
+  simdutf_really_inline T *data() noexcept { return storage; }
+  simdutf_really_inline constexpr const T *data() const noexcept {
+    return storage;
+  }
+  simdutf_really_inline constexpr size_t size() const noexcept { return N; }
+  simdutf_really_inline T *begin() noexcept { return data(); }
+  simdutf_really_inline constexpr const T *begin() const noexcept {
+    return data();
+  }
+  simdutf_really_inline T *end() noexcept { return data() + N; }
+  simdutf_really_inline constexpr const T *end() const noexcept {
+    return data() + N;
+  }
+  simdutf_really_inline T &operator[](size_t index) noexcept {
+    return storage[index];
+  }
+  simdutf_really_inline constexpr const T &
+  operator[](size_t index) const noexcept {
+    return storage[index];
+  }
+};
+#endif
+
+//--------------------------------------------------------------------
+// Types and Traits
+//--------------------------------------------------------------------
+#ifndef SIMDUTF_NO_LIBCXX
+using ptrdiff_t = std::ptrdiff_t;
+template <typename T, typename U> using is_same = std::is_same<T, U>;
+template <typename T> using remove_reference = std::remove_reference<T>;
+template <typename T> using remove_const = std::remove_const<T>;
+template <typename T> using remove_volatile = std::remove_volatile<T>;
+template <typename T> using remove_cv = std::remove_cv<T>;
+template <typename T> using decay = std::decay<T>;
+#else
+using ptrdiff_t = ::ptrdiff_t;
+
+template <typename T, typename U> struct is_same {
+  static constexpr bool value = false;
+};
+
+template <typename T> struct is_same<T, T> {
+  static constexpr bool value = true;
+};
+
+template <typename T> struct remove_reference {
+  using type = T;
+};
+
+template <typename T> struct remove_reference<T &> {
+  using type = T;
+};
+
+template <typename T> struct remove_reference<T &&> {
+  using type = T;
+};
+
+template <typename T> struct remove_const {
+  using type = T;
+};
+
+template <typename T> struct remove_const<const T> {
+  using type = T;
+};
+
+template <typename T> struct remove_volatile {
+  using type = T;
+};
+
+template <typename T> struct remove_volatile<volatile T> {
+  using type = T;
+};
+
+template <typename T> struct remove_cv {
+  using type = typename remove_const<typename remove_volatile<T>::type>::type;
+};
+
+template <typename T> struct decay {
+  using type = typename remove_cv<typename remove_reference<T>::type>::type;
+};
+#endif
+
+template <typename T> using decay_t = typename decay<T>::type;
+
+//--------------------------------------------------------------------
+// String Helpers
+//--------------------------------------------------------------------
+
+simdutf_really_inline constexpr const char *c_str(const char *value) noexcept {
+  return value;
+}
+
+#ifndef SIMDUTF_NO_LIBCXX
+simdutf_really_inline const char *c_str(const std::string &value) noexcept {
+  return value.c_str();
+}
+#endif
+
+//--------------------------------------------------------------------
+// Span
+//--------------------------------------------------------------------
+#if !defined(SIMDUTF_NO_LIBCXX) && SIMDUTF_CPLUSPLUS20
+template <typename T> using span = std::span<T>;
+#else
+template <typename T> class span {
+public:
+  using element_type = T;
+  using value_type = typename remove_cv<T>::type;
+  using pointer = T *;
+  using reference = T &;
+  using iterator = pointer;
+
+  simdutf_really_inline constexpr span() noexcept : data_(nullptr), size_(0) {}
+  simdutf_really_inline constexpr span(pointer data, size_t size) noexcept
+      : data_(data), size_(size) {}
+
+  simdutf_really_inline constexpr pointer data() const noexcept {
+    return data_;
+  }
+  simdutf_really_inline constexpr size_t size() const noexcept { return size_; }
+  simdutf_really_inline constexpr iterator begin() const noexcept {
+    return data_;
+  }
+  simdutf_really_inline constexpr iterator end() const noexcept {
+    return data_ + size_;
+  }
+  simdutf_really_inline constexpr reference
+  operator[](size_t index) const noexcept {
+    return data_[index];
+  }
+
+private:
+  pointer data_;
+  size_t size_;
+};
+#endif
+
+//--------------------------------------------------------------------
+// Iterator Helpers
+//--------------------------------------------------------------------
+template <typename Iterator>
+simdutf_really_inline constexpr ptrdiff_t distance(Iterator first,
+                                                   Iterator last) noexcept {
+#ifndef SIMDUTF_NO_LIBCXX
+  return std::distance(first, last);
+#else
+  return last - first;
+#endif
+}
+
+//--------------------------------------------------------------------
+// Algorithm Helpers
+//--------------------------------------------------------------------
+template <typename T>
+simdutf_really_inline simdutf_constexpr T min_value(T a, T b) noexcept {
+#if !defined(SIMDUTF_NO_LIBCXX) && SIMDUTF_CPLUSPLUS14
+  return (std::min)(a, b);
+#else
+  return b < a ? b : a;
+#endif
+}
+
+template <typename T>
+simdutf_really_inline T *find(T *first, T *last, const T &value) noexcept {
+#ifndef SIMDUTF_NO_LIBCXX
+  return std::find(first, last, value);
+#else
+  while (first != last) {
+    if (*first == value) {
+      return first;
+    }
+    ++first;
+  }
+  return last;
+#endif
+}
+
+template <typename T>
+simdutf_really_inline const T *find(const T *first, const T *last,
+                                    const T &value) noexcept {
+#ifndef SIMDUTF_NO_LIBCXX
+  return std::find(first, last, value);
+#else
+  while (first != last) {
+    if (*first == value) {
+      return first;
+    }
+    ++first;
+  }
+  return last;
+#endif
+}
+
+//--------------------------------------------------------------------
+// Memory Helpers
+//--------------------------------------------------------------------
+simdutf_really_inline void *memcpy(void *destination, const void *source,
+                                   size_t count) noexcept {
+#ifndef SIMDUTF_NO_LIBCXX
+  return std::memcpy(destination, source, count);
+#else
+  return ::memcpy(destination, source, count);
+#endif
+}
+
+simdutf_really_inline void *memmove(void *destination, const void *source,
+                                    size_t count) noexcept {
+#ifndef SIMDUTF_NO_LIBCXX
+  return std::memmove(destination, source, count);
+#else
+  return ::memmove(destination, source, count);
+#endif
+}
+
+simdutf_really_inline void *memset(void *destination, int ch,
+                                   size_t count) noexcept {
+#ifndef SIMDUTF_NO_LIBCXX
+  return std::memset(destination, ch, count);
+#else
+  return ::memset(destination, ch, count);
+#endif
+}
+
+} // namespace internal
+} // namespace simdutf
+
+#endif // SIMDUTF_INTERNAL_STL_COMPAT_H

--- a/include/simdutf/portability.h
+++ b/include/simdutf/portability.h
@@ -3,13 +3,44 @@
 
 #include "simdutf/compiler_check.h"
 
-#include <cfloat>
-#include <cstddef>
-#include <cstdint>
-#include <cstdlib>
+#ifdef SIMDUTF_NO_LIBCXX
+  #include <float.h>
+  #include <stddef.h>
+  #include <stdint.h>
+  #include <stdlib.h>
+#else
+  #include <cfloat>
+  #include <cstddef>
+  #include <cstdint>
+  #include <cstdlib>
+#endif
 #ifndef _WIN32
   // strcasecmp, strncasecmp
   #include <strings.h>
+#endif
+
+#ifdef SIMDUTF_NO_LIBCXX
+  #undef SIMDUTF_NO_LIBCXX
+  #define SIMDUTF_NO_LIBCXX 1
+  /**
+   * SIMDUTF_NO_LIBCXX is an all-or-nothing reduced-surface build contract
+   * that forces simdutf to avoid using any libc++ or libc++abi features.
+   *
+   * Every translation unit that compiles simdutf sources or includes simdutf
+   * headers must use the same setting. Public APIs that expose std::* either
+   * change shape or are unavailable in this mode, so it should be treated as a
+   * separate ABI from the normal build.
+   *
+   * To avoid pulling in libc++/libstdc++ or their runtime hooks, this mode
+   * also forces the no-threads/shared-state path and disables the
+   * std::atomic_ref, std::span, and std::text_encoding surfaces so later
+   * headers can rely on the reduced-surface contract.
+   */
+  #undef SIMDUTF_NO_THREADS
+  #define SIMDUTF_NO_THREADS 1
+  #undef SIMDUTF_ATOMIC_REF
+  #define SIMDUTF_SPAN_DISABLED 1
+  #define SIMDUTF_NO_STD_TEXT_ENCODING 1
 #endif
 
 #if defined(__apple_build_version__)
@@ -20,17 +51,27 @@
 #endif
 
 #if SIMDUTF_CPLUSPLUS20
-  #include <version>
-  #if __cpp_concepts >= 201907L && __cpp_lib_span >= 202002L &&                \
-      !defined(SIMDUTF_SPAN_DISABLED)
-    #define SIMDUTF_SPAN 1
-  #endif // __cpp_concepts >= 201907L && __cpp_lib_span >= 202002L
-  #if __cpp_lib_atomic_ref >= 201806L
-    #define SIMDUTF_ATOMIC_REF 1
-  #endif // __cpp_lib_atomic_ref
+  #ifndef SIMDUTF_NO_LIBCXX
+    #include <version>
+    #if __cpp_concepts >= 201907L && __cpp_lib_span >= 202002L &&              \
+        !defined(SIMDUTF_SPAN_DISABLED)
+      #define SIMDUTF_SPAN 1
+    #endif // __cpp_concepts >= 201907L && __cpp_lib_span >= 202002L
+    #if __cpp_lib_atomic_ref >= 201806L
+      #define SIMDUTF_ATOMIC_REF 1
+    #endif // __cpp_lib_atomic_ref
+  #endif   // SIMDUTF_NO_LIBCXX
   #if __has_cpp_attribute(maybe_unused) >= 201603L
     #define SIMDUTF_MAYBE_UNUSED_AVAILABLE 1
   #endif // __has_cpp_attribute(maybe_unused) >= 201603L
+#endif
+
+// Best-effort weak symbol annotation for fallback ABI hooks that should defer
+// to a toolchain-provided definition when one is linked in.
+#if defined(__GNUC__) || defined(__clang__)
+  #define SIMDUTF_WEAK __attribute__((weak))
+#else
+  #define SIMDUTF_WEAK
 #endif
 
 /**

--- a/include/simdutf/scalar/ascii.h
+++ b/include/simdutf/scalar/ascii.h
@@ -22,9 +22,9 @@ simdutf_warn_unused simdutf_constexpr23 bool validate(InputPtr data,
   {
     for (; pos + 16 <= len; pos += 16) {
       uint64_t v1;
-      std::memcpy(&v1, data + pos, sizeof(uint64_t));
+      internal::memcpy(&v1, data + pos, sizeof(uint64_t));
       uint64_t v2;
-      std::memcpy(&v2, data + pos + sizeof(uint64_t), sizeof(uint64_t));
+      internal::memcpy(&v2, data + pos + sizeof(uint64_t), sizeof(uint64_t));
       uint64_t v{v1 | v2};
       if ((v & 0x8080808080808080) != 0) {
         return false;
@@ -34,7 +34,7 @@ simdutf_warn_unused simdutf_constexpr23 bool validate(InputPtr data,
 
   // process the tail byte-by-byte
   for (; pos < len; pos++) {
-    if (static_cast<std::uint8_t>(data[pos]) >= 0b10000000) {
+    if (static_cast<uint8_t>(data[pos]) >= 0b10000000) {
       return false;
     }
   }
@@ -55,13 +55,13 @@ validate_with_errors(InputPtr data, size_t len) noexcept {
     // process in blocks of 16 bytes when possible
     for (; pos + 16 <= len; pos += 16) {
       uint64_t v1;
-      std::memcpy(&v1, data + pos, sizeof(uint64_t));
+      internal::memcpy(&v1, data + pos, sizeof(uint64_t));
       uint64_t v2;
-      std::memcpy(&v2, data + pos + sizeof(uint64_t), sizeof(uint64_t));
+      internal::memcpy(&v2, data + pos + sizeof(uint64_t), sizeof(uint64_t));
       uint64_t v{v1 | v2};
       if ((v & 0x8080808080808080) != 0) {
         for (; pos < len; pos++) {
-          if (static_cast<std::uint8_t>(data[pos]) >= 0b10000000) {
+          if (static_cast<uint8_t>(data[pos]) >= 0b10000000) {
             return result(error_code::TOO_LARGE, pos);
           }
         }
@@ -71,7 +71,7 @@ validate_with_errors(InputPtr data, size_t len) noexcept {
 
   // process the tail byte-by-byte
   for (; pos < len; pos++) {
-    if (static_cast<std::uint8_t>(data[pos]) >= 0b10000000) {
+    if (static_cast<uint8_t>(data[pos]) >= 0b10000000) {
       return result(error_code::TOO_LARGE, pos);
     }
   }

--- a/include/simdutf/scalar/atomic_util.h
+++ b/include/simdutf/scalar/atomic_util.h
@@ -2,6 +2,7 @@
 #define SIMDUTF_ATOMIC_UTIL_H
 #if SIMDUTF_ATOMIC_REF
   #include <atomic>
+  #include "simdutf/internal/stl_compat.h"
 namespace simdutf {
 namespace scalar {
 
@@ -28,7 +29,7 @@ inline void memcpy_atomic_read(char *dst, const char *src, size_t len) {
   // Handle unaligned start
   size_t offset = reinterpret_cast<std::uintptr_t>(src) % alignment;
   if (offset) {
-    size_t to_align = std::min(len, alignment - offset);
+    size_t to_align = internal::min_value(len, alignment - offset);
     bbb_memcpy_atomic_read(dst, src, to_align);
     src += to_align;
     dst += to_align;
@@ -40,7 +41,7 @@ inline void memcpy_atomic_read(char *dst, const char *src, size_t len) {
     auto *src_aligned = reinterpret_cast<uint64_t *>(const_cast<char *>(src));
     const auto dst_value =
         std::atomic_ref<uint64_t>(*src_aligned).load(std::memory_order_relaxed);
-    std::memcpy(dst, &dst_value, sizeof(uint64_t));
+    internal::memcpy(dst, &dst_value, sizeof(uint64_t));
     src += alignment;
     dst += alignment;
     len -= alignment;
@@ -75,7 +76,7 @@ inline void memcpy_atomic_write(char *dst, const char *src, size_t len) {
   // Handle unaligned start
   size_t offset = reinterpret_cast<std::uintptr_t>(dst) % alignment;
   if (offset) {
-    size_t to_align = std::min(len, alignment - offset);
+    size_t to_align = internal::min_value(len, alignment - offset);
     bbb_memcpy_atomic_write(dst, src, to_align);
     dst += to_align;
     src += to_align;
@@ -86,7 +87,8 @@ inline void memcpy_atomic_write(char *dst, const char *src, size_t len) {
   while (len >= alignment) {
     auto *dst_aligned = reinterpret_cast<uint64_t *>(dst);
     uint64_t src_val;
-    std::memcpy(&src_val, src, sizeof(uint64_t)); // Non-atomic read from src
+    internal::memcpy(&src_val, src,
+                     sizeof(uint64_t)); // Non-atomic read from src
     std::atomic_ref<uint64_t>(*dst_aligned)
         .store(src_val, std::memory_order_relaxed);
     dst += alignment;

--- a/include/simdutf/scalar/base64.h
+++ b/include/simdutf/scalar/base64.h
@@ -1,11 +1,13 @@
 #ifndef SIMDUTF_BASE64_H
 #define SIMDUTF_BASE64_H
 
-#include <algorithm>
-#include <cstddef>
-#include <cstdint>
-#include <cstring>
-#include <iostream>
+#ifdef SIMDUTF_NO_LIBCXX
+  #include <stddef.h>
+  #include <stdint.h>
+#else
+  #include <cstddef>
+  #include <cstdint>
+#endif
 
 namespace simdutf {
 namespace scalar {

--- a/include/simdutf/scalar/utf16_to_latin1/utf16_to_latin1.h
+++ b/include/simdutf/scalar/utf16_to_latin1/utf16_to_latin1.h
@@ -1,8 +1,6 @@
 #ifndef SIMDUTF_UTF16_TO_LATIN1_H
 #define SIMDUTF_UTF16_TO_LATIN1_H
 
-#include <cstring> // for std::memcpy
-
 namespace simdutf {
 namespace scalar {
 namespace {
@@ -58,10 +56,10 @@ simdutf_constexpr23 result convert_with_errors(InputPtr data, size_t len,
       if (pos + 16 <= len) { // if it is safe to read 32 more bytes, check that
                              // they are Latin1
         uint64_t v1, v2, v3, v4;
-        ::memcpy(&v1, data + pos, sizeof(uint64_t));
-        ::memcpy(&v2, data + pos + 4, sizeof(uint64_t));
-        ::memcpy(&v3, data + pos + 8, sizeof(uint64_t));
-        ::memcpy(&v4, data + pos + 12, sizeof(uint64_t));
+        internal::memcpy(&v1, data + pos, sizeof(uint64_t));
+        internal::memcpy(&v2, data + pos + 4, sizeof(uint64_t));
+        internal::memcpy(&v3, data + pos + 8, sizeof(uint64_t));
+        internal::memcpy(&v4, data + pos + 12, sizeof(uint64_t));
 
         if simdutf_constexpr (!match_system(big_endian)) {
           v1 = (v1 >> 8) | (v1 << (64 - 8));

--- a/include/simdutf/scalar/utf16_to_latin1/valid_utf16_to_latin1.h
+++ b/include/simdutf/scalar/utf16_to_latin1/valid_utf16_to_latin1.h
@@ -11,7 +11,7 @@ simdutf_constexpr23 inline size_t
 convert_valid_impl(InputIterator data, size_t len,
                    OutputIterator latin_output) {
   static_assert(
-      std::is_same<typename std::decay<decltype(*data)>::type, uint16_t>::value,
+      internal::is_same<internal::decay_t<decltype(*data)>, uint16_t>::value,
       "must decay to uint16_t");
   size_t pos = 0;
   const auto start = latin_output;

--- a/include/simdutf/scalar/utf32_to_latin1/valid_utf32_to_latin1.h
+++ b/include/simdutf/scalar/utf32_to_latin1/valid_utf32_to_latin1.h
@@ -10,7 +10,7 @@ template <typename ReadPtr, typename WritePtr>
 simdutf_constexpr23 size_t convert_valid(ReadPtr data, size_t len,
                                          WritePtr latin1_output) {
   static_assert(
-      std::is_same<typename std::decay<decltype(*data)>::type, uint32_t>::value,
+      internal::is_same<internal::decay_t<decltype(*data)>, uint32_t>::value,
       "dereferencing the data pointer must result in a uint32_t");
   auto start = latin1_output;
   uint32_t utf32_char;
@@ -28,7 +28,7 @@ simdutf_constexpr23 size_t convert_valid(ReadPtr data, size_t len,
       if (pos + 2 <= len) {
         // if it is safe to read 8 more bytes, check that they are Latin1
         uint64_t v;
-        std::memcpy(&v, data + pos, sizeof(uint64_t));
+        internal::memcpy(&v, data + pos, sizeof(uint64_t));
         if ((v & 0xFFFFFF00FFFFFF00) == 0) {
           *latin1_output++ = char(data[pos]);
           *latin1_output++ = char(data[pos + 1]);

--- a/include/simdutf/scalar/utf8.h
+++ b/include/simdutf/scalar/utf8.h
@@ -11,7 +11,7 @@ template <class BytePtr>
 simdutf_constexpr23 simdutf_warn_unused bool validate(BytePtr data,
                                                       size_t len) noexcept {
   static_assert(
-      std::is_same<typename std::decay<decltype(*data)>::type, uint8_t>::value,
+      internal::is_same<internal::decay_t<decltype(*data)>, uint8_t>::value,
       "dereferencing the data pointer must result in a uint8_t");
   uint64_t pos = 0;
   uint32_t code_point = 0;
@@ -25,9 +25,9 @@ simdutf_constexpr23 simdutf_warn_unused bool validate(BytePtr data,
       if (next_pos <= len) { // if it is safe to read 16 more bytes, check
                              // that they are ascii
         uint64_t v1{};
-        std::memcpy(&v1, data + pos, sizeof(uint64_t));
+        internal::memcpy(&v1, data + pos, sizeof(uint64_t));
         uint64_t v2{};
-        std::memcpy(&v2, data + pos + sizeof(uint64_t), sizeof(uint64_t));
+        internal::memcpy(&v2, data + pos + sizeof(uint64_t), sizeof(uint64_t));
         uint64_t v{v1 | v2};
         if ((v & 0x8080808080808080) == 0) {
           pos = next_pos;
@@ -116,7 +116,7 @@ template <class BytePtr>
 simdutf_constexpr23 simdutf_warn_unused result
 validate_with_errors(BytePtr data, size_t len) noexcept {
   static_assert(
-      std::is_same<typename std::decay<decltype(*data)>::type, uint8_t>::value,
+      internal::is_same<internal::decay_t<decltype(*data)>, uint8_t>::value,
       "dereferencing the data pointer must result in a uint8_t");
   size_t pos = 0;
   uint32_t code_point = 0;
@@ -126,9 +126,9 @@ validate_with_errors(BytePtr data, size_t len) noexcept {
     if (next_pos <=
         len) { // if it is safe to read 16 more bytes, check that they are ascii
       uint64_t v1;
-      std::memcpy(&v1, data + pos, sizeof(uint64_t));
+      internal::memcpy(&v1, data + pos, sizeof(uint64_t));
       uint64_t v2;
-      std::memcpy(&v2, data + pos + sizeof(uint64_t), sizeof(uint64_t));
+      internal::memcpy(&v2, data + pos + sizeof(uint64_t), sizeof(uint64_t));
       uint64_t v{v1 | v2};
       if ((v & 0x8080808080808080) == 0) {
         pos = next_pos;

--- a/include/simdutf/scalar/utf8_to_latin1/utf8_to_latin1.h
+++ b/include/simdutf/scalar/utf8_to_latin1/utf8_to_latin1.h
@@ -182,7 +182,7 @@ inline result rewind_and_convert_with_errors(size_t prior_bytes,
   bool found_leading_bytes{false};
   // important: it is i <= how_far_back and not 'i < how_far_back'.
   for (size_t i = 0; i <= how_far_back; i++) {
-    unsigned char byte = buf[-static_cast<std::ptrdiff_t>(i)];
+    unsigned char byte = buf[-static_cast<internal::ptrdiff_t>(i)];
     found_leading_bytes = ((byte & 0b11000000) != 0b10000000);
     if (found_leading_bytes) {
       if (i > 0 && byte < 128) {

--- a/include/simdutf/scalar/utf8_to_utf16/utf8_to_utf16.h
+++ b/include/simdutf/scalar/utf8_to_utf16/utf8_to_utf16.h
@@ -299,7 +299,7 @@ inline result rewind_and_convert_with_errors(size_t prior_bytes,
   bool found_leading_bytes{false};
   // important: it is i <= how_far_back and not 'i < how_far_back'.
   for (size_t i = 0; i <= how_far_back; i++) {
-    unsigned char byte = buf[-static_cast<std::ptrdiff_t>(i)];
+    unsigned char byte = buf[-static_cast<internal::ptrdiff_t>(i)];
     found_leading_bytes = ((byte & 0b11000000) != 0b10000000);
     if (found_leading_bytes) {
       if (i > 0 && byte < 128) {

--- a/include/simdutf/scalar/utf8_to_utf32/utf8_to_utf32.h
+++ b/include/simdutf/scalar/utf8_to_utf32/utf8_to_utf32.h
@@ -255,7 +255,7 @@ inline result rewind_and_convert_with_errors(size_t prior_bytes,
   bool found_leading_bytes{false};
   // important: it is i <= how_far_back and not 'i < how_far_back'.
   for (size_t i = 0; i <= how_far_back; i++) {
-    unsigned char byte = buf[-static_cast<std::ptrdiff_t>(i)];
+    unsigned char byte = buf[-static_cast<internal::ptrdiff_t>(i)];
     found_leading_bytes = ((byte & 0b11000000) != 0b10000000);
     if (found_leading_bytes) {
       if (i > 0 && byte < 128) {

--- a/include/simdutf_c.h
+++ b/include/simdutf_c.h
@@ -12,17 +12,19 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#ifdef __has_include
-  #if __has_include(<uchar.h>)
-    #include <uchar.h>
-  #else // __has_include(<uchar.h>)
+#ifndef __cplusplus
+  #ifdef __has_include
+    #if __has_include(<uchar.h>)
+      #include <uchar.h>
+    #else // __has_include(<uchar.h>)
+      #define char16_t uint16_t
+      #define char32_t uint32_t
+    #endif // __has_include(<uchar.h>)
+  #else    // __has_include
     #define char16_t uint16_t
     #define char32_t uint32_t
-  #endif // __has_include(<uchar.h>)
-#else    // __has_include(<uchar.h>)
-  #define char16_t uint16_t
-  #define char32_t uint32_t
-#endif // __has_include
+  #endif // __has_include
+#endif   // __cplusplus
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/check_no_libcxx_abi.sh
+++ b/scripts/check_no_libcxx_abi.sh
@@ -1,0 +1,307 @@
+#!/bin/sh
+
+#
+# Verifies the stricter SIMDUTF_NO_LIBCXX ABI contract by auditing
+# src/implementation.cpp and src/simdutf.cpp, then linking native smoke tests
+# without implicitly adding a C++ standard library or ABI library.
+
+set -eu
+
+rootdir=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+builddir=${BUILD_DIR:-$rootdir/build/no-libcxx-build-contract}
+cxx=${CXX:-c++}
+cc=${CC:-cc}
+
+implementation_obj=$builddir/implementation-no-libcxx-noeh-nortti.o
+implementation_undefined=$builddir/implementation-no-libcxx-noeh-nortti.undefined.txt
+implementation_abi_runtime=$builddir/implementation-no-libcxx-noeh-nortti.abi-runtime.txt
+
+simdutf_obj=$builddir/simdutf-no-libcxx-noeh-nortti.o
+simdutf_undefined=$builddir/simdutf-no-libcxx-noeh-nortti.undefined.txt
+simdutf_abi_runtime=$builddir/simdutf-no-libcxx-noeh-nortti.abi-runtime.txt
+
+dispatch_simdutf_obj=$builddir/simdutf-multi-no-libcxx-noeh-nortti.o
+dispatch_smoke_src=$builddir/dispatch_smoke.cpp
+dispatch_smoke_obj=$builddir/dispatch_smoke.o
+dispatch_smoke_bin=$builddir/dispatch_smoke
+dispatch_smoke_deps=$builddir/dispatch_smoke.deps.txt
+
+single_impl_smoke_src=$builddir/single_impl_smoke.cpp
+single_impl_smoke_obj=$builddir/single_impl_smoke.o
+single_impl_simdutf_obj=$builddir/simdutf-fallback-only-no-libcxx-noeh-nortti.o
+single_impl_smoke_bin=$builddir/single_impl_smoke
+single_impl_smoke_deps=$builddir/single_impl_smoke.deps.txt
+
+smoke_results=$builddir/smoke-tests.txt
+
+mkdir -p "$builddir"
+
+compile_no_libcxx() {
+  "$cxx" -std=c++17 \
+    -DSIMDUTF_NO_LIBCXX=1 \
+    -fno-exceptions \
+    -fno-rtti \
+    -I"$rootdir/include" \
+    -I"$rootdir/src" \
+    "$@"
+}
+
+compile_fallback_only_no_libcxx() {
+  compile_no_libcxx \
+    -DSIMDUTF_IMPLEMENTATION_ICELAKE=0 \
+    -DSIMDUTF_IMPLEMENTATION_HASWELL=0 \
+    -DSIMDUTF_IMPLEMENTATION_WESTMERE=0 \
+    -DSIMDUTF_IMPLEMENTATION_ARM64=0 \
+    -DSIMDUTF_IMPLEMENTATION_PPC64=0 \
+    -DSIMDUTF_IMPLEMENTATION_RVV=0 \
+    -DSIMDUTF_IMPLEMENTATION_LASX=0 \
+    -DSIMDUTF_IMPLEMENTATION_LSX=0 \
+    -DSIMDUTF_IMPLEMENTATION_FALLBACK=1 \
+    "$@"
+}
+
+compile_multi_backend_no_libcxx() {
+  compile_no_libcxx \
+    -DSIMDUTF_IMPLEMENTATION_FALLBACK=1 \
+    "$@"
+}
+
+if command -v rg >/dev/null 2>&1; then
+  regex_search() {
+    rg "$@"
+  }
+
+  regex_search_ignore_case() {
+    rg -i "$@"
+  }
+else
+  regex_search() {
+    grep -E "$@"
+  }
+
+  regex_search_ignore_case() {
+    grep -iE "$@"
+  }
+fi
+
+record_undefined_symbols() {
+  obj=$1
+  undefined=$2
+  abi_runtime=$3
+
+  nm -u "$obj" | c++filt > "$undefined"
+
+  if ! regex_search \
+    '(__|__Unwind|__cxxabiv1|std::terminate|vtable for __cxxabiv1|typeinfo (for|name for)|__dynamic_cast)' \
+    "$undefined" > "$abi_runtime"; then
+    : > "$abi_runtime"
+  fi
+}
+
+assert_no_forbidden_abi_symbols() {
+  undefined=$1
+
+  if regex_search -n \
+    '(__cxa_guard_|__cxa_pure_virtual|__gxx_personality|__cxa_begin_catch|__cxa_throw|__cxa_allocate_exception|__cxa_free_exception|typeinfo for |typeinfo name for |__dynamic_cast|vtable for __cxxabiv1)' \
+    "$undefined"; then
+    echo "unexpected ABI/runtime dependency found in $undefined" >&2
+    exit 1
+  fi
+}
+
+record_link_dependencies() {
+  binary=$1
+  output=$2
+
+  if command -v otool >/dev/null 2>&1; then
+    otool -L "$binary" > "$output"
+  elif command -v ldd >/dev/null 2>&1; then
+    ldd "$binary" > "$output"
+  elif command -v readelf >/dev/null 2>&1; then
+    readelf -d "$binary" > "$output"
+  else
+    printf '%s\n' "dependency inspection unavailable on this host" > "$output"
+  fi
+}
+
+assert_no_cpp_runtime_dependencies() {
+  deps=$1
+
+  if regex_search_ignore_case '(libc\+\+|libc\+\+abi|libstdc\+\+|libsupc\+\+)' "$deps"; then
+    echo "unexpected C++ runtime dependency found in $deps" >&2
+    exit 1
+  fi
+}
+
+compile_no_libcxx -c "$rootdir/src/implementation.cpp" -o "$implementation_obj"
+record_undefined_symbols "$implementation_obj" "$implementation_undefined" \
+  "$implementation_abi_runtime"
+assert_no_forbidden_abi_symbols "$implementation_undefined"
+
+compile_no_libcxx -c "$rootdir/src/simdutf.cpp" -o "$simdutf_obj"
+record_undefined_symbols "$simdutf_obj" "$simdutf_undefined" \
+  "$simdutf_abi_runtime"
+assert_no_forbidden_abi_symbols "$simdutf_undefined"
+
+cat > "$dispatch_smoke_src" <<'EOF'
+#include "simdutf.h"
+#include <stdlib.h>
+#include <string.h>
+
+static int check_lookup_round_trip() {
+  const simdutf::implementation *fallback =
+      simdutf::get_available_implementations()["fallback"];
+  if (fallback == nullptr) {
+    return 31;
+  }
+  if (strcmp(fallback->name(), "fallback") != 0) {
+    return 32;
+  }
+  if (simdutf::get_available_implementations()[fallback->name()] != fallback) {
+    return 33;
+  }
+  return 0;
+}
+
+static int check_default_detection() {
+  if (simdutf::get_available_implementations().size() < 2) {
+    return 11;
+  }
+  const simdutf::implementation *best =
+      simdutf::get_available_implementations().detect_best_supported();
+  if (best == nullptr) {
+    return 12;
+  }
+  const simdutf::implementation *before = simdutf::get_active_implementation();
+  if (before == nullptr) {
+    return 13;
+  }
+  if (before == best) {
+    return 14;
+  }
+  if (!simdutf::validate_utf8("abc", 3)) {
+    return 15;
+  }
+  const simdutf::implementation *after = simdutf::get_active_implementation();
+  if (after != best) {
+    return 16;
+  }
+  if (strcmp(after->name(), best->name()) != 0) {
+    return 17;
+  }
+  return check_lookup_round_trip();
+}
+
+static int check_force() {
+  const simdutf::implementation *forced =
+      simdutf::get_available_implementations()["fallback"];
+  if (forced == nullptr) {
+    return 21;
+  }
+  if (setenv("SIMDUTF_FORCE_IMPLEMENTATION", "fallback", 1) != 0) {
+    return 22;
+  }
+  if (!simdutf::validate_utf8("abc", 3)) {
+    return 23;
+  }
+  const simdutf::implementation *active = simdutf::get_active_implementation();
+  if (active != forced) {
+    return 24;
+  }
+  if (strcmp(active->name(), "fallback") != 0) {
+    return 25;
+  }
+  return check_lookup_round_trip();
+}
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    return 2;
+  }
+  if (strcmp(argv[1], "default") == 0) {
+    return check_default_detection();
+  }
+  if (strcmp(argv[1], "force") == 0) {
+    return check_force();
+  }
+  return 3;
+}
+EOF
+
+compile_multi_backend_no_libcxx -c "$rootdir/src/simdutf.cpp" \
+  -o "$dispatch_simdutf_obj"
+compile_multi_backend_no_libcxx -c "$dispatch_smoke_src" \
+  -o "$dispatch_smoke_obj"
+"$cc" "$dispatch_smoke_obj" "$dispatch_simdutf_obj" -o "$dispatch_smoke_bin"
+record_link_dependencies "$dispatch_smoke_bin" "$dispatch_smoke_deps"
+assert_no_cpp_runtime_dependencies "$dispatch_smoke_deps"
+
+: > "$smoke_results"
+"$dispatch_smoke_bin" default
+printf '%s\n' "dispatch_smoke default: ok" >> "$smoke_results"
+"$dispatch_smoke_bin" force
+printf '%s\n' "dispatch_smoke force: ok" >> "$smoke_results"
+
+cat > "$single_impl_smoke_src" <<'EOF'
+#include "simdutf.h"
+#include <string.h>
+
+int main() {
+  const simdutf::implementation *fallback =
+      simdutf::get_available_implementations()["fallback"];
+  if (fallback == nullptr) {
+    return 41;
+  }
+  if (simdutf::get_available_implementations().size() != 1) {
+    return 42;
+  }
+  if (simdutf::get_active_implementation() != fallback) {
+    return 43;
+  }
+  if (!simdutf::validate_utf8("abc", 3)) {
+    return 44;
+  }
+  if (simdutf::get_active_implementation() != fallback) {
+    return 45;
+  }
+  if (strcmp(simdutf::get_active_implementation()->name(), "fallback") != 0) {
+    return 46;
+  }
+  return 0;
+}
+EOF
+
+compile_fallback_only_no_libcxx -c "$rootdir/src/simdutf.cpp" \
+  -o "$single_impl_simdutf_obj"
+compile_fallback_only_no_libcxx -c "$single_impl_smoke_src" \
+  -o "$single_impl_smoke_obj"
+"$cc" "$single_impl_smoke_obj" "$single_impl_simdutf_obj" \
+  -o "$single_impl_smoke_bin"
+record_link_dependencies "$single_impl_smoke_bin" "$single_impl_smoke_deps"
+assert_no_cpp_runtime_dependencies "$single_impl_smoke_deps"
+"$single_impl_smoke_bin"
+printf '%s\n' "single_impl_smoke fallback-only: ok" >> "$smoke_results"
+
+echo "compiled: $implementation_obj"
+echo "undefined symbols: $implementation_undefined"
+echo "abi/runtime subset: $implementation_abi_runtime"
+
+echo "compiled: $simdutf_obj"
+echo "undefined symbols: $simdutf_undefined"
+echo "abi/runtime subset: $simdutf_abi_runtime"
+
+echo "smoke results: $smoke_results"
+echo "dispatch smoke dependencies: $dispatch_smoke_deps"
+echo "single implementation smoke dependencies: $single_impl_smoke_deps"
+
+if [ -s "$implementation_abi_runtime" ]; then
+  cat "$implementation_abi_runtime"
+else
+  echo "(src/implementation.cpp ABI/runtime subset is empty)"
+fi
+
+if [ -s "$simdutf_abi_runtime" ]; then
+  cat "$simdutf_abi_runtime"
+else
+  echo "(src/simdutf.cpp ABI/runtime subset is empty)"
+fi

--- a/singleheader/amalgamate.py
+++ b/singleheader/amalgamate.py
@@ -26,6 +26,7 @@ redefines_simdutf_implementation = re.compile(r'^#define\s+SIMDUTF_IMPLEMENTATIO
 undefines_simdutf_implementation = re.compile(r'^#undef\s+SIMDUTF_IMPLEMENTATION\s*$')
 uses_simdutf_implementation = re.compile(r'SIMDUTF_IMPLEMENTATION([^_a-zA-Z0-9]|$)')
 generic_pattern = re.compile(r'.*generic/.*\.h')
+scalar_pattern = re.compile(r'.*simdutf/scalar/.*\.h')
 begin_pattern = re.compile(r'.*/begin\.h')
 end_pattern = re.compile(r'.*/end\.h')
 
@@ -178,6 +179,11 @@ def doinclude(file, line):
         if os.path.exists(path):
             # generic includes are included multiple times
             if generic_pattern.match(file):
+                dofile(directory, file)
+            # scalar headers may be referenced from both the public header and
+            # src/simdutf.cpp under different preprocessor conditions.
+            # Let the normal header guards decide which copy is active.
+            elif scalar_pattern.match(file):
                 dofile(directory, file)
             # begin/end_implementation are also included multiple times
             elif begin_pattern.match(file):

--- a/singleheader/amalgamation_demo.cpp
+++ b/singleheader/amalgamation_demo.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <string.h>
 
 #include "simdutf.cpp"
 #include "simdutf.h"
@@ -41,9 +42,8 @@ int main(int, char *[]) {
   size_t utf8words = simdutf::convert_utf16le_to_utf8(
       utf16_output.get(), utf16words, utf8_output.get());
   printf("wrote %zu UTF-8 words.", utf8words);
-  std::string final_string(utf8_output.get(), utf8words);
-  puts(final_string.c_str());
-  if (final_string != source) {
+  printf("%.*s\n", int(utf8words), utf8_output.get());
+  if (utf8words != 4 || memcmp(utf8_output.get(), source, utf8words) != 0) {
     puts("bad conversion");
     return EXIT_FAILURE;
   } else {

--- a/src/arm64/arm_base64.cpp
+++ b/src/arm64/arm_base64.cpp
@@ -169,7 +169,8 @@ size_t encode_base64_impl(char *dst, const char *src, size_t srclen,
         if (offset + 64 > line_length) {
           size_t location_end = line_length - offset;
           size_t to_move = 64 - location_end;
-          std::memmove(out + location_end + 1, out + location_end, to_move);
+          internal::memmove(out + location_end + 1, out + location_end,
+                            to_move);
           out[location_end] = '\n';
           offset = to_move;
           out += 64 + 1;
@@ -219,7 +220,8 @@ size_t encode_base64_impl(char *dst, const char *src, size_t srclen,
         if (offset + 32 > line_length) {
           size_t location_end = line_length - offset;
           size_t to_move = 32 - location_end;
-          std::memmove(out + location_end + 1, out + location_end, to_move);
+          internal::memmove(out + location_end + 1, out + location_end,
+                            to_move);
           out[location_end] = '\n';
           offset = to_move;
           out += 32 + 1;
@@ -679,8 +681,8 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
           base64_decode_block(dst, buffer + i * 64);
           dst += 48;
         }
-        std::memcpy(buffer, buffer + (block_size - 1) * 64,
-                    64); // 64 might be too much
+        internal::memcpy(buffer, buffer + (block_size - 1) * 64,
+                         64); // 64 might be too much
         bufferptr -= (block_size - 1) * 64;
       }
     }
@@ -717,7 +719,7 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
 #if !SIMDUTF_IS_BIG_ENDIAN
       triple = scalar::u32_swap_bytes(triple);
 #endif
-      std::memcpy(dst, &triple, 4);
+      internal::memcpy(dst, &triple, 4);
 
       dst += 3;
       buffer_start += 4;
@@ -731,7 +733,7 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
 #if !SIMDUTF_IS_BIG_ENDIAN
       triple = scalar::u32_swap_bytes(triple);
 #endif
-      std::memcpy(dst, &triple, 3);
+      internal::memcpy(dst, &triple, 3);
 
       dst += 3;
       buffer_start += 4;

--- a/src/arm64/arm_convert_latin1_to_utf16.cpp
+++ b/src/arm64/arm_convert_latin1_to_utf16.cpp
@@ -1,5 +1,5 @@
 template <endianness big_endian>
-std::pair<const char *, char16_t *>
+internal::pair<const char *, char16_t *>
 arm_convert_latin1_to_utf16(const char *buf, size_t len,
                             char16_t *utf16_output) {
   const char *end = buf + len;
@@ -20,5 +20,5 @@ arm_convert_latin1_to_utf16(const char *buf, size_t len,
     buf += 16;
   }
 
-  return std::make_pair(buf, utf16_output);
+  return internal::make_pair(buf, utf16_output);
 }

--- a/src/arm64/arm_convert_latin1_to_utf32.cpp
+++ b/src/arm64/arm_convert_latin1_to_utf32.cpp
@@ -1,4 +1,4 @@
-std::pair<const char *, char32_t *>
+internal::pair<const char *, char32_t *>
 arm_convert_latin1_to_utf32(const char *buf, size_t len,
                             char32_t *utf32_output) {
   const char *end = buf + len;
@@ -20,5 +20,5 @@ arm_convert_latin1_to_utf32(const char *buf, size_t len,
     buf += 16;
   }
 
-  return std::make_pair(buf, utf32_output);
+  return internal::make_pair(buf, utf32_output);
 }

--- a/src/arm64/arm_convert_latin1_to_utf8.cpp
+++ b/src/arm64/arm_convert_latin1_to_utf8.cpp
@@ -2,7 +2,7 @@
   Returns a pair: the first unprocessed byte from buf and utf8_output
   A scalar routing should carry on the conversion of the tail.
 */
-std::pair<const char *, char *>
+internal::pair<const char *, char *>
 arm_convert_latin1_to_utf8(const char *latin1_input, size_t len,
                            char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
@@ -66,5 +66,6 @@ arm_convert_latin1_to_utf8(const char *latin1_input, size_t len,
 
   } // while
 
-  return std::make_pair(latin1_input, reinterpret_cast<char *>(utf8_output));
+  return internal::make_pair(latin1_input,
+                             reinterpret_cast<char *>(utf8_output));
 }

--- a/src/arm64/arm_convert_utf16_to_latin1.cpp
+++ b/src/arm64/arm_convert_utf16_to_latin1.cpp
@@ -1,6 +1,6 @@
 
 template <endianness big_endian>
-std::pair<const char16_t *, char *>
+internal::pair<const char16_t *, char *>
 arm_convert_utf16_to_latin1(const char16_t *buf, size_t len,
                             char *latin1_output) {
   const char16_t *end = buf + len;
@@ -18,14 +18,15 @@ arm_convert_utf16_to_latin1(const char16_t *buf, size_t len,
       buf += 8;
       latin1_output += 8;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return internal::pair<const char16_t *, char *>{
+          nullptr, reinterpret_cast<char *>(latin1_output)};
     }
   } // while
-  return std::make_pair(buf, latin1_output);
+  return internal::make_pair(buf, latin1_output);
 }
 
 template <endianness big_endian>
-std::pair<result, char *>
+internal::pair<result, char *>
 arm_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
                                         char *latin1_output) {
   const char16_t *start = buf;
@@ -50,12 +51,12 @@ arm_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
         if (word <= 0xff) {
           *latin1_output++ = char(word);
         } else {
-          return std::make_pair(result(error_code::TOO_LARGE, buf - start + k),
-                                latin1_output);
+          return internal::make_pair(
+              result(error_code::TOO_LARGE, buf - start + k), latin1_output);
         }
       }
     }
   } // while
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        latin1_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             latin1_output);
 }

--- a/src/arm64/arm_convert_utf16_to_utf32.cpp
+++ b/src/arm64/arm_convert_utf16_to_utf32.cpp
@@ -51,7 +51,7 @@
   A scalar routing should carry on the conversion of the tail.
 */
 template <endianness big_endian>
-std::pair<const char16_t *, char32_t *>
+internal::pair<const char16_t *, char32_t *>
 arm_convert_utf16_to_utf32(const char16_t *buf, size_t len,
                            char32_t *utf32_out) {
   uint32_t *utf32_output = reinterpret_cast<uint32_t *>(utf32_out);
@@ -99,8 +99,8 @@ arm_convert_utf16_to_utf32(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char32_t *>(utf32_output));
+            return internal::pair<const char16_t *, char32_t *>{
+                nullptr, reinterpret_cast<char32_t *>(utf32_output)};
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
           *utf32_output++ = char32_t(value);
@@ -109,7 +109,7 @@ arm_convert_utf16_to_utf32(const char16_t *buf, size_t len,
       buf += k;
     }
   } // while
-  return std::make_pair(buf, reinterpret_cast<char32_t *>(utf32_output));
+  return internal::make_pair(buf, reinterpret_cast<char32_t *>(utf32_output));
 }
 
 /*
@@ -120,7 +120,7 @@ arm_convert_utf16_to_utf32(const char16_t *buf, size_t len,
   tail if needed.
 */
 template <endianness big_endian>
-std::pair<result, char32_t *>
+internal::pair<result, char32_t *>
 arm_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
                                        char32_t *utf32_out) {
   uint32_t *utf32_output = reinterpret_cast<uint32_t *>(utf32_out);
@@ -169,7 +169,7 @@ arm_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k - 1),
                 reinterpret_cast<char32_t *>(utf32_output));
           }
@@ -180,6 +180,6 @@ arm_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
       buf += k;
     }
   } // while
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        reinterpret_cast<char32_t *>(utf32_output));
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             reinterpret_cast<char32_t *>(utf32_output));
 }

--- a/src/arm64/arm_convert_utf16_to_utf8.cpp
+++ b/src/arm64/arm_convert_utf16_to_utf8.cpp
@@ -51,7 +51,7 @@
   A scalar routing should carry on the conversion of the tail.
 */
 template <endianness big_endian>
-std::pair<const char16_t *, char *>
+internal::pair<const char16_t *, char *>
 arm_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
   const char16_t *end = buf + len;
@@ -62,7 +62,7 @@ arm_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
   const size_t safety_margin =
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= static_cast<internal::ptrdiff_t>(16 + safety_margin)) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
     if simdutf_constexpr (!match_system(big_endian)) {
       in = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(in)));
@@ -292,8 +292,8 @@ arm_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char *>(utf8_output));
+            return internal::pair<const char16_t *, char *>{
+                nullptr, reinterpret_cast<char *>(utf8_output)};
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
           *utf8_output++ = char((value >> 18) | 0b11110000);
@@ -306,7 +306,7 @@ arm_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
     }
   } // while
 
-  return std::make_pair(buf, reinterpret_cast<char *>(utf8_output));
+  return internal::make_pair(buf, reinterpret_cast<char *>(utf8_output));
 }
 
 /*
@@ -317,7 +317,7 @@ arm_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
   tail if needed.
 */
 template <endianness big_endian>
-std::pair<result, char *>
+internal::pair<result, char *>
 arm_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
                                       char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
@@ -331,7 +331,7 @@ arm_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= static_cast<internal::ptrdiff_t>(16 + safety_margin)) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
     if simdutf_constexpr (!match_system(big_endian)) {
       in = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(in)));
@@ -561,7 +561,7 @@ arm_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k - 1),
                 reinterpret_cast<char *>(utf8_output));
           }
@@ -576,8 +576,8 @@ arm_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
     }
   } // while
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        reinterpret_cast<char *>(utf8_output));
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             reinterpret_cast<char *>(utf8_output));
 }
 
 template <endianness big_endian>

--- a/src/arm64/arm_convert_utf32_to_latin1.cpp
+++ b/src/arm64/arm_convert_utf32_to_latin1.cpp
@@ -1,4 +1,4 @@
-std::pair<const char32_t *, char *>
+internal::pair<const char32_t *, char *>
 arm_convert_utf32_to_latin1(const char32_t *buf, size_t len,
                             char *latin1_output) {
   const char32_t *end = buf + len;
@@ -16,13 +16,14 @@ arm_convert_utf32_to_latin1(const char32_t *buf, size_t len,
       buf += 8;
       latin1_output += 8;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return internal::pair<const char32_t *, char *>{
+          nullptr, reinterpret_cast<char *>(latin1_output)};
     }
   } // while
-  return std::make_pair(buf, latin1_output);
+  return internal::make_pair(buf, latin1_output);
 }
 
-std::pair<result, char *>
+internal::pair<result, char *>
 arm_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
                                         char *latin1_output) {
   const char32_t *start = buf;
@@ -49,12 +50,12 @@ arm_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
         if (word <= 0xff) {
           *latin1_output++ = char(word);
         } else {
-          return std::make_pair(result(error_code::TOO_LARGE, buf - start + k),
-                                latin1_output);
+          return internal::make_pair(
+              result(error_code::TOO_LARGE, buf - start + k), latin1_output);
         }
       }
     }
   } // while
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        latin1_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             latin1_output);
 }

--- a/src/arm64/arm_convert_utf32_to_utf16.cpp
+++ b/src/arm64/arm_convert_utf32_to_utf16.cpp
@@ -65,7 +65,7 @@ neon_expand_surrogate(const uint32x4_t in) {
 }
 
 template <endianness big_endian>
-std::pair<const char32_t *, char16_t *>
+internal::pair<const char32_t *, char16_t *>
 arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
                            char16_t *utf16_out) {
   uint16_t *utf16_output = reinterpret_cast<uint16_t *>(utf16_out);
@@ -74,7 +74,7 @@ arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
   uint16x8_t forbidden_bytemask = vmovq_n_u16(0x0);
   // To avoid buffer overflow while writing compressed_v
   const size_t safety_margin = 4;
-  while (end - buf >= std::ptrdiff_t(8 + safety_margin)) {
+  while (end - buf >= static_cast<internal::ptrdiff_t>(8 + safety_margin)) {
     uint32x4x2_t in = vld1q_u32_x2(reinterpret_cast<const uint32_t *>(buf));
 
     // Check if no bits set above 16th
@@ -98,8 +98,8 @@ arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
       buf += 8;
     } else {
       if (simdutf_unlikely(fast_invalid_utf32(in) || max_val > 0x10ffff)) {
-        return std::make_pair(nullptr,
-                              reinterpret_cast<char16_t *>(utf16_output));
+        return internal::pair<const char32_t *, char16_t *>{
+            nullptr, reinterpret_cast<char16_t *>(utf16_output)};
       }
       expansion_result_t res = neon_expand_surrogate<big_endian>(in.val[0]);
       vst1q_u8(reinterpret_cast<uint8_t *>(utf16_output), res.compressed_v);
@@ -113,14 +113,15 @@ arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
 
   // check for invalid input
   if (vmaxvq_u32(vreinterpretq_u32_u16(forbidden_bytemask)) != 0) {
-    return std::make_pair(nullptr, reinterpret_cast<char16_t *>(utf16_output));
+    return internal::pair<const char32_t *, char16_t *>{
+        nullptr, reinterpret_cast<char16_t *>(utf16_output)};
   }
 
-  return std::make_pair(buf, reinterpret_cast<char16_t *>(utf16_output));
+  return internal::make_pair(buf, reinterpret_cast<char16_t *>(utf16_output));
 }
 
 template <endianness big_endian>
-std::pair<result, char16_t *>
+internal::pair<result, char16_t *>
 arm_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
                                        char16_t *utf16_out) {
   uint16_t *utf16_output = reinterpret_cast<uint16_t *>(utf16_out);
@@ -129,7 +130,7 @@ arm_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
 
   // To avoid buffer overflow while writing compressed_v
   const size_t safety_margin = 4;
-  while (end - buf >= std::ptrdiff_t(8 + safety_margin)) {
+  while (end - buf >= static_cast<internal::ptrdiff_t>(8 + safety_margin)) {
     uint32x4x2_t in = vld1q_u32_x2(reinterpret_cast<const uint32_t *>(buf));
 
     // Check if no bits set above 16th
@@ -143,8 +144,8 @@ arm_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
       const uint16x8_t forbidden_bytemask =
           vceqq_u16(vandq_u16(utf16_packed, v_f800), v_d800);
       if (vmaxvq_u16(forbidden_bytemask) != 0) {
-        return std::make_pair(result(error_code::SURROGATE, buf - start),
-                              reinterpret_cast<char16_t *>(utf16_output));
+        return internal::make_pair(result(error_code::SURROGATE, buf - start),
+                                   reinterpret_cast<char16_t *>(utf16_output));
       }
 
       if simdutf_constexpr (!match_system(big_endian)) {
@@ -203,6 +204,6 @@ arm_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
     }
   }
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        reinterpret_cast<char16_t *>(utf16_output));
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             reinterpret_cast<char16_t *>(utf16_output));
 }

--- a/src/arm64/arm_convert_utf32_to_utf8.cpp
+++ b/src/arm64/arm_convert_utf32_to_utf8.cpp
@@ -1,4 +1,4 @@
-std::pair<const char32_t *, char *>
+internal::pair<const char32_t *, char *>
 arm_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
   const char32_t *end = buf + len;
@@ -221,16 +221,16 @@ arm_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) {
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char *>(utf8_output));
+            return internal::pair<const char32_t *, char *>{
+                nullptr, reinterpret_cast<char *>(utf8_output)};
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
           *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else {
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char *>(utf8_output));
+            return internal::pair<const char32_t *, char *>{
+                nullptr, reinterpret_cast<char *>(utf8_output)};
           }
           *utf8_output++ = char((word >> 18) | 0b11110000);
           *utf8_output++ = char(((word >> 12) & 0b111111) | 0b10000000);
@@ -244,12 +244,13 @@ arm_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
 
   // check for invalid input
   if (vmaxvq_u16(forbidden_bytemask) != 0) {
-    return std::make_pair(nullptr, reinterpret_cast<char *>(utf8_output));
+    return internal::pair<const char32_t *, char *>{
+        nullptr, reinterpret_cast<char *>(utf8_output)};
   }
-  return std::make_pair(buf, reinterpret_cast<char *>(utf8_output));
+  return internal::make_pair(buf, reinterpret_cast<char *>(utf8_output));
 }
 
-std::pair<result, char *>
+internal::pair<result, char *>
 arm_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
                                       char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
@@ -335,8 +336,8 @@ arm_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
         const uint16x8_t forbidden_bytemask = vandq_u16(
             vcleq_u16(utf16_packed, v_dfff), vcgeq_u16(utf16_packed, v_d800));
         if (vmaxvq_u16(forbidden_bytemask) != 0) {
-          return std::make_pair(result(error_code::SURROGATE, buf - start),
-                                reinterpret_cast<char *>(utf8_output));
+          return internal::make_pair(result(error_code::SURROGATE, buf - start),
+                                     reinterpret_cast<char *>(utf8_output));
         }
 
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
@@ -477,7 +478,7 @@ arm_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) {
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k),
                 reinterpret_cast<char *>(utf8_output));
           }
@@ -486,7 +487,7 @@ arm_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else {
           if (word > 0x10FFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::TOO_LARGE, buf - start + k),
                 reinterpret_cast<char *>(utf8_output));
           }
@@ -500,6 +501,6 @@ arm_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
     }
   } // while
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        reinterpret_cast<char *>(utf8_output));
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             reinterpret_cast<char *>(utf8_output));
 }

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -406,7 +406,7 @@ simdutf_warn_unused result implementation::validate_utf32_with_errors(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(
     const char *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char *, char *> ret =
+  internal::pair<const char *, char *> ret =
       arm_convert_latin1_to_utf8(buf, len, utf8_output);
   size_t converted_chars = ret.second - utf8_output;
 
@@ -422,7 +422,7 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16le(
     const char *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char *, char16_t *> ret =
+  internal::pair<const char *, char16_t *> ret =
       arm_convert_latin1_to_utf16<endianness::LITTLE>(buf, len, utf16_output);
   size_t converted_chars = ret.second - utf16_output;
   if (ret.first != buf + len) {
@@ -436,7 +436,7 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf16le(
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(
     const char *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char *, char16_t *> ret =
+  internal::pair<const char *, char16_t *> ret =
       arm_convert_latin1_to_utf16<endianness::BIG>(buf, len, utf16_output);
   size_t converted_chars = ret.second - utf16_output;
   if (ret.first != buf + len) {
@@ -452,7 +452,7 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf32(
     const char *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char *, char32_t *> ret =
+  internal::pair<const char *, char32_t *> ret =
       arm_convert_latin1_to_utf32(buf, len, utf32_output);
   size_t converted_chars = ret.second - utf32_output;
   if (ret.first != buf + len) {
@@ -548,7 +548,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf32(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       arm_convert_utf16_to_latin1<endianness::LITTLE>(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -569,7 +569,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       arm_convert_utf16_to_latin1<endianness::BIG>(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -591,7 +591,7 @@ simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(
 simdutf_warn_unused result
 implementation::convert_utf16le_to_latin1_with_errors(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       arm_convert_utf16_to_latin1_with_errors<endianness::LITTLE>(
           buf, len, latin1_output);
   if (ret.first.error) {
@@ -618,7 +618,7 @@ implementation::convert_utf16le_to_latin1_with_errors(
 simdutf_warn_unused result
 implementation::convert_utf16be_to_latin1_with_errors(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       arm_convert_utf16_to_latin1_with_errors<endianness::BIG>(buf, len,
                                                                latin1_output);
   if (ret.first.error) {
@@ -658,7 +658,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_latin1(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t implementation::convert_utf16le_to_utf8(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       arm_convert_utf16_to_utf8<endianness::LITTLE>(buf, len, utf8_output);
   if (ret.first == nullptr) {
     return 0;
@@ -678,7 +678,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_utf8(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_utf8(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       arm_convert_utf16_to_utf8<endianness::BIG>(buf, len, utf8_output);
   if (ret.first == nullptr) {
     return 0;
@@ -700,7 +700,7 @@ simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       arm_convert_utf16_to_utf8_with_errors<endianness::LITTLE>(buf, len,
                                                                 utf8_output);
   if (ret.first.error) {
@@ -728,7 +728,7 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       arm_convert_utf16_to_utf8_with_errors<endianness::BIG>(buf, len,
                                                              utf8_output);
   if (ret.first.error) {
@@ -769,7 +769,7 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_utf8(
   if (simdutf_unlikely(len == 0)) {
     return 0;
   }
-  std::pair<const char32_t *, char *> ret =
+  internal::pair<const char32_t *, char *> ret =
       arm_convert_utf32_to_utf8(buf, len, utf8_output);
   if (ret.first == nullptr) {
     return 0;
@@ -793,7 +793,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
   }
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       arm_convert_utf32_to_utf8_with_errors(buf, len, utf8_output);
   if (ret.first.count != len) {
     result scalar_res = scalar::utf32_to_utf8::convert_with_errors(
@@ -815,7 +815,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::convert_utf16le_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char16_t *, char32_t *> ret =
+  internal::pair<const char16_t *, char32_t *> ret =
       arm_convert_utf16_to_utf32<endianness::LITTLE>(buf, len, utf32_output);
   if (ret.first == nullptr) {
     return 0;
@@ -835,7 +835,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_utf32(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char16_t *, char32_t *> ret =
+  internal::pair<const char16_t *, char32_t *> ret =
       arm_convert_utf16_to_utf32<endianness::BIG>(buf, len, utf32_output);
   if (ret.first == nullptr) {
     return 0;
@@ -857,7 +857,7 @@ simdutf_warn_unused result implementation::convert_utf16le_to_utf32_with_errors(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char32_t *> ret =
+  internal::pair<result, char32_t *> ret =
       arm_convert_utf16_to_utf32_with_errors<endianness::LITTLE>(buf, len,
                                                                  utf32_output);
   if (ret.first.error) {
@@ -885,7 +885,7 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf32_with_errors(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char32_t *> ret =
+  internal::pair<result, char32_t *> ret =
       arm_convert_utf16_to_utf32_with_errors<endianness::BIG>(buf, len,
                                                               utf32_output);
   if (ret.first.error) {
@@ -913,7 +913,7 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf32_with_errors(
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_utf32_to_latin1(
     const char32_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char32_t *, char *> ret =
+  internal::pair<const char32_t *, char *> ret =
       arm_convert_utf32_to_latin1(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -933,7 +933,7 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_latin1(
 
 simdutf_warn_unused result implementation::convert_utf32_to_latin1_with_errors(
     const char32_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       arm_convert_utf32_to_latin1_with_errors(buf, len, latin1_output);
   if (ret.first.error) {
     return ret.first;
@@ -957,7 +957,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_latin1_with_errors(
 
 simdutf_warn_unused size_t implementation::convert_valid_utf32_to_latin1(
     const char32_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char32_t *, char *> ret =
+  internal::pair<const char32_t *, char *> ret =
       arm_convert_utf32_to_latin1(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -984,7 +984,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf32_to_utf8(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf16le(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char32_t *, char16_t *> ret =
+  internal::pair<const char32_t *, char16_t *> ret =
       arm_convert_utf32_to_utf16<endianness::LITTLE>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -1004,7 +1004,7 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_utf16le(
 
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf16be(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char32_t *, char16_t *> ret =
+  internal::pair<const char32_t *, char16_t *> ret =
       arm_convert_utf32_to_utf16<endianness::BIG>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -1026,7 +1026,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf16le_with_errors(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char16_t *> ret =
+  internal::pair<result, char16_t *> ret =
       arm_convert_utf32_to_utf16_with_errors<endianness::LITTLE>(buf, len,
                                                                  utf16_output);
   if (ret.first.count != len) {
@@ -1050,7 +1050,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf16be_with_errors(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char16_t *> ret =
+  internal::pair<result, char16_t *> ret =
       arm_convert_utf32_to_utf16_with_errors<endianness::BIG>(buf, len,
                                                               utf16_output);
   if (ret.first.count != len) {

--- a/src/encoding_types.cpp
+++ b/src/encoding_types.cpp
@@ -1,6 +1,10 @@
 
 namespace simdutf {
+#ifdef SIMDUTF_NO_LIBCXX
+const char *to_string(encoding_type bom) {
+#else
 std::string to_string(encoding_type bom) {
+#endif
   switch (bom) {
   case UTF16_LE:
     return "UTF16 little-endian";

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -574,12 +574,12 @@ size_t implementation::binary_to_base64_with_lines(
 
 const char *implementation::find(const char *start, const char *end,
                                  char character) const noexcept {
-  return std::find(start, end, character);
+  return internal::find(start, end, character);
 }
 
 const char16_t *implementation::find(const char16_t *start, const char16_t *end,
                                      char16_t character) const noexcept {
-  return std::find(start, end, character);
+  return internal::find(start, end, character);
 }
 #endif // SIMDUTF_FEATURE_BASE64
 

--- a/src/generic/base64.h
+++ b/src/generic/base64.h
@@ -110,8 +110,8 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
           base64_decode_block(dst, buffer + (block_size - 2) * 64);
         }
         dst += 48;
-        std::memcpy(buffer, buffer + (block_size - 1) * 64,
-                    64); // 64 might be too much
+        simdutf::internal::memcpy(buffer, buffer + (block_size - 1) * 64,
+                                  64); // 64 might be too much
         bufferptr -= (block_size - 1) * 64;
       }
     }
@@ -154,7 +154,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
 #if !SIMDUTF_IS_BIG_ENDIAN
       triple = scalar::u32_swap_bytes(triple);
 #endif
-      std::memcpy(dst, &triple, 3);
+      simdutf::internal::memcpy(dst, &triple, 3);
 
       dst += 3;
       buffer_start += 4;
@@ -168,7 +168,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
 #if !SIMDUTF_IS_BIG_ENDIAN
       triple = scalar::u32_swap_bytes(triple);
 #endif
-      std::memcpy(dst, &triple, 3);
+      simdutf::internal::memcpy(dst, &triple, 3);
 
       dst += 3;
       buffer_start += 4;

--- a/src/generic/buf_block_reader.h
+++ b/src/generic/buf_block_reader.h
@@ -30,38 +30,38 @@ private:
   size_t idx;
 };
 
+simdutf_unused static char
+    format_input_text_64_buf[sizeof(simd8x64<uint8_t>) + 1];
+simdutf_unused static char format_input_text_buf[sizeof(simd8x64<uint8_t>) + 1];
+simdutf_unused static char format_mask_buf[64 + 1];
+
 // Routines to print masks and text for debugging bitmask operations
 simdutf_unused static char *format_input_text_64(const uint8_t *text) {
-  static char *buf =
-      reinterpret_cast<char *>(malloc(sizeof(simd8x64<uint8_t>) + 1));
   for (size_t i = 0; i < sizeof(simd8x64<uint8_t>); i++) {
-    buf[i] = int8_t(text[i]) < ' ' ? '_' : int8_t(text[i]);
+    format_input_text_64_buf[i] = int8_t(text[i]) < ' ' ? '_' : int8_t(text[i]);
   }
-  buf[sizeof(simd8x64<uint8_t>)] = '\0';
-  return buf;
+  format_input_text_64_buf[sizeof(simd8x64<uint8_t>)] = '\0';
+  return format_input_text_64_buf;
 }
 
 // Routines to print masks and text for debugging bitmask operations
 simdutf_unused static char *format_input_text(const simd8x64<uint8_t> &in) {
-  static char *buf =
-      reinterpret_cast<char *>(malloc(sizeof(simd8x64<uint8_t>) + 1));
-  in.store(reinterpret_cast<uint8_t *>(buf));
+  in.store(reinterpret_cast<uint8_t *>(format_input_text_buf));
   for (size_t i = 0; i < sizeof(simd8x64<uint8_t>); i++) {
-    if (buf[i] < ' ') {
-      buf[i] = '_';
+    if (format_input_text_buf[i] < ' ') {
+      format_input_text_buf[i] = '_';
     }
   }
-  buf[sizeof(simd8x64<uint8_t>)] = '\0';
-  return buf;
+  format_input_text_buf[sizeof(simd8x64<uint8_t>)] = '\0';
+  return format_input_text_buf;
 }
 
 simdutf_unused static char *format_mask(uint64_t mask) {
-  static char *buf = reinterpret_cast<char *>(malloc(64 + 1));
   for (size_t i = 0; i < 64; i++) {
-    buf[i] = (mask & (size_t(1) << i)) ? 'X' : ' ';
+    format_mask_buf[i] = (mask & (size_t(1) << i)) ? 'X' : ' ';
   }
-  buf[64] = '\0';
-  return buf;
+  format_mask_buf[64] = '\0';
+  return format_mask_buf;
 }
 
 template <size_t STEP_SIZE>
@@ -92,10 +92,11 @@ buf_block_reader<STEP_SIZE>::get_remainder(uint8_t *dst) const {
   if (len == idx) {
     return 0;
   } // memcpy(dst, null, 0) will trigger an error with some sanitizers
-  std::memset(dst, 0x20,
-              STEP_SIZE); // std::memset STEP_SIZE because it is more efficient
-                          // to write out 8 or 16 bytes at once.
-  std::memcpy(dst, buf + idx, len - idx);
+  simdutf::internal::memset(
+      dst, 0x20,
+      STEP_SIZE); // memset STEP_SIZE because it is more efficient to write out
+                  // 8 or 16 bytes at once.
+  simdutf::internal::memcpy(dst, buf + idx, len - idx);
   return len - idx;
 }
 

--- a/src/generic/find.h
+++ b/src/generic/find.h
@@ -11,10 +11,9 @@ simdutf_really_inline const char *find(const char *start, const char *end,
   // Align the start pointer to 64 bytes
   uintptr_t misalignment = reinterpret_cast<uintptr_t>(start) % 64;
   if (misalignment != 0) {
-    size_t adjustment = 64 - misalignment;
-    if (size_t(std::distance(start, end)) < adjustment) {
-      adjustment = std::distance(start, end);
-    }
+    size_t remaining = size_t(end - start);
+    size_t adjustment =
+        internal::min_value<size_t>(64 - misalignment, remaining);
     for (size_t i = 0; i < adjustment; i++) {
       if (start[i] == character) {
         return start + i;
@@ -24,7 +23,8 @@ simdutf_really_inline const char *find(const char *start, const char *end,
   }
 
   // Main loop for 64-byte aligned data
-  for (; std::distance(start, end) >= 64; start += 64) {
+  for (size_t remaining = size_t(end - start); remaining >= 64;
+       start += 64, remaining -= 64) {
     simd8x64<uint8_t> input(reinterpret_cast<const uint8_t *>(start));
     uint64_t matches = input.eq(uint8_t(character));
     if (matches != 0) {
@@ -33,7 +33,7 @@ simdutf_really_inline const char *find(const char *start, const char *end,
       return start + index;
     }
   }
-  return std::find(start, end, character);
+  return internal::find(start, end, character);
 }
 
 simdutf_really_inline const char16_t *
@@ -44,10 +44,9 @@ find(const char16_t *start, const char16_t *end, char16_t character) noexcept {
   // Align the start pointer to 64 bytes if misalignment is even
   uintptr_t misalignment = reinterpret_cast<uintptr_t>(start) % 64;
   if (misalignment != 0 && misalignment % 2 == 0) {
-    size_t adjustment = (64 - misalignment) / sizeof(char16_t);
-    if (size_t(std::distance(start, end)) < adjustment) {
-      adjustment = std::distance(start, end);
-    }
+    size_t remaining = size_t(end - start);
+    size_t adjustment = internal::min_value<size_t>(
+        (64 - misalignment) / sizeof(char16_t), remaining);
     for (size_t i = 0; i < adjustment; i++) {
       if (start[i] == character) {
         return start + i;
@@ -57,7 +56,8 @@ find(const char16_t *start, const char16_t *end, char16_t character) noexcept {
   }
 
   // Main loop for 64-byte aligned data
-  for (; std::distance(start, end) >= 32; start += 32) {
+  for (size_t remaining = size_t(end - start); remaining >= 32;
+       start += 32, remaining -= 32) {
     simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(start));
     uint64_t matches = input.eq(uint16_t(character));
     if (matches != 0) {
@@ -66,7 +66,7 @@ find(const char16_t *start, const char16_t *end, char16_t character) noexcept {
       return start + index;
     }
   }
-  return std::find(start, end, character);
+  return internal::find(start, end, character);
 }
 
 } // namespace util

--- a/src/generic/utf32.h
+++ b/src/generic/utf32.h
@@ -1,5 +1,3 @@
-#include <limits>
-
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
 namespace {
@@ -35,8 +33,7 @@ simdutf_really_inline size_t utf8_length_from_utf32(const char32_t *input,
   // 1. vectorized loop unrolled 4 times
   {
     // we use vector of uint32 counters, this is why this limit is used
-    const size_t max_iterations =
-        std::numeric_limits<uint32_t>::max() / (max_increment * 4);
+    const size_t max_iterations = size_t(UINT32_MAX) / (max_increment * 4);
     size_t blocks = length / (N * 4);
     length -= blocks * (N * 4);
     while (blocks != 0) {
@@ -91,8 +88,7 @@ simdutf_really_inline size_t utf8_length_from_utf32(const char32_t *input,
 
   // 2. vectorized loop for tail
   {
-    const size_t max_iterations =
-        std::numeric_limits<uint32_t>::max() / max_increment;
+    const size_t max_iterations = size_t(UINT32_MAX) / max_increment;
     size_t blocks = length / N;
     length -= blocks * N;
     while (blocks != 0) {

--- a/src/haswell/avx2_base64.cpp
+++ b/src/haswell/avx2_base64.cpp
@@ -370,7 +370,8 @@ avx2_encode_base64_impl(char *dst, const char *src, size_t srclen,
         if (offset + 32 > line_length) {
           size_t location_end = line_length - offset;
           size_t to_move = 32 - location_end;
-          std::memmove(out + location_end + 1, out + location_end, to_move);
+          internal::memmove(out + location_end + 1, out + location_end,
+                            to_move);
           out[location_end] = '\n';
           offset = to_move;
           out += 32 + 1;
@@ -383,7 +384,7 @@ avx2_encode_base64_impl(char *dst, const char *src, size_t srclen,
         alignas(32) uint8_t buffer[32];
         _mm256_storeu_si256(reinterpret_cast<__m256i *>(buffer),
                             lookup_pshufb_improved<isbase64url>(indices));
-        std::memcpy(out, buffer, 32);
+        internal::memcpy(out, buffer, 32);
         size_t out_pos = 0;
         size_t local_offset = offset;
         for (size_t j = 0; j < 32;) {
@@ -493,7 +494,7 @@ simdutf_really_inline void base64_decode_block_safe(char *out,
   alignas(32) char buffer[32]; // We enforce safety with a buffer.
   base64_decode(
       buffer, _mm256_loadu_si256(reinterpret_cast<const __m256i *>(src + 32)));
-  std::memcpy(out + 24, buffer, 24);
+  internal::memcpy(out + 24, buffer, 24);
 }
 
 // --- decoding - base64 class --------------------------------
@@ -544,7 +545,7 @@ public:
     base64_decode(out, chunks[0]);
     alignas(32) char buffer[32]; // We enforce safety with a buffer.
     base64_decode(buffer, chunks[1]);
-    std::memcpy(out + 24, buffer, 24);
+    internal::memcpy(out + 24, buffer, 24);
   }
 
   template <bool base64_url, bool ignore_garbage, bool default_or_url>

--- a/src/haswell/avx2_convert_latin1_to_utf16.cpp
+++ b/src/haswell/avx2_convert_latin1_to_utf16.cpp
@@ -1,5 +1,5 @@
 template <endianness big_endian>
-std::pair<const char *, char16_t *>
+internal::pair<const char *, char16_t *>
 avx2_convert_latin1_to_utf16(const char *latin1_input, size_t len,
                              char16_t *utf16_output) {
   size_t rounded_len = len & ~0xF; // Round down to nearest multiple of 16
@@ -24,5 +24,6 @@ avx2_convert_latin1_to_utf16(const char *latin1_input, size_t len,
     _mm256_storeu_si256(reinterpret_cast<__m256i *>(utf16_output + i), utf16);
   }
 
-  return std::make_pair(latin1_input + rounded_len, utf16_output + rounded_len);
+  return internal::make_pair(latin1_input + rounded_len,
+                             utf16_output + rounded_len);
 }

--- a/src/haswell/avx2_convert_latin1_to_utf32.cpp
+++ b/src/haswell/avx2_convert_latin1_to_utf32.cpp
@@ -1,4 +1,4 @@
-std::pair<const char *, char32_t *>
+internal::pair<const char *, char32_t *>
 avx2_convert_latin1_to_utf32(const char *buf, size_t len,
                              char32_t *utf32_output) {
   size_t rounded_len = ((len | 7) ^ 7); // Round down to nearest multiple of 8
@@ -16,5 +16,5 @@ avx2_convert_latin1_to_utf32(const char *buf, size_t len,
   }
 
   // return pointers pointing to where we left off
-  return std::make_pair(buf + rounded_len, utf32_output + rounded_len);
+  return internal::make_pair(buf + rounded_len, utf32_output + rounded_len);
 }

--- a/src/haswell/avx2_convert_latin1_to_utf8.cpp
+++ b/src/haswell/avx2_convert_latin1_to_utf8.cpp
@@ -1,4 +1,4 @@
-std::pair<const char *, char *>
+internal::pair<const char *, char *>
 avx2_convert_latin1_to_utf8(const char *latin1_input, size_t len,
                             char *utf8_output) {
   const char *end = latin1_input + len;
@@ -7,7 +7,7 @@ avx2_convert_latin1_to_utf8(const char *latin1_input, size_t len,
   const __m256i v_ff80 = _mm256_set1_epi16((int16_t)0xff80);
   const size_t safety_margin = 12;
 
-  while (end - latin1_input >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - latin1_input >= internal::ptrdiff_t(16 + safety_margin)) {
     __m128i in8 = _mm_loadu_si128((__m128i *)latin1_input);
     // a single 16-bit UTF-16 word can yield 1, 2 or 3 UTF-8 bytes
     const __m128i v_80 = _mm_set1_epi8((char)0x80);
@@ -79,5 +79,5 @@ avx2_convert_latin1_to_utf8(const char *latin1_input, size_t len,
     continue;
 
   } // while
-  return std::make_pair(latin1_input, utf8_output);
+  return internal::make_pair(latin1_input, utf8_output);
 }

--- a/src/haswell/avx2_convert_utf16_to_latin1.cpp
+++ b/src/haswell/avx2_convert_utf16_to_latin1.cpp
@@ -1,5 +1,5 @@
 template <endianness big_endian>
-std::pair<const char16_t *, char *>
+internal::pair<const char16_t *, char *>
 avx2_convert_utf16_to_latin1(const char16_t *buf, size_t len,
                              char *latin1_output) {
   const char16_t *end = buf + len;
@@ -29,14 +29,15 @@ avx2_convert_utf16_to_latin1(const char16_t *buf, size_t len,
       buf += 32;
       latin1_output += 32;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return internal::pair<const char16_t *, char *>{
+          nullptr, reinterpret_cast<char *>(latin1_output)};
     }
   } // while
-  return std::make_pair(buf, latin1_output);
+  return internal::make_pair(buf, latin1_output);
 }
 
 template <endianness big_endian>
-std::pair<result, char *>
+internal::pair<result, char *>
 avx2_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
                                          char *latin1_output) {
   const char16_t *start = buf;
@@ -70,7 +71,7 @@ avx2_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
         if (word <= 0xff) {
           *latin1_output++ = char(word);
         } else {
-          return std::make_pair(
+          return internal::make_pair(
               result{error_code::TOO_LARGE, (size_t)(buf - start + k)},
               latin1_output);
         }
@@ -78,6 +79,6 @@ avx2_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
       buf += 16;
     }
   } // while
-  return std::make_pair(result{error_code::SUCCESS, (size_t)(buf - start)},
-                        latin1_output);
+  return internal::make_pair(result{error_code::SUCCESS, (size_t)(buf - start)},
+                             latin1_output);
 }

--- a/src/haswell/avx2_convert_utf16_to_utf32.cpp
+++ b/src/haswell/avx2_convert_utf16_to_utf32.cpp
@@ -52,7 +52,7 @@
   A scalar routing should carry on the conversion of the tail.
 */
 template <endianness big_endian>
-std::pair<const char16_t *, char32_t *>
+internal::pair<const char16_t *, char32_t *>
 avx2_convert_utf16_to_utf32(const char16_t *buf, size_t len,
                             char32_t *utf32_output) {
   const char16_t *end = buf + len;
@@ -113,7 +113,8 @@ avx2_convert_utf16_to_utf32(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr, utf32_output);
+            return internal::pair<const char16_t *, char32_t *>{nullptr,
+                                                                utf32_output};
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
           *utf32_output++ = char32_t(value);
@@ -122,7 +123,7 @@ avx2_convert_utf16_to_utf32(const char16_t *buf, size_t len,
       buf += k;
     }
   } // while
-  return std::make_pair(buf, utf32_output);
+  return internal::make_pair(buf, utf32_output);
 }
 
 /*
@@ -133,7 +134,7 @@ avx2_convert_utf16_to_utf32(const char16_t *buf, size_t len,
   tail if needed.
 */
 template <endianness big_endian>
-std::pair<result, char32_t *>
+internal::pair<result, char32_t *>
 avx2_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
                                         char32_t *utf32_output) {
   const char16_t *start = buf;
@@ -195,7 +196,7 @@ avx2_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k - 1),
                 utf32_output);
           }
@@ -206,5 +207,6 @@ avx2_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
       buf += k;
     }
   } // while
-  return std::make_pair(result(error_code::SUCCESS, buf - start), utf32_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             utf32_output);
 }

--- a/src/haswell/avx2_convert_utf16_to_utf8.cpp
+++ b/src/haswell/avx2_convert_utf16_to_utf8.cpp
@@ -52,7 +52,7 @@
   A scalar routing should carry on the conversion of the tail.
 */
 template <endianness big_endian>
-std::pair<const char16_t *, char *>
+internal::pair<const char16_t *, char *>
 avx2_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_output) {
   const char16_t *end = buf + len;
   const __m256i v_0000 = _mm256_setzero_si256();
@@ -63,7 +63,7 @@ avx2_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_output) {
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= internal::ptrdiff_t(16 + safety_margin)) {
     __m256i in = _mm256_loadu_si256((__m256i *)buf);
     if (big_endian) {
       const __m256i swap = _mm256_setr_epi8(
@@ -305,7 +305,8 @@ avx2_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_output) {
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr, utf8_output);
+            return internal::pair<const char16_t *, char *>{nullptr,
+                                                            utf8_output};
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
           *utf8_output++ = char((value >> 18) | 0b11110000);
@@ -317,7 +318,7 @@ avx2_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_output) {
       buf += k;
     }
   } // while
-  return std::make_pair(buf, utf8_output);
+  return internal::make_pair(buf, utf8_output);
 }
 
 /*
@@ -328,7 +329,7 @@ avx2_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_output) {
   tail if needed.
 */
 template <endianness big_endian>
-std::pair<result, char *>
+internal::pair<result, char *>
 avx2_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
                                        char *utf8_output) {
   const char16_t *start = buf;
@@ -342,7 +343,7 @@ avx2_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= internal::ptrdiff_t(16 + safety_margin)) {
     __m256i in = _mm256_loadu_si256((__m256i *)buf);
     if (big_endian) {
       const __m256i swap = _mm256_setr_epi8(
@@ -584,7 +585,7 @@ avx2_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k - 1),
                 utf8_output);
           }
@@ -598,5 +599,6 @@ avx2_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
       buf += k;
     }
   } // while
-  return std::make_pair(result(error_code::SUCCESS, buf - start), utf8_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             utf8_output);
 }

--- a/src/haswell/avx2_convert_utf32_to_latin1.cpp
+++ b/src/haswell/avx2_convert_utf32_to_latin1.cpp
@@ -1,4 +1,4 @@
-std::pair<const char32_t *, char *>
+internal::pair<const char32_t *, char *>
 avx2_convert_utf32_to_latin1(const char32_t *buf, size_t len,
                              char *latin1_output) {
   const size_t rounded_len =
@@ -16,7 +16,7 @@ avx2_convert_utf32_to_latin1(const char32_t *buf, size_t len,
         _mm256_or_si256(_mm256_or_si256(a, b), _mm256_or_si256(c, d));
 
     if (!_mm256_testz_si256(check_combined, high_bytes_mask)) {
-      return std::make_pair(nullptr, latin1_output);
+      return internal::pair<const char32_t *, char *>{nullptr, latin1_output};
     }
 
     b = _mm256_slli_epi32(b, 1 * 8);
@@ -54,10 +54,10 @@ avx2_convert_utf32_to_latin1(const char32_t *buf, size_t len,
     buf += 32;
   }
 
-  return std::make_pair(buf, latin1_output);
+  return internal::make_pair(buf, latin1_output);
 }
 
-std::pair<result, char *>
+internal::pair<result, char *>
 avx2_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
                                          char *latin1_output) {
   const size_t rounded_len =
@@ -83,7 +83,7 @@ avx2_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
         if (codepoint <= 0xFF) {
           *latin1_output++ = static_cast<char>(codepoint);
         } else {
-          return std::make_pair(result(error_code::TOO_LARGE, buf - start + k),
+          return internal::make_pair(result(error_code::TOO_LARGE, buf - start + k),
                                 latin1_output);
         }
       }
@@ -111,6 +111,6 @@ avx2_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
     buf += 32;
   }
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
                         latin1_output);
 }

--- a/src/haswell/avx2_convert_utf32_to_utf16.cpp
+++ b/src/haswell/avx2_convert_utf32_to_utf16.cpp
@@ -1,5 +1,5 @@
 template <endianness big_endian>
-std::pair<const char32_t *, char16_t *>
+internal::pair<const char32_t *, char16_t *>
 avx2_convert_utf32_to_utf16(const char32_t *buf, size_t len,
                             char16_t *utf16_output) {
   const char32_t *end = buf + len;
@@ -13,7 +13,7 @@ avx2_convert_utf32_to_utf16(const char32_t *buf, size_t len,
   const __m256i v_f800 = _mm256_set1_epi32((uint32_t)0xf800);
   const __m256i v_d800 = _mm256_set1_epi32((uint32_t)0xd800);
 
-  while (end - buf >= std::ptrdiff_t(8 + safety_margin)) {
+  while (end - buf >= internal::ptrdiff_t(8 + safety_margin)) {
     const __m256i in = _mm256_loadu_si256((__m256i *)buf);
 
     if (simdutf_likely(_mm256_testz_si256(in, v_ffff0000))) {
@@ -44,7 +44,8 @@ avx2_convert_utf32_to_utf16(const char32_t *buf, size_t len,
         if ((word & 0xFFFF0000) == 0) {
           // will not generate a surrogate pair
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr, utf16_output);
+            return internal::pair<const char32_t *, char16_t *>{nullptr,
+                                                                utf16_output};
           }
           *utf16_output++ =
               big_endian
@@ -53,7 +54,8 @@ avx2_convert_utf32_to_utf16(const char32_t *buf, size_t len,
         } else {
           // will generate a surrogate pair
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr, utf16_output);
+            return internal::pair<const char32_t *, char16_t *>{nullptr,
+                                                                utf16_output};
           }
           word -= 0x10000;
           uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
@@ -74,14 +76,14 @@ avx2_convert_utf32_to_utf16(const char32_t *buf, size_t len,
 
   // check for invalid input
   if (static_cast<uint32_t>(_mm256_movemask_epi8(forbidden_bytemask)) != 0) {
-    return std::make_pair(nullptr, utf16_output);
+    return internal::pair<const char32_t *, char16_t *>{nullptr, utf16_output};
   }
 
-  return std::make_pair(buf, utf16_output);
+  return internal::make_pair(buf, utf16_output);
 }
 
 template <endianness big_endian>
-std::pair<result, char16_t *>
+internal::pair<result, char16_t *>
 avx2_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
                                         char16_t *utf16_output) {
   const char32_t *start = buf;
@@ -95,7 +97,7 @@ avx2_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
   const __m256i v_f800 = _mm256_set1_epi32((uint32_t)0xf800);
   const __m256i v_d800 = _mm256_set1_epi32((uint32_t)0xd800);
 
-  while (end - buf >= std::ptrdiff_t(8 + safety_margin)) {
+  while (end - buf >= internal::ptrdiff_t(8 + safety_margin)) {
     const __m256i in = _mm256_loadu_si256((__m256i *)buf);
 
     if (simdutf_likely(_mm256_testz_si256(in, v_ffff0000))) {
@@ -105,8 +107,8 @@ avx2_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
           _mm256_cmpeq_epi32(_mm256_and_si256(in, v_f800), v_d800);
       if (static_cast<uint32_t>(_mm256_movemask_epi8(forbidden_bytemask)) !=
           0x0) {
-        return std::make_pair(result(error_code::SURROGATE, buf - start),
-                              utf16_output);
+        return internal::make_pair(result(error_code::SURROGATE, buf - start),
+                                   utf16_output);
       }
 
       __m128i utf16_packed = _mm_packus_epi32(_mm256_castsi256_si128(in),
@@ -130,7 +132,7 @@ avx2_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
         if ((word & 0xFFFF0000) == 0) {
           // will not generate a surrogate pair
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k), utf16_output);
           }
           *utf16_output++ =
@@ -140,7 +142,7 @@ avx2_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
         } else {
           // will generate a surrogate pair
           if (word > 0x10FFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::TOO_LARGE, buf - start + k), utf16_output);
           }
           word -= 0x10000;
@@ -160,5 +162,6 @@ avx2_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
     }
   }
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start), utf16_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             utf16_output);
 }

--- a/src/haswell/avx2_convert_utf32_to_utf8.cpp
+++ b/src/haswell/avx2_convert_utf32_to_utf8.cpp
@@ -1,4 +1,4 @@
-std::pair<const char32_t *, char *>
+internal::pair<const char32_t *, char *>
 avx2_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
   const char32_t *end = buf + len;
   const __m256i v_0000 = _mm256_setzero_si256();
@@ -14,7 +14,7 @@ avx2_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= internal::ptrdiff_t(16 + safety_margin)) {
     __m256i in = _mm256_loadu_si256((__m256i *)buf);
     __m256i nextin = _mm256_loadu_si256((__m256i *)buf + 1);
     running_max = _mm256_max_epu32(_mm256_max_epu32(in, running_max), nextin);
@@ -247,14 +247,16 @@ avx2_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) { // 3-byte
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr, utf8_output);
+            return internal::pair<const char32_t *, char *>{nullptr,
+                                                            utf8_output};
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
           *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else { // 4-byte
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr, utf8_output);
+            return internal::pair<const char32_t *, char *>{nullptr,
+                                                            utf8_output};
           }
           *utf8_output++ = char((word >> 18) | 0b11110000);
           *utf8_output++ = char(((word >> 12) & 0b111111) | 0b10000000);
@@ -270,17 +272,17 @@ avx2_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
   const __m256i v_10ffff = _mm256_set1_epi32((uint32_t)0x10ffff);
   if (static_cast<uint32_t>(_mm256_movemask_epi8(_mm256_cmpeq_epi32(
           _mm256_max_epu32(running_max, v_10ffff), v_10ffff))) != 0xffffffff) {
-    return std::make_pair(nullptr, utf8_output);
+    return internal::pair<const char32_t *, char *>{nullptr, utf8_output};
   }
 
   if (static_cast<uint32_t>(_mm256_movemask_epi8(forbidden_bytemask)) != 0) {
-    return std::make_pair(nullptr, utf8_output);
+    return internal::pair<const char32_t *, char *>{nullptr, utf8_output};
   }
 
-  return std::make_pair(buf, utf8_output);
+  return internal::make_pair(buf, utf8_output);
 }
 
-std::pair<result, char *>
+internal::pair<result, char *>
 avx2_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
                                        char *utf8_output) {
   const char32_t *end = buf + len;
@@ -298,7 +300,7 @@ avx2_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= internal::ptrdiff_t(16 + safety_margin)) {
     __m256i in = _mm256_loadu_si256((__m256i *)buf);
     __m256i nextin = _mm256_loadu_si256((__m256i *)buf + 1);
     // Check for too large input
@@ -306,8 +308,8 @@ avx2_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
         _mm256_max_epu32(_mm256_max_epu32(in, nextin), v_10ffff);
     if (static_cast<uint32_t>(_mm256_movemask_epi8(
             _mm256_cmpeq_epi32(max_input, v_10ffff))) != 0xffffffff) {
-      return std::make_pair(result(error_code::TOO_LARGE, buf - start),
-                            utf8_output);
+      return internal::make_pair(result(error_code::TOO_LARGE, buf - start),
+                                 utf8_output);
     }
 
     // Pack 32-bit UTF-32 code units to 16-bit UTF-16 code units with unsigned
@@ -406,8 +408,8 @@ avx2_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
           _mm256_cmpeq_epi16(_mm256_and_si256(in_16, v_f800), v_d800);
       if (static_cast<uint32_t>(_mm256_movemask_epi8(forbidden_bytemask)) !=
           0x0) {
-        return std::make_pair(result(error_code::SURROGATE, buf - start),
-                              utf8_output);
+        return internal::make_pair(result(error_code::SURROGATE, buf - start),
+                                   utf8_output);
       }
 
       const __m256i dup_even = _mm256_setr_epi16(
@@ -544,7 +546,7 @@ avx2_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) { // 3-byte
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k), utf8_output);
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
@@ -552,7 +554,7 @@ avx2_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else { // 4-byte
           if (word > 0x10FFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::TOO_LARGE, buf - start + k), utf8_output);
           }
           *utf8_output++ = char((word >> 18) | 0b11110000);
@@ -565,5 +567,6 @@ avx2_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
     }
   } // while
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start), utf8_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             utf8_output);
 }

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -206,7 +206,7 @@ implementation::detect_encodings(const char *input,
 
   uint8_t block[64]{};
   size_t idx = reader.block_index();
-  std::memcpy(block, &input[idx], length - idx);
+  internal::memcpy(block, &input[idx], length - idx);
   simd::simd8x64<uint8_t> in(block);
   c.check_next_input(in);
 
@@ -408,7 +408,7 @@ simdutf_warn_unused result implementation::validate_utf32_with_errors(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(
     const char *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char *, char *> ret =
+  internal::pair<const char *, char *> ret =
       avx2_convert_latin1_to_utf8(buf, len, utf8_output);
   size_t converted_chars = ret.second - utf8_output;
 
@@ -425,7 +425,7 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16le(
     const char *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char *, char16_t *> ret =
+  internal::pair<const char *, char16_t *> ret =
       avx2_convert_latin1_to_utf16<endianness::LITTLE>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -445,7 +445,7 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf16le(
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(
     const char *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char *, char16_t *> ret =
+  internal::pair<const char *, char16_t *> ret =
       avx2_convert_latin1_to_utf16<endianness::BIG>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -467,7 +467,7 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf32(
     const char *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char *, char32_t *> ret =
+  internal::pair<const char *, char32_t *> ret =
       avx2_convert_latin1_to_utf32(buf, len, utf32_output);
   if (ret.first == nullptr) {
     return 0;
@@ -565,7 +565,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf32(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       haswell::avx2_convert_utf16_to_latin1<endianness::LITTLE>(buf, len,
                                                                 latin1_output);
   if (ret.first == nullptr) {
@@ -586,7 +586,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       haswell::avx2_convert_utf16_to_latin1<endianness::BIG>(buf, len,
                                                              latin1_output);
   if (ret.first == nullptr) {
@@ -608,7 +608,7 @@ simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(
 simdutf_warn_unused result
 implementation::convert_utf16le_to_latin1_with_errors(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       avx2_convert_utf16_to_latin1_with_errors<endianness::LITTLE>(
           buf, len, latin1_output);
   if (ret.first.error) {
@@ -635,7 +635,7 @@ implementation::convert_utf16le_to_latin1_with_errors(
 simdutf_warn_unused result
 implementation::convert_utf16be_to_latin1_with_errors(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       avx2_convert_utf16_to_latin1_with_errors<endianness::BIG>(buf, len,
                                                                 latin1_output);
   if (ret.first.error) {
@@ -675,7 +675,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_latin1(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t implementation::convert_utf16le_to_utf8(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       haswell::avx2_convert_utf16_to_utf8<endianness::LITTLE>(buf, len,
                                                               utf8_output);
   if (ret.first == nullptr) {
@@ -696,7 +696,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_utf8(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_utf8(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       haswell::avx2_convert_utf16_to_utf8<endianness::BIG>(buf, len,
                                                            utf8_output);
   if (ret.first == nullptr) {
@@ -719,7 +719,7 @@ simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       haswell::avx2_convert_utf16_to_utf8_with_errors<endianness::LITTLE>(
           buf, len, utf8_output);
   if (ret.first.error) {
@@ -747,7 +747,7 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       haswell::avx2_convert_utf16_to_utf8_with_errors<endianness::BIG>(
           buf, len, utf8_output);
   if (ret.first.error) {
@@ -785,7 +785,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf16be_to_utf8(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf8(
     const char32_t *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char32_t *, char *> ret =
+  internal::pair<const char32_t *, char *> ret =
       avx2_convert_utf32_to_utf8(buf, len, utf8_output);
   if (ret.first == nullptr) {
     return 0;
@@ -806,7 +806,7 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_utf8(
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_utf32_to_latin1(
     const char32_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char32_t *, char *> ret =
+  internal::pair<const char32_t *, char *> ret =
       avx2_convert_utf32_to_latin1(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -827,7 +827,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_latin1_with_errors(
     const char32_t *buf, size_t len, char *latin1_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       avx2_convert_utf32_to_latin1_with_errors(buf, len, latin1_output);
   if (ret.first.count != len) {
     result scalar_res = scalar::utf32_to_latin1::convert_with_errors(
@@ -856,7 +856,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
     const char32_t *buf, size_t len, char *utf8_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       haswell::avx2_convert_utf32_to_utf8_with_errors(buf, len, utf8_output);
   if (ret.first.count != len) {
     result scalar_res = scalar::utf32_to_utf8::convert_with_errors(
@@ -878,7 +878,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::convert_utf16le_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char16_t *, char32_t *> ret =
+  internal::pair<const char16_t *, char32_t *> ret =
       haswell::avx2_convert_utf16_to_utf32<endianness::LITTLE>(buf, len,
                                                                utf32_output);
   if (ret.first == nullptr) {
@@ -899,7 +899,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_utf32(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char16_t *, char32_t *> ret =
+  internal::pair<const char16_t *, char32_t *> ret =
       haswell::avx2_convert_utf16_to_utf32<endianness::BIG>(buf, len,
                                                             utf32_output);
   if (ret.first == nullptr) {
@@ -922,7 +922,7 @@ simdutf_warn_unused result implementation::convert_utf16le_to_utf32_with_errors(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char32_t *> ret =
+  internal::pair<result, char32_t *> ret =
       haswell::avx2_convert_utf16_to_utf32_with_errors<endianness::LITTLE>(
           buf, len, utf32_output);
   if (ret.first.error) {
@@ -950,7 +950,7 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf32_with_errors(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char32_t *> ret =
+  internal::pair<result, char32_t *> ret =
       haswell::avx2_convert_utf16_to_utf32_with_errors<endianness::BIG>(
           buf, len, utf32_output);
   if (ret.first.error) {
@@ -985,7 +985,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf32_to_utf8(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf16le(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char32_t *, char16_t *> ret =
+  internal::pair<const char32_t *, char16_t *> ret =
       avx2_convert_utf32_to_utf16<endianness::LITTLE>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -1005,7 +1005,7 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_utf16le(
 
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf16be(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char32_t *, char16_t *> ret =
+  internal::pair<const char32_t *, char16_t *> ret =
       avx2_convert_utf32_to_utf16<endianness::BIG>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -1027,7 +1027,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf16le_with_errors(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char16_t *> ret =
+  internal::pair<result, char16_t *> ret =
       haswell::avx2_convert_utf32_to_utf16_with_errors<endianness::LITTLE>(
           buf, len, utf16_output);
   if (ret.first.count != len) {
@@ -1051,7 +1051,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf16be_with_errors(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char16_t *> ret =
+  internal::pair<result, char16_t *> ret =
       haswell::avx2_convert_utf32_to_utf16_with_errors<endianness::BIG>(
           buf, len, utf16_output);
   if (ret.first.count != len) {

--- a/src/icelake/icelake_base64.inl.cpp
+++ b/src/icelake/icelake_base64.inl.cpp
@@ -382,8 +382,8 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
           base64_decode_block(dst, buffer + i * 64);
           dst += 48;
         }
-        std::memcpy(buffer, buffer + (block_size - 1) * 64,
-                    64); // 64 might be too much
+        simdutf::internal::memcpy(buffer, buffer + (block_size - 1) * 64,
+                                  64); // 64 might be too much
         bufferptr -= (block_size - 1) * 64;
       }
     }

--- a/src/icelake/icelake_convert_utf16_to_latin1.inl.cpp
+++ b/src/icelake/icelake_convert_utf16_to_latin1.inl.cpp
@@ -43,7 +43,7 @@ size_t icelake_convert_utf16_to_latin1(const char16_t *buf, size_t len,
 }
 
 template <endianness big_endian>
-std::pair<result, char *>
+simdutf::internal::pair<result, char *>
 icelake_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
                                             char *latin1_output) {
   const char16_t *end = buf + len;
@@ -69,8 +69,8 @@ icelake_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
         *latin1_output++ = uint8_t(word);
         buf++;
       }
-      return std::make_pair(result(error_code::TOO_LARGE, buf - start),
-                            latin1_output);
+      return simdutf::internal::make_pair(
+          result(error_code::TOO_LARGE, buf - start), latin1_output);
     }
     _mm256_storeu_si256(
         (__m256i *)latin1_output,
@@ -92,12 +92,13 @@ icelake_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
         *latin1_output++ = uint8_t(word);
         buf++;
       }
-      return std::make_pair(result(error_code::TOO_LARGE, buf - start),
-                            latin1_output);
+      return simdutf::internal::make_pair(
+          result(error_code::TOO_LARGE, buf - start), latin1_output);
     }
     _mm256_mask_storeu_epi8(
         latin1_output, mask,
         _mm512_castsi512_si256(_mm512_permutexvar_epi8(shufmask, in)));
   }
-  return std::make_pair(result(error_code::SUCCESS, len), latin1_output);
+  return simdutf::internal::make_pair(result(error_code::SUCCESS, len),
+                                      latin1_output);
 }

--- a/src/icelake/icelake_convert_utf16_to_utf32.inl.cpp
+++ b/src/icelake/icelake_convert_utf16_to_utf32.inl.cpp
@@ -5,7 +5,7 @@
   A scalar routing should carry on the conversion of the tail.
 */
 template <endianness big_endian>
-std::tuple<const char16_t *, char32_t *, bool>
+simdutf::internal::tuple<const char16_t *, char32_t *, bool>
 convert_utf16_to_utf32(const char16_t *buf, size_t len,
                        char32_t *utf32_output) {
   const char16_t *end = buf + len;
@@ -17,7 +17,7 @@ convert_utf16_to_utf32(const char16_t *buf, size_t len,
       0x0607040502030001, 0x0e0f0c0d0a0b0809, 0x0607040502030001,
       0x0e0f0c0d0a0b0809, 0x0607040502030001, 0x0e0f0c0d0a0b0809,
       0x0607040502030001, 0x0e0f0c0d0a0b0809);
-  while (std::distance(buf, end) >= 32) {
+  while (simdutf::internal::distance(buf, end) >= 32) {
     // Always safe because buf + 32 <= end so that end - buf >= 32 bytes:
     __m512i in = _mm512_loadu_si512((__m512i *)buf);
     if (big_endian) {
@@ -117,7 +117,7 @@ convert_utf16_to_utf32(const char16_t *buf, size_t len,
         carry = (H >> 30) & 0x1;
       } else {
         // invalid case
-        return std::make_tuple(buf + carry, utf32_output, false);
+        return simdutf::internal::make_tuple(buf + carry, utf32_output, false);
       }
     } else {
       // no surrogates
@@ -132,5 +132,5 @@ convert_utf16_to_utf32(const char16_t *buf, size_t len,
       carry = 0;
     }
   } // while
-  return std::make_tuple(buf + carry, utf32_output, true);
+  return simdutf::internal::make_tuple(buf + carry, utf32_output, true);
 }

--- a/src/icelake/icelake_convert_utf32_to_latin1.inl.cpp
+++ b/src/icelake/icelake_convert_utf32_to_latin1.inl.cpp
@@ -31,7 +31,7 @@ size_t icelake_convert_utf32_to_latin1(const char32_t *buf, size_t len,
   return len;
 }
 
-std::pair<result, char *>
+simdutf::internal::pair<result, char *>
 icelake_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
                                             char *latin1_output) {
   const char32_t *end = buf + len;
@@ -47,8 +47,8 @@ icelake_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
       while (uint32_t(*buf) <= 0xff) {
         *latin1_output++ = uint8_t(*buf++);
       }
-      return std::make_pair(result(error_code::TOO_LARGE, buf - start),
-                            latin1_output);
+      return simdutf::internal::make_pair(
+          result(error_code::TOO_LARGE, buf - start), latin1_output);
     }
     _mm_storeu_si128(
         (__m128i *)latin1_output,
@@ -63,12 +63,13 @@ icelake_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
       while (uint32_t(*buf) <= 0xff) {
         *latin1_output++ = uint8_t(*buf++);
       }
-      return std::make_pair(result(error_code::TOO_LARGE, buf - start),
-                            latin1_output);
+      return simdutf::internal::make_pair(
+          result(error_code::TOO_LARGE, buf - start), latin1_output);
     }
     _mm_mask_storeu_epi8(
         latin1_output, mask,
         _mm512_castsi512_si128(_mm512_permutexvar_epi8(shufmask, in)));
   }
-  return std::make_pair(result(error_code::SUCCESS, len), latin1_output);
+  return simdutf::internal::make_pair(result(error_code::SUCCESS, len),
+                                      latin1_output);
 }

--- a/src/icelake/icelake_convert_utf32_to_utf16.inl.cpp
+++ b/src/icelake/icelake_convert_utf32_to_utf16.inl.cpp
@@ -1,7 +1,7 @@
 // file included directly
 
 template <endianness big_endian>
-std::pair<const char32_t *, char16_t *>
+simdutf::internal::pair<const char32_t *, char16_t *>
 avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
                               char16_t *utf16_output) {
   const char32_t *end = buf + len;
@@ -16,7 +16,7 @@ avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
   const __m512i v_3ff = _mm512_set1_epi32(0x3FF);
   const __m512i v_dc00d800 = _mm512_set1_epi32((int32_t)0xDC00D800);
 
-  while (end - buf >= std::ptrdiff_t(16)) {
+  while (end - buf >= simdutf::internal::ptrdiff_t(16)) {
     __m512i in = _mm512_loadu_si512(buf);
 
     // no bits set above 16th bit <=> can pack to UTF16 without surrogate pairs
@@ -48,7 +48,7 @@ avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
           saturation_bitmask, _mm512_and_si512(in, v_f800), v_d800);
       error |= _mm512_mask_cmpgt_epu32_mask(surrogate_bitmask, in, v_10ffff);
       if (simdutf_unlikely(error)) {
-        return std::make_pair(nullptr, utf16_output);
+        return {nullptr, utf16_output};
       }
       __m512i v1, v2, v;
       // for the bits saturation_bitmask == 0, we need to unpack the 32-bit word
@@ -113,7 +113,7 @@ avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
           saturation_bitmask, _mm512_and_si512(in, v_f800), v_d800);
       error |= _mm512_mask_cmpgt_epu32_mask(surrogate_bitmask, in, v_10ffff);
       if (simdutf_unlikely(error)) {
-        return std::make_pair(nullptr, utf16_output);
+        return {nullptr, utf16_output};
       }
       __m512i v1, v2, v;
       in = _mm512_mask_sub_epi32(in, surrogate_bitmask, in, v_10000);
@@ -145,14 +145,14 @@ avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
 
   // check for invalid input
   if (forbidden_bytemask != 0) {
-    return std::make_pair(nullptr, utf16_output);
+    return {nullptr, utf16_output};
   }
 
-  return std::make_pair(buf, utf16_output);
+  return simdutf::internal::make_pair(buf, utf16_output);
 }
 
 template <endianness big_endian>
-std::pair<result, char16_t *>
+simdutf::internal::pair<result, char16_t *>
 avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
                                           char16_t *utf16_output) {
   const char32_t *start = buf;
@@ -170,7 +170,7 @@ avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
   error_code code = error_code::SUCCESS;
   bool err = false;
 
-  while (end - buf >= std::ptrdiff_t(16)) {
+  while (end - buf >= simdutf::internal::ptrdiff_t(16)) {
     __m512i in = _mm512_loadu_si512(buf);
 
     // no bits set above 16th bit <=> can pack to UTF16 without surrogate pairs
@@ -193,8 +193,9 @@ avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
         _mm256_mask_storeu_epi16(
             utf16_output, __mmask16(_blsmsk_u32(forbidden_bytemask) >> 1),
             utf16_packed);
-        return std::make_pair(result(error_code::SURROGATE, buf - start + idx),
-                              utf16_output + idx);
+        return simdutf::internal::make_pair(
+            result(error_code::SURROGATE, buf - start + idx),
+            utf16_output + idx);
       }
       _mm256_storeu_si256((__m256i *)utf16_output, utf16_packed);
       utf16_output += 16;
@@ -245,8 +246,8 @@ avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
       //_mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
       utf16_output += written_out;
       if (simdutf_unlikely(err)) {
-        return std::make_pair(result(code, buf - start + error_idx),
-                              utf16_output);
+        return simdutf::internal::make_pair(
+            result(code, buf - start + error_idx), utf16_output);
       }
     }
     buf += 16;
@@ -274,8 +275,9 @@ avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
         _mm256_mask_storeu_epi16(
             utf16_output, __mmask16(_blsmsk_u32(forbidden_bytemask) >> 1),
             utf16_packed);
-        return std::make_pair(result(error_code::SURROGATE, buf - start + idx),
-                              utf16_output + idx);
+        return simdutf::internal::make_pair(
+            result(error_code::SURROGATE, buf - start + idx),
+            utf16_output + idx);
       }
       _mm256_mask_storeu_epi16(utf16_output, input_mask, utf16_packed);
       utf16_output += remaining_len;
@@ -327,12 +329,13 @@ avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
       //_mm512_mask_compressstoreu_epi16(utf16_output, output_mask, in);
       utf16_output += written_out;
       if (simdutf_unlikely(err)) {
-        return std::make_pair(result(code, buf - start + error_idx),
-                              utf16_output);
+        return simdutf::internal::make_pair(
+            result(code, buf - start + error_idx), utf16_output);
       }
     }
     buf += remaining_len;
   }
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start), utf16_output);
+  return simdutf::internal::make_pair(result(error_code::SUCCESS, buf - start),
+                                      utf16_output);
 }

--- a/src/icelake/icelake_convert_utf32_to_utf8.inl.cpp
+++ b/src/icelake/icelake_convert_utf32_to_utf8.inl.cpp
@@ -1,7 +1,7 @@
 // file included directly
 
 // Todo: currently, this is just the haswell code, optimize for icelake kernel.
-std::pair<const char32_t *, char *>
+simdutf::internal::pair<const char32_t *, char *>
 avx512_convert_utf32_to_utf8(const char32_t *buf, size_t len,
                              char *utf8_output) {
   const char32_t *end = buf + len;
@@ -18,7 +18,7 @@ avx512_convert_utf32_to_utf8(const char32_t *buf, size_t len,
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= simdutf::internal::ptrdiff_t(16 + safety_margin)) {
     __m256i in = _mm256_loadu_si256((__m256i *)buf);
     __m256i nextin = _mm256_loadu_si256((__m256i *)buf + 1);
     running_max = _mm256_max_epu32(_mm256_max_epu32(in, running_max), nextin);
@@ -251,14 +251,14 @@ avx512_convert_utf32_to_utf8(const char32_t *buf, size_t len,
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) { // 3-byte
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr, utf8_output);
+            return {nullptr, utf8_output};
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
           *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else { // 4-byte
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr, utf8_output);
+            return {nullptr, utf8_output};
           }
           *utf8_output++ = char((word >> 18) | 0b11110000);
           *utf8_output++ = char(((word >> 12) & 0b111111) | 0b10000000);
@@ -274,18 +274,18 @@ avx512_convert_utf32_to_utf8(const char32_t *buf, size_t len,
   const __m256i v_10ffff = _mm256_set1_epi32((uint32_t)0x10ffff);
   if (static_cast<uint32_t>(_mm256_movemask_epi8(_mm256_cmpeq_epi32(
           _mm256_max_epu32(running_max, v_10ffff), v_10ffff))) != 0xffffffff) {
-    return std::make_pair(nullptr, utf8_output);
+    return {nullptr, utf8_output};
   }
 
   if (static_cast<uint32_t>(_mm256_movemask_epi8(forbidden_bytemask)) != 0) {
-    return std::make_pair(nullptr, utf8_output);
+    return {nullptr, utf8_output};
   }
 
-  return std::make_pair(buf, utf8_output);
+  return simdutf::internal::make_pair(buf, utf8_output);
 }
 
 // Todo: currently, this is just the haswell code, optimize for icelake kernel.
-std::pair<result, char *>
+simdutf::internal::pair<result, char *>
 avx512_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
                                          char *utf8_output) {
   const char32_t *end = buf + len;
@@ -303,7 +303,7 @@ avx512_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= simdutf::internal::ptrdiff_t(16 + safety_margin)) {
     __m256i in = _mm256_loadu_si256((__m256i *)buf);
     __m256i nextin = _mm256_loadu_si256((__m256i *)buf + 1);
     // Check for too large input
@@ -311,8 +311,8 @@ avx512_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
         _mm256_max_epu32(_mm256_max_epu32(in, nextin), v_10ffff);
     if (static_cast<uint32_t>(_mm256_movemask_epi8(
             _mm256_cmpeq_epi32(max_input, v_10ffff))) != 0xffffffff) {
-      return std::make_pair(result(error_code::TOO_LARGE, buf - start),
-                            utf8_output);
+      return simdutf::internal::make_pair(
+          result(error_code::TOO_LARGE, buf - start), utf8_output);
     }
 
     // Pack 32-bit UTF-32 code units to 16-bit UTF-16 code units with unsigned
@@ -411,8 +411,8 @@ avx512_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
           _mm256_cmpeq_epi16(_mm256_and_si256(in_16, v_f800), v_d800);
       if (static_cast<uint32_t>(_mm256_movemask_epi8(forbidden_bytemask)) !=
           0x0) {
-        return std::make_pair(result(error_code::SURROGATE, buf - start),
-                              utf8_output);
+        return simdutf::internal::make_pair(
+            result(error_code::SURROGATE, buf - start), utf8_output);
       }
 
       const __m256i dup_even = _mm256_setr_epi16(
@@ -549,7 +549,7 @@ avx512_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) { // 3-byte
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(
+            return simdutf::internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k), utf8_output);
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
@@ -557,7 +557,7 @@ avx512_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else { // 4-byte
           if (word > 0x10FFFF) {
-            return std::make_pair(
+            return simdutf::internal::make_pair(
                 result(error_code::TOO_LARGE, buf - start + k), utf8_output);
           }
           *utf8_output++ = char((word >> 18) | 0b11110000);
@@ -570,5 +570,6 @@ avx512_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
     }
   } // while
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start), utf8_output);
+  return simdutf::internal::make_pair(result(error_code::SUCCESS, buf - start),
+                                      utf8_output);
 }

--- a/src/icelake/icelake_convert_utf8_to_utf16.inl.cpp
+++ b/src/icelake/icelake_convert_utf8_to_utf16.inl.cpp
@@ -28,7 +28,7 @@ fast_avx512_convert_utf8_to_utf16(const char *in, size_t len, char16_t *out) {
   if (!result) {
     out = nullptr;
   }
-  return std::make_pair(in, out);
+  return simdutf::internal::make_pair(in, out);
 }
 
 template <endianness big_endian>

--- a/src/icelake/icelake_from_utf8.inl.cpp
+++ b/src/icelake/icelake_from_utf8.inl.cpp
@@ -5,10 +5,10 @@
 template <endianness big_endian, typename OUTPUT>
 // todo: replace with the utf-8 to utf-16 routine adapted to utf-32. This code
 // is legacy.
-std::pair<const char *, OUTPUT *>
+simdutf::internal::pair<const char *, OUTPUT *>
 validating_utf8_to_fixed_length(const char *str, size_t len, OUTPUT *dwords) {
-  constexpr bool UTF32 = std::is_same<OUTPUT, uint32_t>::value;
-  constexpr bool UTF16 = std::is_same<OUTPUT, char16_t>::value;
+  constexpr bool UTF32 = simdutf::internal::is_same<OUTPUT, uint32_t>::value;
+  constexpr bool UTF16 = simdutf::internal::is_same<OUTPUT, char16_t>::value;
   static_assert(
       UTF32 or UTF16,
       "output type has to be uint32_t (for UTF-32) or char16_t (for UTF-16)");
@@ -133,12 +133,12 @@ validating_utf8_to_fixed_length(const char *str, size_t len, OUTPUT *dwords) {
 // identified todo: replace with the utf-8 to utf-16 routine adapted to utf-32.
 // This code is legacy.
 template <endianness big_endian, typename OUTPUT>
-std::tuple<const char *, OUTPUT *, bool>
+simdutf::internal::tuple<const char *, OUTPUT *, bool>
 validating_utf8_to_fixed_length_with_constant_checks(const char *str,
                                                      size_t len,
                                                      OUTPUT *dwords) {
-  constexpr bool UTF32 = std::is_same<OUTPUT, uint32_t>::value;
-  constexpr bool UTF16 = std::is_same<OUTPUT, char16_t>::value;
+  constexpr bool UTF32 = simdutf::internal::is_same<OUTPUT, uint32_t>::value;
+  constexpr bool UTF16 = simdutf::internal::is_same<OUTPUT, char16_t>::value;
   static_assert(
       UTF32 or UTF16,
       "output type has to be uint32_t (for UTF-32) or char16_t (for UTF-16)");

--- a/src/icelake/icelake_from_valid_utf8.inl.cpp
+++ b/src/icelake/icelake_from_valid_utf8.inl.cpp
@@ -18,10 +18,10 @@
     - pair.second   - the first unprocessed output word
 */
 template <endianness big_endian, typename OUTPUT>
-std::pair<const char *, OUTPUT *>
+simdutf::internal::pair<const char *, OUTPUT *>
 valid_utf8_to_fixed_length(const char *str, size_t len, OUTPUT *dwords) {
-  constexpr bool UTF32 = std::is_same<OUTPUT, uint32_t>::value;
-  constexpr bool UTF16 = std::is_same<OUTPUT, char16_t>::value;
+  constexpr bool UTF32 = simdutf::internal::is_same<OUTPUT, uint32_t>::value;
+  constexpr bool UTF16 = simdutf::internal::is_same<OUTPUT, char16_t>::value;
   static_assert(
       UTF32 or UTF16,
       "output type has to be uint32_t (for UTF-32) or char16_t (for UTF-16)");
@@ -133,4 +133,4 @@ valid_utf8_to_fixed_length(const char *str, size_t len, OUTPUT *dwords) {
   return {ptr, output};
 }
 
-using utf8_to_utf16_result = std::pair<const char *, char16_t *>;
+using utf8_to_utf16_result = simdutf::internal::pair<const char *, char16_t *>;

--- a/src/icelake/icelake_utf8_common.inl.cpp
+++ b/src/icelake/icelake_utf8_common.inl.cpp
@@ -2,8 +2,8 @@
 // UTF-8.
 enum block_processing_mode { SIMDUTF_FULL, SIMDUTF_TAIL };
 
-using utf8_to_utf16_result = std::pair<const char *, char16_t *>;
-using utf8_to_utf32_result = std::pair<const char *, uint32_t *>;
+using utf8_to_utf16_result = simdutf::internal::pair<const char *, char16_t *>;
+using utf8_to_utf32_result = simdutf::internal::pair<const char *, uint32_t *>;
 
 /*
     process_block_utf8_to_utf16 converts up to 64 bytes from 'in' from UTF-8

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -1,5 +1,3 @@
-#include <tuple>
-#include <utility>
 #include "simdutf/icelake/intrinsics.h"
 
 #include "simdutf/icelake/begin.h"
@@ -82,7 +80,11 @@ using namespace simd;
   #include "icelake/icelake_find.inl.cpp"
 #endif // SIMDUTF_FEATURE_BASE64
 
-#include <cstdint>
+#ifndef SIMDUTF_NO_LIBCXX
+  #include <cstdint>
+#else
+  #include <stdint.h>
+#endif
 
 } // namespace
 } // namespace SIMDUTF_IMPLEMENTATION
@@ -875,8 +877,8 @@ simdutf_warn_unused result implementation::convert_utf8_to_utf32_with_errors(
   auto ret = icelake::validating_utf8_to_fixed_length_with_constant_checks<
       endianness::LITTLE, uint32_t>(buf, len, utf32_output);
 
-  if (!std::get<2>(ret)) {
-    size_t pos = std::get<0>(ret) - buf;
+  if (!simdutf::internal::get<2>(ret)) {
+    size_t pos = simdutf::internal::get<0>(ret) - buf;
     // We might have an error that occurs right before  pos.
     // This is only a concern if buf[pos] is not a continuation byte.
     if ((buf[pos] & 0xc0) != 0x80 && pos >= 64) {
@@ -890,7 +892,8 @@ simdutf_warn_unused result implementation::convert_utf8_to_utf32_with_errors(
         return {simdutf::TOO_LONG, pos};
       }
     }
-    // todo: we reset the output to utf32 instead of using std::get<2.(ret) as
+    // todo: we reset the output to utf32 instead of using
+    // simdutf::internal::get<1>(ret) as
     // you'd expect. that is because
     // validating_utf8_to_fixed_length_with_constant_checks may have processed
     // data beyond the error.
@@ -899,9 +902,9 @@ simdutf_warn_unused result implementation::convert_utf8_to_utf32_with_errors(
     res.count += pos;
     return res;
   }
-  size_t saved_bytes = std::get<1>(ret) - utf32_output;
+  size_t saved_bytes = simdutf::internal::get<1>(ret) - utf32_output;
   const char *end = buf + len;
-  if (std::get<0>(ret) == end) {
+  if (simdutf::internal::get<0>(ret) == end) {
     return {simdutf::SUCCESS, saved_bytes};
   }
 
@@ -910,24 +913,26 @@ simdutf_warn_unused result implementation::convert_utf8_to_utf32_with_errors(
   //       continuation bytes lie outside 16-byte window.
   //       It means, we have to skip continuation bytes from
   //       the beginning ret.first, as they were already consumed.
-  while (std::get<0>(ret) != end and
-         ((uint8_t(*std::get<0>(ret)) & 0xc0) == 0x80)) {
-    std::get<0>(ret) += 1;
+  while (simdutf::internal::get<0>(ret) != end and
+         ((uint8_t(*simdutf::internal::get<0>(ret)) & 0xc0) == 0x80)) {
+    simdutf::internal::get<0>(ret) += 1;
   }
 
-  if (std::get<0>(ret) != end) {
+  if (simdutf::internal::get<0>(ret) != end) {
     auto scalar_result = scalar::utf8_to_utf32::convert_with_errors(
-        std::get<0>(ret), len - (std::get<0>(ret) - buf),
+        simdutf::internal::get<0>(ret),
+        len - (simdutf::internal::get<0>(ret) - buf),
         reinterpret_cast<char32_t *>(utf32_output) + saved_bytes);
     if (scalar_result.error != simdutf::SUCCESS) {
-      scalar_result.count += (std::get<0>(ret) - buf);
+      scalar_result.count += (simdutf::internal::get<0>(ret) - buf);
     } else {
       scalar_result.count += saved_bytes;
     }
     return scalar_result;
   }
 
-  return {simdutf::SUCCESS, size_t(std::get<1>(ret) - utf32_output)};
+  return {simdutf::SUCCESS,
+          size_t(simdutf::internal::get<1>(ret) - utf32_output)};
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf32(
@@ -1089,8 +1094,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf32_to_latin1(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf8(
     const char32_t *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char32_t *, char *> ret =
-      avx512_convert_utf32_to_utf8(buf, len, utf8_output);
+  auto ret = avx512_convert_utf32_to_utf8(buf, len, utf8_output);
   if (ret.first == nullptr) {
     return 0;
   }
@@ -1110,7 +1114,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
     const char32_t *buf, size_t len, char *utf8_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  auto ret =
       icelake::avx512_convert_utf32_to_utf8_with_errors(buf, len, utf8_output);
   if (ret.first.count != len) {
     result scalar_res = scalar::utf32_to_utf8::convert_with_errors(
@@ -1137,7 +1141,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf32_to_utf8(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf16le(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char32_t *, char16_t *> ret =
+  auto ret =
       avx512_convert_utf32_to_utf16<endianness::LITTLE>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -1148,7 +1152,7 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_utf16le(
 
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf16be(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char32_t *, char16_t *> ret =
+  auto ret =
       avx512_convert_utf32_to_utf16<endianness::BIG>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -1161,9 +1165,8 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf16le_with_errors(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char16_t *> ret =
-      avx512_convert_utf32_to_utf16_with_errors<endianness::LITTLE>(
-          buf, len, utf16_output);
+  auto ret = avx512_convert_utf32_to_utf16_with_errors<endianness::LITTLE>(
+      buf, len, utf16_output);
   if (ret.first.error) {
     return ret.first;
   }
@@ -1177,9 +1180,8 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf16be_with_errors(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char16_t *> ret =
-      avx512_convert_utf32_to_utf16_with_errors<endianness::BIG>(buf, len,
-                                                                 utf16_output);
+  auto ret = avx512_convert_utf32_to_utf16_with_errors<endianness::BIG>(
+      buf, len, utf16_output);
   if (ret.first.error) {
     return ret.first;
   }
@@ -1201,17 +1203,18 @@ simdutf_warn_unused size_t implementation::convert_valid_utf32_to_utf16be(
 
 simdutf_warn_unused size_t implementation::convert_utf16le_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::tuple<const char16_t *, char32_t *, bool> ret =
-      icelake::convert_utf16_to_utf32<endianness::LITTLE>(buf, len,
-                                                          utf32_output);
-  if (!std::get<2>(ret)) {
+  auto ret = icelake::convert_utf16_to_utf32<endianness::LITTLE>(buf, len,
+                                                                 utf32_output);
+  if (!simdutf::internal::get<2>(ret)) {
     return 0;
   }
-  size_t saved_bytes = std::get<1>(ret) - utf32_output;
-  if (std::get<0>(ret) != buf + len) {
+  size_t saved_bytes = simdutf::internal::get<1>(ret) - utf32_output;
+  if (simdutf::internal::get<0>(ret) != buf + len) {
     const size_t scalar_saved_bytes =
         scalar::utf16_to_utf32::convert<endianness::LITTLE>(
-            std::get<0>(ret), len - (std::get<0>(ret) - buf), std::get<1>(ret));
+            simdutf::internal::get<0>(ret),
+            len - (simdutf::internal::get<0>(ret) - buf),
+            simdutf::internal::get<1>(ret));
     if (scalar_saved_bytes == 0) {
       return 0;
     }
@@ -1222,16 +1225,18 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_utf32(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::tuple<const char16_t *, char32_t *, bool> ret =
+  auto ret =
       icelake::convert_utf16_to_utf32<endianness::BIG>(buf, len, utf32_output);
-  if (!std::get<2>(ret)) {
+  if (!simdutf::internal::get<2>(ret)) {
     return 0;
   }
-  size_t saved_bytes = std::get<1>(ret) - utf32_output;
-  if (std::get<0>(ret) != buf + len) {
+  size_t saved_bytes = simdutf::internal::get<1>(ret) - utf32_output;
+  if (simdutf::internal::get<0>(ret) != buf + len) {
     const size_t scalar_saved_bytes =
         scalar::utf16_to_utf32::convert<endianness::BIG>(
-            std::get<0>(ret), len - (std::get<0>(ret) - buf), std::get<1>(ret));
+            simdutf::internal::get<0>(ret),
+            len - (simdutf::internal::get<0>(ret) - buf),
+            simdutf::internal::get<1>(ret));
     if (scalar_saved_bytes == 0) {
       return 0;
     }
@@ -1242,23 +1247,26 @@ simdutf_warn_unused size_t implementation::convert_utf16be_to_utf32(
 
 simdutf_warn_unused result implementation::convert_utf16le_to_utf32_with_errors(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::tuple<const char16_t *, char32_t *, bool> ret =
-      icelake::convert_utf16_to_utf32<endianness::LITTLE>(buf, len,
-                                                          utf32_output);
-  if (!std::get<2>(ret)) {
+  auto ret = icelake::convert_utf16_to_utf32<endianness::LITTLE>(buf, len,
+                                                                 utf32_output);
+  if (!simdutf::internal::get<2>(ret)) {
     result scalar_res =
         scalar::utf16_to_utf32::convert_with_errors<endianness::LITTLE>(
-            std::get<0>(ret), len - (std::get<0>(ret) - buf), std::get<1>(ret));
-    scalar_res.count += (std::get<0>(ret) - buf);
+            simdutf::internal::get<0>(ret),
+            len - (simdutf::internal::get<0>(ret) - buf),
+            simdutf::internal::get<1>(ret));
+    scalar_res.count += (simdutf::internal::get<0>(ret) - buf);
     return scalar_res;
   }
-  size_t saved_bytes = std::get<1>(ret) - utf32_output;
-  if (std::get<0>(ret) != buf + len) {
+  size_t saved_bytes = simdutf::internal::get<1>(ret) - utf32_output;
+  if (simdutf::internal::get<0>(ret) != buf + len) {
     result scalar_res =
         scalar::utf16_to_utf32::convert_with_errors<endianness::LITTLE>(
-            std::get<0>(ret), len - (std::get<0>(ret) - buf), std::get<1>(ret));
+            simdutf::internal::get<0>(ret),
+            len - (simdutf::internal::get<0>(ret) - buf),
+            simdutf::internal::get<1>(ret));
     if (scalar_res.error) {
-      scalar_res.count += (std::get<0>(ret) - buf);
+      scalar_res.count += (simdutf::internal::get<0>(ret) - buf);
       return scalar_res;
     } else {
       scalar_res.count += saved_bytes;
@@ -1270,22 +1278,26 @@ simdutf_warn_unused result implementation::convert_utf16le_to_utf32_with_errors(
 
 simdutf_warn_unused result implementation::convert_utf16be_to_utf32_with_errors(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::tuple<const char16_t *, char32_t *, bool> ret =
+  auto ret =
       icelake::convert_utf16_to_utf32<endianness::BIG>(buf, len, utf32_output);
-  if (!std::get<2>(ret)) {
+  if (!simdutf::internal::get<2>(ret)) {
     result scalar_res =
         scalar::utf16_to_utf32::convert_with_errors<endianness::BIG>(
-            std::get<0>(ret), len - (std::get<0>(ret) - buf), std::get<1>(ret));
-    scalar_res.count += (std::get<0>(ret) - buf);
+            simdutf::internal::get<0>(ret),
+            len - (simdutf::internal::get<0>(ret) - buf),
+            simdutf::internal::get<1>(ret));
+    scalar_res.count += (simdutf::internal::get<0>(ret) - buf);
     return scalar_res;
   }
-  size_t saved_bytes = std::get<1>(ret) - utf32_output;
-  if (std::get<0>(ret) != buf + len) {
+  size_t saved_bytes = simdutf::internal::get<1>(ret) - utf32_output;
+  if (simdutf::internal::get<0>(ret) != buf + len) {
     result scalar_res =
         scalar::utf16_to_utf32::convert_with_errors<endianness::BIG>(
-            std::get<0>(ret), len - (std::get<0>(ret) - buf), std::get<1>(ret));
+            simdutf::internal::get<0>(ret),
+            len - (simdutf::internal::get<0>(ret) - buf),
+            simdutf::internal::get<1>(ret));
     if (scalar_res.error) {
-      scalar_res.count += (std::get<0>(ret) - buf);
+      scalar_res.count += (simdutf::internal::get<0>(ret) - buf);
       return scalar_res;
     } else {
       scalar_res.count += saved_bytes;
@@ -1297,17 +1309,18 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf32_with_errors(
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::tuple<const char16_t *, char32_t *, bool> ret =
-      icelake::convert_utf16_to_utf32<endianness::LITTLE>(buf, len,
-                                                          utf32_output);
-  if (!std::get<2>(ret)) {
+  auto ret = icelake::convert_utf16_to_utf32<endianness::LITTLE>(buf, len,
+                                                                 utf32_output);
+  if (!simdutf::internal::get<2>(ret)) {
     return 0;
   }
-  size_t saved_bytes = std::get<1>(ret) - utf32_output;
-  if (std::get<0>(ret) != buf + len) {
+  size_t saved_bytes = simdutf::internal::get<1>(ret) - utf32_output;
+  if (simdutf::internal::get<0>(ret) != buf + len) {
     const size_t scalar_saved_bytes =
         scalar::utf16_to_utf32::convert<endianness::LITTLE>(
-            std::get<0>(ret), len - (std::get<0>(ret) - buf), std::get<1>(ret));
+            simdutf::internal::get<0>(ret),
+            len - (simdutf::internal::get<0>(ret) - buf),
+            simdutf::internal::get<1>(ret));
     if (scalar_saved_bytes == 0) {
       return 0;
     }
@@ -1318,16 +1331,18 @@ simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_utf32(
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16be_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::tuple<const char16_t *, char32_t *, bool> ret =
+  auto ret =
       icelake::convert_utf16_to_utf32<endianness::BIG>(buf, len, utf32_output);
-  if (!std::get<2>(ret)) {
+  if (!simdutf::internal::get<2>(ret)) {
     return 0;
   }
-  size_t saved_bytes = std::get<1>(ret) - utf32_output;
-  if (std::get<0>(ret) != buf + len) {
+  size_t saved_bytes = simdutf::internal::get<1>(ret) - utf32_output;
+  if (simdutf::internal::get<0>(ret) != buf + len) {
     const size_t scalar_saved_bytes =
         scalar::utf16_to_utf32::convert<endianness::BIG>(
-            std::get<0>(ret), len - (std::get<0>(ret) - buf), std::get<1>(ret));
+            simdutf::internal::get<0>(ret),
+            len - (simdutf::internal::get<0>(ret) - buf),
+            simdutf::internal::get<1>(ret));
     if (scalar_saved_bytes == 0) {
       return 0;
     }

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1,10 +1,23 @@
 #include "simdutf.h"
-#include <initializer_list>
-#include <climits>
-#include <type_traits>
+#ifdef SIMDUTF_NO_LIBCXX
+  #include <limits.h>
+#else
+  #include <climits>
+  #include <type_traits>
+#endif
 #if SIMDUTF_ATOMIC_REF
-  #include <array>
   #include "simdutf/scalar/atomic_util.h"
+#endif
+
+#ifdef SIMDUTF_NO_LIBCXX
+// The abstract implementation vtable still carries pure-virtual slots even
+// though correct dispatch never reaches them in this build mode. Provide the
+// narrowest possible ABI shim so stricter no-libcxx objects do not require
+// libc++abi just for this unreachable hook. Keep it weak so a toolchain's real
+// libc++abi definition wins if one is linked in anyway.
+extern "C" SIMDUTF_WEAK [[noreturn]] void __cxa_pure_virtual() noexcept {
+  __builtin_trap();
+}
 #endif
 
 static_assert(sizeof(uint8_t) == sizeof(char),
@@ -16,21 +29,16 @@ static_assert(sizeof(uint32_t) == sizeof(char32_t),
 // next line is redundant, but it is kept to catch defective systems.
 static_assert(CHAR_BIT == 8, "simdutf requires 8-bit bytes");
 
-// Useful for debugging purposes
-namespace simdutf {
-namespace {
-
-template <typename T> std::string toBinaryString(T b) {
-  std::string binary = "";
-  T mask = T(1) << (sizeof(T) * CHAR_BIT - 1);
-  while (mask > 0) {
-    binary += ((b & mask) == 0) ? '0' : '1';
-    mask >>= 1;
-  }
-  return binary;
-}
-} // namespace
-} // namespace simdutf
+#ifdef SIMDUTF_NO_LIBCXX
+  #ifdef __clang__
+    #define SIMDUTF_TRIVIALLY_DESTRUCTIBLE(T) __is_trivially_destructible(T)
+  #else
+    #define SIMDUTF_TRIVIALLY_DESTRUCTIBLE(T) __has_trivial_destructor(T)
+  #endif
+#else
+  #define SIMDUTF_TRIVIALLY_DESTRUCTIBLE(T)                                    \
+    std::is_trivially_destructible<T>::value
+#endif
 
 namespace simdutf {
 bool implementation::supported_by_runtime_system() const {
@@ -122,61 +130,165 @@ namespace internal {
        SIMDUTF_IMPLEMENTATION_LASX + SIMDUTF_IMPLEMENTATION_FALLBACK ==        \
    1)
 
+enum : size_t {
+  implementation_count =
+#if SIMDUTF_IMPLEMENTATION_ICELAKE
+      1 +
+#endif
+#if SIMDUTF_IMPLEMENTATION_HASWELL
+      1 +
+#endif
+#if SIMDUTF_IMPLEMENTATION_WESTMERE
+      1 +
+#endif
+#if SIMDUTF_IMPLEMENTATION_ARM64
+      1 +
+#endif
+#if SIMDUTF_IMPLEMENTATION_PPC64
+      1 +
+#endif
+#if SIMDUTF_IMPLEMENTATION_RVV
+      1 +
+#endif
+#if SIMDUTF_IMPLEMENTATION_LSX
+      1 +
+#endif
+#if SIMDUTF_IMPLEMENTATION_LASX
+      1 +
+#endif
+#if SIMDUTF_IMPLEMENTATION_FALLBACK
+      1 +
+#endif
+      0
+};
+
 // Static array of known implementations. We are hoping these get baked into the
 // executable without requiring a static initializer.
+//
+// For no libc++ builds:
+//
+// Keep the existing getter-based dispatch code, but hoist the backend
+// singletons out of function-local static variables so this stricter ABI path
+// does not emit thread-safe local-static guards (`__cxa_guard_*`). That is
+// acceptable here because these backend objects are just cheap metadata
+// wrappers, so eager translation-unit initialization is not a meaningful
+// startup cost.
 
 #if SIMDUTF_IMPLEMENTATION_ICELAKE
+  #ifdef SIMDUTF_NO_LIBCXX
+static const icelake::implementation icelake_singleton{};
+  #endif
 static const icelake::implementation *get_icelake_singleton() {
+  #ifdef SIMDUTF_NO_LIBCXX
+  return &icelake_singleton;
+  #else
   static const icelake::implementation icelake_singleton{};
   return &icelake_singleton;
+  #endif
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_HASWELL
+  #ifdef SIMDUTF_NO_LIBCXX
+static const haswell::implementation haswell_singleton{};
+  #endif
 static const haswell::implementation *get_haswell_singleton() {
+  #ifdef SIMDUTF_NO_LIBCXX
+  return &haswell_singleton;
+  #else
   static const haswell::implementation haswell_singleton{};
   return &haswell_singleton;
+  #endif
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_WESTMERE
+  #ifdef SIMDUTF_NO_LIBCXX
+static const westmere::implementation westmere_singleton{};
+  #endif
 static const westmere::implementation *get_westmere_singleton() {
+  #ifdef SIMDUTF_NO_LIBCXX
+  return &westmere_singleton;
+  #else
   static const westmere::implementation westmere_singleton{};
   return &westmere_singleton;
+  #endif
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_ARM64
+  #ifdef SIMDUTF_NO_LIBCXX
+static const arm64::implementation arm64_singleton{};
+  #endif
 static const arm64::implementation *get_arm64_singleton() {
+  #ifdef SIMDUTF_NO_LIBCXX
+  return &arm64_singleton;
+  #else
   static const arm64::implementation arm64_singleton{};
   return &arm64_singleton;
+  #endif
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_PPC64
+  #ifdef SIMDUTF_NO_LIBCXX
+static const ppc64::implementation ppc64_singleton{};
+  #endif
 static const ppc64::implementation *get_ppc64_singleton() {
+  #ifdef SIMDUTF_NO_LIBCXX
+  return &ppc64_singleton;
+  #else
   static const ppc64::implementation ppc64_singleton{};
   return &ppc64_singleton;
+  #endif
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_RVV
+  #ifdef SIMDUTF_NO_LIBCXX
+static const rvv::implementation rvv_singleton{};
+  #endif
 static const rvv::implementation *get_rvv_singleton() {
+  #ifdef SIMDUTF_NO_LIBCXX
+  return &rvv_singleton;
+  #else
   static const rvv::implementation rvv_singleton{};
   return &rvv_singleton;
+  #endif
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_LASX
+  #ifdef SIMDUTF_NO_LIBCXX
+static const lasx::implementation lasx_singleton{};
+  #endif
 static const lasx::implementation *get_lasx_singleton() {
+  #ifdef SIMDUTF_NO_LIBCXX
+  return &lasx_singleton;
+  #else
   static const lasx::implementation lasx_singleton{};
   return &lasx_singleton;
+  #endif
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_LSX
+  #ifdef SIMDUTF_NO_LIBCXX
+static const lsx::implementation lsx_singleton{};
+  #endif
 static const lsx::implementation *get_lsx_singleton() {
+  #ifdef SIMDUTF_NO_LIBCXX
+  return &lsx_singleton;
+  #else
   static const lsx::implementation lsx_singleton{};
   return &lsx_singleton;
+  #endif
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_FALLBACK
+  #ifdef SIMDUTF_NO_LIBCXX
+static const fallback::implementation fallback_singleton{};
+  #endif
 static const fallback::implementation *get_fallback_singleton() {
+  #ifdef SIMDUTF_NO_LIBCXX
+  return &fallback_singleton;
+  #else
   static const fallback::implementation fallback_singleton{};
   return &fallback_singleton;
+  #endif
 }
 #endif
 
@@ -216,8 +328,13 @@ simdutf_really_inline static const implementation *get_single_implementation() {
 class detect_best_supported_implementation_on_first_use final
     : public implementation {
 public:
+#ifdef SIMDUTF_NO_LIBCXX
+  const char *name() const noexcept final { return set_best()->name(); }
+  const char *description() const noexcept final {
+#else
   std::string name() const noexcept final { return set_best()->name(); }
   std::string description() const noexcept final {
+#endif
     return set_best()->description();
   }
   uint32_t required_instruction_sets() const noexcept final {
@@ -822,44 +939,86 @@ private:
   const implementation *set_best() const noexcept;
 };
 
-static_assert(std::is_trivially_destructible<
-                  detect_best_supported_implementation_on_first_use>::value,
+static_assert(SIMDUTF_TRIVIALLY_DESTRUCTIBLE(
+                  detect_best_supported_implementation_on_first_use),
               "detect_best_supported_implementation_on_first_use should be "
               "trivially destructible");
 
-static const std::initializer_list<const implementation *> &
+using implementation_pointer_array =
+    array<const implementation *, implementation_count>;
+
+#ifdef SIMDUTF_NO_LIBCXX
+// In the stricter no-libcxx mode, keep the backend list in translation-unit
+// storage so we do not pay for thread-safe local-static guards. The order here
+// still defines both the public iteration order and the runtime detection
+// priority.
+static const implementation_pointer_array available_implementation_pointers{{
+  #if SIMDUTF_IMPLEMENTATION_ICELAKE
+  get_icelake_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_HASWELL
+  get_haswell_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_WESTMERE
+  get_westmere_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_ARM64
+  get_arm64_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_PPC64
+  get_ppc64_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_RVV
+  get_rvv_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_LASX
+  get_lasx_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_LSX
+  get_lsx_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_FALLBACK
+  get_fallback_singleton(),
+  #endif
+}}; // available_implementation_pointers
+#endif
+
+static const implementation_pointer_array &
 get_available_implementation_pointers() {
-  static const std::initializer_list<const implementation *>
-      available_implementation_pointers{
-#if SIMDUTF_IMPLEMENTATION_ICELAKE
-          get_icelake_singleton(),
-#endif
-#if SIMDUTF_IMPLEMENTATION_HASWELL
-          get_haswell_singleton(),
-#endif
-#if SIMDUTF_IMPLEMENTATION_WESTMERE
-          get_westmere_singleton(),
-#endif
-#if SIMDUTF_IMPLEMENTATION_ARM64
-          get_arm64_singleton(),
-#endif
-#if SIMDUTF_IMPLEMENTATION_PPC64
-          get_ppc64_singleton(),
-#endif
-#if SIMDUTF_IMPLEMENTATION_RVV
-          get_rvv_singleton(),
-#endif
-#if SIMDUTF_IMPLEMENTATION_LASX
-          get_lasx_singleton(),
-#endif
-#if SIMDUTF_IMPLEMENTATION_LSX
-          get_lsx_singleton(),
-#endif
-#if SIMDUTF_IMPLEMENTATION_FALLBACK
-          get_fallback_singleton(),
-#endif
-      }; // available_implementation_pointers
+#ifdef SIMDUTF_NO_LIBCXX
   return available_implementation_pointers;
+#else
+  static const implementation_pointer_array available_implementation_pointers{{
+  #if SIMDUTF_IMPLEMENTATION_ICELAKE
+      get_icelake_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_HASWELL
+      get_haswell_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_WESTMERE
+      get_westmere_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_ARM64
+      get_arm64_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_PPC64
+      get_ppc64_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_RVV
+      get_rvv_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_LASX
+      get_lasx_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_LSX
+      get_lsx_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_FALLBACK
+      get_fallback_singleton(),
+  #endif
+  }}; // available_implementation_pointers
+  return available_implementation_pointers;
+#endif
 }
 
 // So we can return UNSUPPORTED_ARCHITECTURE from the parser when there is no
@@ -1380,11 +1539,19 @@ public:
                        "Unsupported CPU (no detected SIMD instructions)", 0) {}
 };
 
+#ifdef SIMDUTF_NO_LIBCXX
+static const unsupported_implementation unsupported_singleton{};
+#endif
+
 const unsupported_implementation *get_unsupported_singleton() {
+#ifdef SIMDUTF_NO_LIBCXX
+  return &unsupported_singleton;
+#else
   static const unsupported_implementation unsupported_singleton{};
   return &unsupported_singleton;
+#endif
 }
-static_assert(std::is_trivially_destructible<unsupported_implementation>::value,
+static_assert(SIMDUTF_TRIVIALLY_DESTRUCTIBLE(unsupported_implementation),
               "unsupported_singleton should be trivially destructible");
 
 size_t available_implementation_list::size() const noexcept {
@@ -1392,11 +1559,13 @@ size_t available_implementation_list::size() const noexcept {
 }
 const implementation *const *
 available_implementation_list::begin() const noexcept {
-  return internal::get_available_implementation_pointers().begin();
+  return internal::get_available_implementation_pointers().data();
 }
 const implementation *const *
 available_implementation_list::end() const noexcept {
-  return internal::get_available_implementation_pointers().end();
+  const auto &implementations =
+      internal::get_available_implementation_pointers();
+  return implementations.data() + implementations.size();
 }
 const implementation *
 available_implementation_list::detect_best_supported() const noexcept {
@@ -1438,14 +1607,38 @@ detect_best_supported_implementation_on_first_use::set_best() const noexcept {
 
 } // namespace internal
 
+#ifdef SIMDUTF_NO_LIBCXX
+// Mirror the default-build getters with translation-unit storage so this path
+// preserves the same first-use dispatch model without emitting __cxa_guard_*
+// for local static variables. Multi-backend builds still begin at the detector
+// sentinel, while single-backend builds still point directly at the only
+// implementation.
+static const internal::available_implementation_list
+    available_implementations{};
+
+  #if SIMDUTF_SINGLE_IMPLEMENTATION
+static internal::atomic_ptr<const implementation> active_implementation_storage{
+    internal::get_single_implementation()};
+  #else
+static const internal::detect_best_supported_implementation_on_first_use
+    detect_best_supported_implementation_on_first_use_singleton;
+static internal::atomic_ptr<const implementation> active_implementation_storage{
+    &detect_best_supported_implementation_on_first_use_singleton};
+  #endif
+#endif
+
 /**
  * The list of available implementations compiled into simdutf.
  */
 SIMDUTF_DLLIMPORTEXPORT const internal::available_implementation_list &
 get_available_implementations() {
+#ifdef SIMDUTF_NO_LIBCXX
+  return available_implementations;
+#else
   static const internal::available_implementation_list
       available_implementations{};
   return available_implementations;
+#endif
 }
 
 /**
@@ -1453,17 +1646,21 @@ get_available_implementations() {
  */
 SIMDUTF_DLLIMPORTEXPORT internal::atomic_ptr<const implementation> &
 get_active_implementation() {
-#if SIMDUTF_SINGLE_IMPLEMENTATION
+#ifdef SIMDUTF_NO_LIBCXX
+  return active_implementation_storage;
+#else
+  #if SIMDUTF_SINGLE_IMPLEMENTATION
   // skip runtime detection
   static internal::atomic_ptr<const implementation> active_implementation{
       internal::get_single_implementation()};
   return active_implementation;
-#else
+  #else
   static const internal::detect_best_supported_implementation_on_first_use
       detect_best_supported_implementation_on_first_use_singleton;
   static internal::atomic_ptr<const implementation> active_implementation{
       &detect_best_supported_implementation_on_first_use_singleton};
   return active_implementation;
+  #endif
 #endif
 }
 
@@ -1674,7 +1871,7 @@ simdutf_warn_unused result atomic_base64_to_binary_safe_impl(
   // Arbitrary block sizes: 4KB for input.
   constexpr size_t buffer_size = 4096;
     #endif
-  std::array<char, buffer_size> temp_buffer;
+  internal::array<char, buffer_size> temp_buffer;
   const char_type *const input_init = input;
   size_t actual_out = 0;
   bool last_chunk = false;
@@ -1682,7 +1879,8 @@ simdutf_warn_unused result atomic_base64_to_binary_safe_impl(
   result r;
   while (!last_chunk) {
     last_chunk |= (temp_buffer.size() >= outlen - actual_out);
-    size_t temp_outlen = (std::min)(temp_buffer.size(), outlen - actual_out);
+    size_t temp_outlen =
+        internal::min_value(temp_buffer.size(), outlen - actual_out);
     r = base64_to_binary_safe(input, length, temp_buffer.data(), temp_outlen,
                               options, last_chunk_handling_options,
                               decode_up_to_bad_char);
@@ -1837,7 +2035,7 @@ convert_utf16_to_utf8_safe(const char16_t *buf, size_t len, char *utf8_output,
     // The worst case for convert_utf16_to_utf8 is when you go from 1 char16_t
     // to 3 characters of UTF-8. So we can read at most utf8_len / 3 char16_t
     // characters.
-    auto read_len = std::min(len, utf8_len / 3);
+    auto read_len = internal::min_value(len, utf8_len / 3);
     if (read_len <= 16) {
       break;
     }
@@ -2414,9 +2612,10 @@ size_t atomic_binary_to_base64(const char *input, size_t length, char *output,
   // Arbitrary block sizes: 3KB for input which produces 4KB in output.
   constexpr size_t input_block_size = 1024 * 3;
     #endif
-  std::array<char, input_block_size> inbuf;
+  internal::array<char, input_block_size> inbuf;
   for (size_t i = 0; i < length; i += input_block_size) {
-    const size_t current_block_size = std::min(input_block_size, length - i);
+    size_t current_block_size =
+        internal::min_value(input_block_size, length - i);
     simdutf::scalar::memcpy_atomic_read(inbuf.data(), input + i,
                                         current_block_size);
     const size_t written = binary_to_base64(inbuf.data(), current_block_size,
@@ -2436,7 +2635,7 @@ simdutf_warn_unused size_t convert_latin1_to_utf8_safe(
 
   while (true) {
     // convert_latin1_to_utf8 will never write more than input length * 2
-    auto read_len = std::min(len, utf8_len >> 1);
+    auto read_len = internal::min_value(len, utf8_len >> 1);
     if (read_len <= 16) {
       break;
     }
@@ -2504,10 +2703,15 @@ simdutf_warn_unused int detect_encodings(const char *buf,
 #endif // SIMDUTF_FEATURE_DETECT_ENCODING
 
 const implementation *builtin_implementation() {
+#ifdef SIMDUTF_NO_LIBCXX
+  return get_available_implementations()[SIMDUTF_STRINGIFY(
+      SIMDUTF_BUILTIN_IMPLEMENTATION)];
+#else
   static const implementation *builtin_impl =
       get_available_implementations()[SIMDUTF_STRINGIFY(
           SIMDUTF_BUILTIN_IMPLEMENTATION)];
   return builtin_impl;
+#endif
 }
 
 #if SIMDUTF_FEATURE_UTF8

--- a/src/lasx/implementation.cpp
+++ b/src/lasx/implementation.cpp
@@ -427,7 +427,7 @@ simdutf_warn_unused result implementation::validate_utf32_with_errors(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(
     const char *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char *, char *> ret =
+  internal::pair<const char *, char *> ret =
       lasx_convert_latin1_to_utf8(buf, len, utf8_output);
   size_t converted_chars = ret.second - utf8_output;
 
@@ -443,7 +443,7 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16le(
     const char *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char *, char16_t *> ret =
+  internal::pair<const char *, char16_t *> ret =
       lasx_convert_latin1_to_utf16le(buf, len, utf16_output);
   size_t converted_chars = ret.second - utf16_output;
   if (ret.first != buf + len) {
@@ -457,7 +457,7 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf16le(
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(
     const char *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char *, char16_t *> ret =
+  internal::pair<const char *, char16_t *> ret =
       lasx_convert_latin1_to_utf16be(buf, len, utf16_output);
   size_t converted_chars = ret.second - utf16_output;
   if (ret.first != buf + len) {
@@ -473,7 +473,7 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf32(
     const char *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char *, char32_t *> ret =
+  internal::pair<const char *, char32_t *> ret =
       lasx_convert_latin1_to_utf32(buf, len, utf32_output);
   size_t converted_chars = ret.second - utf32_output;
   if (ret.first != buf + len) {
@@ -663,7 +663,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf32(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       lasx_convert_utf16_to_latin1<endianness::LITTLE>(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -684,7 +684,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       lasx_convert_utf16_to_latin1<endianness::BIG>(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -706,7 +706,7 @@ simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(
 simdutf_warn_unused result
 implementation::convert_utf16le_to_latin1_with_errors(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       lasx_convert_utf16_to_latin1_with_errors<endianness::LITTLE>(
           buf, len, latin1_output);
   if (ret.first.error) {
@@ -733,7 +733,7 @@ implementation::convert_utf16le_to_latin1_with_errors(
 simdutf_warn_unused result
 implementation::convert_utf16be_to_latin1_with_errors(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       lasx_convert_utf16_to_latin1_with_errors<endianness::BIG>(buf, len,
                                                                 latin1_output);
   if (ret.first.error) {
@@ -773,7 +773,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_latin1(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t implementation::convert_utf16le_to_utf8(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       lasx_convert_utf16_to_utf8<endianness::LITTLE>(buf, len, utf8_output);
   if (ret.first == nullptr) {
     return 0;
@@ -793,7 +793,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_utf8(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_utf8(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       lasx_convert_utf16_to_utf8<endianness::BIG>(buf, len, utf8_output);
   if (ret.first == nullptr) {
     return 0;
@@ -815,7 +815,7 @@ simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       lasx_convert_utf16_to_utf8_with_errors<endianness::LITTLE>(buf, len,
                                                                  utf8_output);
   if (ret.first.error) {
@@ -843,7 +843,7 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       lasx_convert_utf16_to_utf8_with_errors<endianness::BIG>(buf, len,
                                                               utf8_output);
   if (ret.first.error) {
@@ -884,7 +884,7 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_utf8(
   if (simdutf_unlikely(len == 0)) {
     return 0;
   }
-  std::pair<const char32_t *, char *> ret =
+  internal::pair<const char32_t *, char *> ret =
       lasx_convert_utf32_to_utf8(buf, len, utf8_output);
   if (ret.first == nullptr) {
     return 0;
@@ -908,7 +908,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
   }
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       lasx_convert_utf32_to_utf8_with_errors(buf, len, utf8_output);
   if (ret.first.count != len) {
     result scalar_res = scalar::utf32_to_utf8::convert_with_errors(
@@ -930,7 +930,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::convert_utf16le_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char16_t *, char32_t *> ret =
+  internal::pair<const char16_t *, char32_t *> ret =
       lasx_convert_utf16_to_utf32<endianness::LITTLE>(buf, len, utf32_output);
   if (ret.first == nullptr) {
     return 0;
@@ -950,7 +950,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_utf32(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char16_t *, char32_t *> ret =
+  internal::pair<const char16_t *, char32_t *> ret =
       lasx_convert_utf16_to_utf32<endianness::BIG>(buf, len, utf32_output);
   if (ret.first == nullptr) {
     return 0;
@@ -972,7 +972,7 @@ simdutf_warn_unused result implementation::convert_utf16le_to_utf32_with_errors(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char32_t *> ret =
+  internal::pair<result, char32_t *> ret =
       lasx_convert_utf16_to_utf32_with_errors<endianness::LITTLE>(buf, len,
                                                                   utf32_output);
   if (ret.first.error) {
@@ -1000,7 +1000,7 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf32_with_errors(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char32_t *> ret =
+  internal::pair<result, char32_t *> ret =
       lasx_convert_utf16_to_utf32_with_errors<endianness::BIG>(buf, len,
                                                                utf32_output);
   if (ret.first.error) {
@@ -1028,7 +1028,7 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf32_with_errors(
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_utf32_to_latin1(
     const char32_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char32_t *, char *> ret =
+  internal::pair<const char32_t *, char *> ret =
       lasx_convert_utf32_to_latin1(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -1048,7 +1048,7 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_latin1(
 
 simdutf_warn_unused result implementation::convert_utf32_to_latin1_with_errors(
     const char32_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       lasx_convert_utf32_to_latin1_with_errors(buf, len, latin1_output);
   if (ret.first.error) {
     return ret.first;
@@ -1072,7 +1072,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_latin1_with_errors(
 
 simdutf_warn_unused size_t implementation::convert_valid_utf32_to_latin1(
     const char32_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char32_t *, char *> ret =
+  internal::pair<const char32_t *, char *> ret =
       lasx_convert_utf32_to_latin1(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -1099,7 +1099,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf32_to_utf8(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf16le(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char32_t *, char16_t *> ret =
+  internal::pair<const char32_t *, char16_t *> ret =
       lasx_convert_utf32_to_utf16<endianness::LITTLE>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -1120,7 +1120,7 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_utf16le(
 
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf16be(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char32_t *, char16_t *> ret =
+  internal::pair<const char32_t *, char16_t *> ret =
       lasx_convert_utf32_to_utf16<endianness::BIG>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -1142,7 +1142,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf16le_with_errors(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char16_t *> ret =
+  internal::pair<result, char16_t *> ret =
       lasx_convert_utf32_to_utf16_with_errors<endianness::LITTLE>(buf, len,
                                                                   utf16_output);
   if (ret.first.count != len) {
@@ -1166,7 +1166,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf16be_with_errors(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char16_t *> ret =
+  internal::pair<result, char16_t *> ret =
       lasx_convert_utf32_to_utf16_with_errors<endianness::BIG>(buf, len,
                                                                utf16_output);
   if (ret.first.count != len) {

--- a/src/lasx/lasx_base64.cpp
+++ b/src/lasx/lasx_base64.cpp
@@ -487,7 +487,7 @@ static inline void base64_decode_block_safe(char *out, const char *src) {
   alignas(32) char buffer[32];
   base64_decode(buffer,
                 __lasx_xvld(reinterpret_cast<const __m256i *>(src), 32));
-  std::memcpy(out + 24, buffer, 24);
+  internal::memcpy(out + 24, buffer, 24);
 }
 
 static inline void base64_decode_block(char *out, block64 *b) {
@@ -498,7 +498,7 @@ static inline void base64_decode_block_safe(char *out, block64 *b) {
   base64_decode(out, b->chunks[0]);
   alignas(32) char buffer[32];
   base64_decode(buffer, b->chunks[1]);
-  std::memcpy(out + 24, buffer, 24);
+  internal::memcpy(out + 24, buffer, 24);
 }
 
 template <bool base64_url, bool ignore_garbage, bool default_or_url,
@@ -579,8 +579,8 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
           base64_decode_block(dst, buffer + (block_size - 2) * 64);
         }
         dst += 48;
-        std::memcpy(buffer, buffer + (block_size - 1) * 64,
-                    64); // 64 might be too much
+        internal::memcpy(buffer, buffer + (block_size - 1) * 64,
+                         64); // 64 might be too much
         bufferptr -= (block_size - 1) * 64;
       }
     }
@@ -622,7 +622,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                         << 8;
       // lasx is little-endian
       triple = scalar::u32_swap_bytes(triple);
-      std::memcpy(dst, &triple, 4);
+      internal::memcpy(dst, &triple, 4);
 
       dst += 3;
       buffer_start += 4;
@@ -635,7 +635,7 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                         << 8;
       // lasx is little-endian
       triple = scalar::u32_swap_bytes(triple);
-      std::memcpy(dst, &triple, 3);
+      internal::memcpy(dst, &triple, 3);
 
       dst += 3;
       buffer_start += 4;

--- a/src/lasx/lasx_convert_latin1_to_utf16.cpp
+++ b/src/lasx/lasx_convert_latin1_to_utf16.cpp
@@ -1,4 +1,4 @@
-std::pair<const char *, char16_t *>
+internal::pair<const char *, char16_t *>
 lasx_convert_latin1_to_utf16le(const char *buf, size_t len,
                                char16_t *utf16_output) {
   const char *end = buf + len;
@@ -34,10 +34,10 @@ lasx_convert_latin1_to_utf16le(const char *buf, size_t len,
     utf16_output += 16;
     buf += 16;
   }
-  return std::make_pair(buf, utf16_output);
+  return internal::make_pair(buf, utf16_output);
 }
 
-std::pair<const char *, char16_t *>
+internal::pair<const char *, char16_t *>
 lasx_convert_latin1_to_utf16be(const char *buf, size_t len,
                                char16_t *utf16_output) {
   const char *end = buf + len;
@@ -72,5 +72,5 @@ lasx_convert_latin1_to_utf16be(const char *buf, size_t len,
     buf += 16;
   }
 
-  return std::make_pair(buf, utf16_output);
+  return internal::make_pair(buf, utf16_output);
 }

--- a/src/lasx/lasx_convert_latin1_to_utf32.cpp
+++ b/src/lasx/lasx_convert_latin1_to_utf32.cpp
@@ -1,4 +1,4 @@
-std::pair<const char *, char32_t *>
+internal::pair<const char *, char32_t *>
 lasx_convert_latin1_to_utf32(const char *buf, size_t len,
                              char32_t *utf32_output) {
   const char *end = buf + len;
@@ -51,5 +51,5 @@ lasx_convert_latin1_to_utf32(const char *buf, size_t len,
     buf += 16;
   }
 
-  return std::make_pair(buf, utf32_output);
+  return internal::make_pair(buf, utf32_output);
 }

--- a/src/lasx/lasx_convert_latin1_to_utf8.cpp
+++ b/src/lasx/lasx_convert_latin1_to_utf8.cpp
@@ -3,7 +3,7 @@
   A scalar routing should carry on the conversion of the tail.
 */
 
-std::pair<const char *, char *>
+internal::pair<const char *, char *>
 lasx_convert_latin1_to_utf8(const char *latin1_input, size_t len,
                             char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
@@ -12,7 +12,7 @@ lasx_convert_latin1_to_utf8(const char *latin1_input, size_t len,
 
   // We always write 16 bytes, of which more than the first 8 bytes
   // are valid. A safety margin of 8 is more than sufficient.
-  while (end - latin1_input >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - latin1_input >= internal::ptrdiff_t(16 + safety_margin)) {
     __m128i in8 = __lsx_vld(reinterpret_cast<const uint8_t *>(latin1_input), 0);
     uint32_t ascii_mask = __lsx_vpickve2gr_wu(__lsx_vmskgez_b(in8), 0);
     if (ascii_mask == 0xFFFF) {
@@ -61,5 +61,6 @@ lasx_convert_latin1_to_utf8(const char *latin1_input, size_t len,
     latin1_input += 16;
   } // while
 
-  return std::make_pair(latin1_input, reinterpret_cast<char *>(utf8_output));
+  return internal::make_pair(latin1_input,
+                             reinterpret_cast<char *>(utf8_output));
 }

--- a/src/lasx/lasx_convert_utf16_to_latin1.cpp
+++ b/src/lasx/lasx_convert_utf16_to_latin1.cpp
@@ -1,5 +1,5 @@
 template <endianness big_endian>
-std::pair<const char16_t *, char *>
+internal::pair<const char16_t *, char *>
 lasx_convert_utf16_to_latin1(const char16_t *buf, size_t len,
                              char *latin1_output) {
   const char16_t *end = buf + len;
@@ -19,14 +19,15 @@ lasx_convert_utf16_to_latin1(const char16_t *buf, size_t len,
       buf += 16;
       latin1_output += 16;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return internal::pair<const char16_t *, char *>{
+          nullptr, reinterpret_cast<char *>(latin1_output)};
     }
   } // while
-  return std::make_pair(buf, latin1_output);
+  return internal::make_pair(buf, latin1_output);
 }
 
 template <endianness big_endian>
-std::pair<result, char *>
+internal::pair<result, char *>
 lasx_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
                                          char *latin1_output) {
   const char16_t *start = buf;
@@ -53,12 +54,12 @@ lasx_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
         if (word <= 0xff) {
           *latin1_output++ = char(word);
         } else {
-          return std::make_pair(result(error_code::TOO_LARGE, buf - start + k),
-                                latin1_output);
+          return internal::make_pair(
+              result(error_code::TOO_LARGE, buf - start + k), latin1_output);
         }
       }
     }
   } // while
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        latin1_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             latin1_output);
 }

--- a/src/lasx/lasx_convert_utf16_to_utf32.cpp
+++ b/src/lasx/lasx_convert_utf16_to_utf32.cpp
@@ -1,5 +1,5 @@
 template <endianness big_endian>
-std::pair<const char16_t *, char32_t *>
+internal::pair<const char16_t *, char32_t *>
 lasx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
                             char32_t *utf32_out) {
   uint32_t *utf32_output = reinterpret_cast<uint32_t *>(utf32_out);
@@ -13,16 +13,16 @@ lasx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
       buf++;
     } else {
       if (buf + 1 >= end) {
-        return std::make_pair(nullptr,
-                              reinterpret_cast<char32_t *>(utf32_output));
+        return internal::pair<const char16_t *, char32_t *>{
+            nullptr, reinterpret_cast<char32_t *>(utf32_output)};
       }
       // must be a surrogate pair
       uint16_t diff = uint16_t(word - 0xD800);
       uint16_t next_word = scalar::utf16::swap_if_needed<big_endian>(buf[1]);
       uint16_t diff2 = uint16_t(next_word - 0xDC00);
       if ((diff | diff2) > 0x3FF) {
-        return std::make_pair(nullptr,
-                              reinterpret_cast<char32_t *>(utf32_output));
+        return internal::pair<const char16_t *, char32_t *>{
+            nullptr, reinterpret_cast<char32_t *>(utf32_output)};
       }
       uint32_t value = (diff << 10) + diff2 + 0x10000;
       *utf32_output++ = char32_t(value);
@@ -73,8 +73,8 @@ lasx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char32_t *>(utf32_output));
+            return internal::pair<const char16_t *, char32_t *>{
+                nullptr, reinterpret_cast<char32_t *>(utf32_output)};
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
           *utf32_output++ = char32_t(value);
@@ -83,7 +83,7 @@ lasx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
       buf += k;
     }
   } // while
-  return std::make_pair(buf, reinterpret_cast<char32_t *>(utf32_output));
+  return internal::make_pair(buf, reinterpret_cast<char32_t *>(utf32_output));
 }
 
 /*
@@ -94,7 +94,7 @@ lasx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
   tail if needed.
 */
 template <endianness big_endian>
-std::pair<result, char32_t *>
+internal::pair<result, char32_t *>
 lasx_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
                                         char32_t *utf32_out) {
   uint32_t *utf32_output = reinterpret_cast<uint32_t *>(utf32_out);
@@ -113,15 +113,15 @@ lasx_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
       uint16_t next_word = scalar::utf16::swap_if_needed<big_endian>(buf[1]);
       uint16_t diff2 = uint16_t(next_word - 0xDC00);
       if ((diff | diff2) > 0x3FF) {
-        return std::make_pair(result(error_code::SURROGATE, buf - start),
-                              reinterpret_cast<char32_t *>(utf32_output));
+        return internal::make_pair(result(error_code::SURROGATE, buf - start),
+                                   reinterpret_cast<char32_t *>(utf32_output));
       }
       uint32_t value = (diff << 10) + diff2 + 0x10000;
       *utf32_output++ = char32_t(value);
       buf += 2;
     } else {
-      return std::make_pair(result(error_code::SURROGATE, buf - start),
-                            reinterpret_cast<char32_t *>(utf32_output));
+      return internal::make_pair(result(error_code::SURROGATE, buf - start),
+                                 reinterpret_cast<char32_t *>(utf32_output));
     }
   }
 
@@ -167,7 +167,7 @@ lasx_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k - 1),
                 reinterpret_cast<char32_t *>(utf32_output));
           }
@@ -178,6 +178,6 @@ lasx_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
       buf += k;
     }
   } // while
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        reinterpret_cast<char32_t *>(utf32_output));
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             reinterpret_cast<char32_t *>(utf32_output));
 }

--- a/src/lasx/lasx_convert_utf16_to_utf8.cpp
+++ b/src/lasx/lasx_convert_utf16_to_utf8.cpp
@@ -52,7 +52,7 @@
 */
 
 template <endianness big_endian>
-std::pair<const char16_t *, char *>
+internal::pair<const char16_t *, char *>
 lasx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
   const char16_t *end = buf + len;
@@ -64,7 +64,7 @@ lasx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
   __m256i v_07ff = __lasx_xvreplgr2vr_h(uint16_t(0x7ff));
   __m256i zero = __lasx_xvldi(0);
   __m128i zero_128 = __lsx_vldi(0);
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= internal::ptrdiff_t(16 + safety_margin)) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint16_t *>(buf), 0);
     if simdutf_constexpr (!match_system(big_endian)) {
       in = lasx_swap_bytes(in);
@@ -278,8 +278,8 @@ lasx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char *>(utf8_output));
+            return internal::pair<const char16_t *, char *>{
+                nullptr, reinterpret_cast<char *>(utf8_output)};
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
           *utf8_output++ = char((value >> 18) | 0b11110000);
@@ -291,7 +291,7 @@ lasx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
       buf += k;
     }
   } // while
-  return std::make_pair(buf, reinterpret_cast<char *>(utf8_output));
+  return internal::make_pair(buf, reinterpret_cast<char *>(utf8_output));
 }
 
 /*
@@ -302,7 +302,7 @@ lasx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
   tail if needed.
 */
 template <endianness big_endian>
-std::pair<result, char *>
+internal::pair<result, char *>
 lasx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
                                        char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
@@ -316,7 +316,7 @@ lasx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
   __m256i v_07ff = __lasx_xvreplgr2vr_h(uint16_t(0x7ff));
   __m256i zero = __lasx_xvldi(0);
   __m128i zero_128 = __lsx_vldi(0);
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= internal::ptrdiff_t(16 + safety_margin)) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint16_t *>(buf), 0);
     if simdutf_constexpr (!match_system(big_endian)) {
       in = lasx_swap_bytes(in);
@@ -530,7 +530,7 @@ lasx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k - 1),
                 reinterpret_cast<char *>(utf8_output));
           }
@@ -545,6 +545,6 @@ lasx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
     }
   } // while
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        reinterpret_cast<char *>(utf8_output));
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             reinterpret_cast<char *>(utf8_output));
 }

--- a/src/lasx/lasx_convert_utf32_to_latin1.cpp
+++ b/src/lasx/lasx_convert_utf32_to_latin1.cpp
@@ -1,4 +1,4 @@
-std::pair<const char32_t *, char *>
+internal::pair<const char32_t *, char *>
 lasx_convert_utf32_to_latin1(const char32_t *buf, size_t len,
                              char *latin1_output) {
   const char32_t *end = buf + len;
@@ -23,13 +23,14 @@ lasx_convert_utf32_to_latin1(const char32_t *buf, size_t len,
       buf += 16;
       latin1_output += 16;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return internal::pair<const char32_t *, char *>{
+          nullptr, reinterpret_cast<char *>(latin1_output)};
     }
   } // while
-  return std::make_pair(buf, latin1_output);
+  return internal::make_pair(buf, latin1_output);
 }
 
-std::pair<result, char *>
+internal::pair<result, char *>
 lasx_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
                                          char *latin1_output) {
   const char32_t *start = buf;
@@ -62,12 +63,12 @@ lasx_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
         if (word <= 0xff) {
           *latin1_output++ = char(word);
         } else {
-          return std::make_pair(result(error_code::TOO_LARGE, buf - start + k),
-                                latin1_output);
+          return internal::make_pair(
+              result(error_code::TOO_LARGE, buf - start + k), latin1_output);
         }
       }
     }
   } // while
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        latin1_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             latin1_output);
 }

--- a/src/lasx/lasx_convert_utf32_to_utf16.cpp
+++ b/src/lasx/lasx_convert_utf32_to_utf16.cpp
@@ -1,5 +1,5 @@
 template <endianness big_endian>
-std::pair<const char32_t *, char16_t *>
+internal::pair<const char32_t *, char16_t *>
 lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
                             char16_t *utf16_out) {
   uint16_t *utf16_output = reinterpret_cast<uint16_t *>(utf16_out);
@@ -11,8 +11,8 @@ lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
     if ((word & 0xFFFF0000) == 0) {
       // will not generate a surrogate pair
       if (word >= 0xD800 && word <= 0xDFFF) {
-        return std::make_pair(nullptr,
-                              reinterpret_cast<char16_t *>(utf16_output));
+        return internal::pair<const char32_t *, char16_t *>{
+            nullptr, reinterpret_cast<char16_t *>(utf16_output)};
       }
       *utf16_output++ = !match_system(big_endian)
                             ? char16_t(word >> 8 | word << 8)
@@ -21,8 +21,8 @@ lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
     } else {
       // will generate a surrogate pair
       if (word > 0x10FFFF) {
-        return std::make_pair(nullptr,
-                              reinterpret_cast<char16_t *>(utf16_output));
+        return internal::pair<const char32_t *, char16_t *>{
+            nullptr, reinterpret_cast<char16_t *>(utf16_output)};
       }
       word -= 0x10000;
       uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
@@ -71,8 +71,8 @@ lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
         if ((word & 0xFFFF0000) == 0) {
           // will not generate a surrogate pair
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char16_t *>(utf16_output));
+            return internal::pair<const char32_t *, char16_t *>{
+                nullptr, reinterpret_cast<char16_t *>(utf16_output)};
           }
           *utf16_output++ = !match_system(big_endian)
                                 ? char16_t(word >> 8 | word << 8)
@@ -80,8 +80,8 @@ lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
         } else {
           // will generate a surrogate pair
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char16_t *>(utf16_output));
+            return internal::pair<const char32_t *, char16_t *>{
+                nullptr, reinterpret_cast<char16_t *>(utf16_output)};
           }
           word -= 0x10000;
           uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
@@ -101,13 +101,14 @@ lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
 
   // check for invalid input
   if (__lasx_xbnz_v(forbidden_bytemask)) {
-    return std::make_pair(nullptr, reinterpret_cast<char16_t *>(utf16_output));
+    return internal::pair<const char32_t *, char16_t *>{
+        nullptr, reinterpret_cast<char16_t *>(utf16_output)};
   }
-  return std::make_pair(buf, reinterpret_cast<char16_t *>(utf16_output));
+  return internal::make_pair(buf, reinterpret_cast<char16_t *>(utf16_output));
 }
 
 template <endianness big_endian>
-std::pair<result, char16_t *>
+internal::pair<result, char16_t *>
 lasx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
                                         char16_t *utf16_out) {
   uint16_t *utf16_output = reinterpret_cast<uint16_t *>(utf16_out);
@@ -120,8 +121,9 @@ lasx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
     if ((word & 0xFFFF0000) == 0) {
       // will not generate a surrogate pair
       if (word >= 0xD800 && word <= 0xDFFF) {
-        return std::make_pair(result(error_code::SURROGATE, buf - start - 1),
-                              reinterpret_cast<char16_t *>(utf16_output));
+        return internal::make_pair(
+            result(error_code::SURROGATE, buf - start - 1),
+            reinterpret_cast<char16_t *>(utf16_output));
       }
       *utf16_output++ = !match_system(big_endian)
                             ? char16_t(word >> 8 | word << 8)
@@ -129,8 +131,9 @@ lasx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
     } else {
       // will generate a surrogate pair
       if (word > 0x10FFFF) {
-        return std::make_pair(result(error_code::TOO_LARGE, buf - start - 1),
-                              reinterpret_cast<char16_t *>(utf16_output));
+        return internal::make_pair(
+            result(error_code::TOO_LARGE, buf - start - 1),
+            reinterpret_cast<char16_t *>(utf16_output));
       }
       word -= 0x10000;
       uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
@@ -161,8 +164,8 @@ lasx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
               __lasx_xvsle_h(v_d800, utf16_packed)), // utf16_packed >= 0xd800
           forbidden_bytemask);
       if (__lasx_xbnz_v(forbidden_bytemask)) {
-        return std::make_pair(result(error_code::SURROGATE, buf - start),
-                              reinterpret_cast<char16_t *>(utf16_output));
+        return internal::make_pair(result(error_code::SURROGATE, buf - start),
+                                   reinterpret_cast<char16_t *>(utf16_output));
       }
 
       if simdutf_constexpr (!match_system(big_endian)) {
@@ -183,7 +186,7 @@ lasx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
         if ((word & 0xFFFF0000) == 0) {
           // will not generate a surrogate pair
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k),
                 reinterpret_cast<char16_t *>(utf16_output));
           }
@@ -193,7 +196,7 @@ lasx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
         } else {
           // will generate a surrogate pair
           if (word > 0x10FFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::TOO_LARGE, buf - start + k),
                 reinterpret_cast<char16_t *>(utf16_output));
           }
@@ -213,6 +216,6 @@ lasx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
     }
   }
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        reinterpret_cast<char16_t *>(utf16_output));
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             reinterpret_cast<char16_t *>(utf16_output));
 }

--- a/src/lasx/lasx_convert_utf32_to_utf8.cpp
+++ b/src/lasx/lasx_convert_utf32_to_utf8.cpp
@@ -1,4 +1,4 @@
-std::pair<const char32_t *, char *>
+internal::pair<const char32_t *, char *>
 lasx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
   const char32_t *end = buf + len;
@@ -13,14 +13,16 @@ lasx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
       *utf8_output++ = char((word & 0b111111) | 0b10000000);
     } else if ((word & 0xFFFF0000) == 0) {
       if (word >= 0xD800 && word <= 0xDFFF) {
-        return std::make_pair(nullptr, reinterpret_cast<char *>(utf8_output));
+        return internal::pair<const char32_t *, char *>{
+            nullptr, reinterpret_cast<char *>(utf8_output)};
       }
       *utf8_output++ = char((word >> 12) | 0b11100000);
       *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
       *utf8_output++ = char((word & 0b111111) | 0b10000000);
     } else {
       if (word > 0x10FFFF) {
-        return std::make_pair(nullptr, reinterpret_cast<char *>(utf8_output));
+        return internal::pair<const char32_t *, char *>{
+            nullptr, reinterpret_cast<char *>(utf8_output)};
       }
       *utf8_output++ = char((word >> 18) | 0b11110000);
       *utf8_output++ = char(((word >> 12) & 0b111111) | 0b10000000);
@@ -42,7 +44,7 @@ lasx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (end - buf > std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf > internal::ptrdiff_t(16 + safety_margin)) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m256i nextin = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 32);
 
@@ -262,16 +264,16 @@ lasx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) {
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char *>(utf8_output));
+            return internal::pair<const char32_t *, char *>{
+                nullptr, reinterpret_cast<char *>(utf8_output)};
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
           *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else {
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char *>(utf8_output));
+            return internal::pair<const char32_t *, char *>{
+                nullptr, reinterpret_cast<char *>(utf8_output)};
           }
           *utf8_output++ = char((word >> 18) | 0b11110000);
           *utf8_output++ = char(((word >> 12) & 0b111111) | 0b10000000);
@@ -285,12 +287,13 @@ lasx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
 
   // check for invalid input
   if (__lasx_xbnz_v(forbidden_bytemask)) {
-    return std::make_pair(nullptr, reinterpret_cast<char *>(utf8_output));
+    return internal::pair<const char32_t *, char *>{
+        nullptr, reinterpret_cast<char *>(utf8_output)};
   }
-  return std::make_pair(buf, reinterpret_cast<char *>(utf8_output));
+  return internal::make_pair(buf, reinterpret_cast<char *>(utf8_output));
 }
 
-std::pair<result, char *>
+internal::pair<result, char *>
 lasx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
                                        char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
@@ -307,16 +310,16 @@ lasx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
       *utf8_output++ = char((word & 0b111111) | 0b10000000);
     } else if ((word & 0xFFFF0000) == 0) {
       if (word >= 0xD800 && word <= 0xDFFF) {
-        return std::make_pair(result(error_code::SURROGATE, buf - start),
-                              reinterpret_cast<char *>(utf8_output));
+        return internal::make_pair(result(error_code::SURROGATE, buf - start),
+                                   reinterpret_cast<char *>(utf8_output));
       }
       *utf8_output++ = char((word >> 12) | 0b11100000);
       *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
       *utf8_output++ = char((word & 0b111111) | 0b10000000);
     } else {
       if (word > 0x10FFFF) {
-        return std::make_pair(result(error_code::TOO_LARGE, buf - start),
-                              reinterpret_cast<char *>(utf8_output));
+        return internal::make_pair(result(error_code::TOO_LARGE, buf - start),
+                                   reinterpret_cast<char *>(utf8_output));
       }
       *utf8_output++ = char((word >> 18) | 0b11110000);
       *utf8_output++ = char(((word >> 12) & 0b111111) | 0b10000000);
@@ -337,7 +340,7 @@ lasx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (end - buf > std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf > internal::ptrdiff_t(16 + safety_margin)) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m256i nextin = __lasx_xvld(reinterpret_cast<const uint32_t *>(buf), 32);
 
@@ -417,8 +420,8 @@ lasx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
                 __lasx_xvsle_h(v_d800, utf16_packed)), // utf16_packed >= 0xd800
             forbidden_bytemask);
         if (__lasx_xbnz_v(forbidden_bytemask)) {
-          return std::make_pair(result(error_code::SURROGATE, buf - start),
-                                reinterpret_cast<char *>(utf8_output));
+          return internal::make_pair(result(error_code::SURROGATE, buf - start),
+                                     reinterpret_cast<char *>(utf8_output));
         }
         /* In this branch we handle three cases:
             1. [0000|0000|0ccc|cccc] => [0ccc|cccc]                           -
@@ -561,7 +564,7 @@ lasx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) {
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k),
                 reinterpret_cast<char *>(utf8_output));
           }
@@ -570,7 +573,7 @@ lasx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else {
           if (word > 0x10FFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::TOO_LARGE, buf - start + k),
                 reinterpret_cast<char *>(utf8_output));
           }
@@ -584,6 +587,6 @@ lasx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
     }
   } // while
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        reinterpret_cast<char *>(utf8_output));
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             reinterpret_cast<char *>(utf8_output));
 }

--- a/src/lsx/implementation.cpp
+++ b/src/lsx/implementation.cpp
@@ -427,7 +427,7 @@ simdutf_warn_unused result implementation::validate_utf32_with_errors(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(
     const char *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char *, char *> ret =
+  internal::pair<const char *, char *> ret =
       lsx_convert_latin1_to_utf8(buf, len, utf8_output);
   size_t converted_chars = ret.second - utf8_output;
 
@@ -443,7 +443,7 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16le(
     const char *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char *, char16_t *> ret =
+  internal::pair<const char *, char16_t *> ret =
       lsx_convert_latin1_to_utf16le(buf, len, utf16_output);
   size_t converted_chars = ret.second - utf16_output;
   if (ret.first != buf + len) {
@@ -457,7 +457,7 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf16le(
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(
     const char *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char *, char16_t *> ret =
+  internal::pair<const char *, char16_t *> ret =
       lsx_convert_latin1_to_utf16be(buf, len, utf16_output);
   size_t converted_chars = ret.second - utf16_output;
   if (ret.first != buf + len) {
@@ -473,7 +473,7 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf32(
     const char *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char *, char32_t *> ret =
+  internal::pair<const char *, char32_t *> ret =
       lsx_convert_latin1_to_utf32(buf, len, utf32_output);
   size_t converted_chars = ret.second - utf32_output;
   if (ret.first != buf + len) {
@@ -565,7 +565,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf32(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       lsx_convert_utf16_to_latin1<endianness::LITTLE>(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -586,7 +586,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       lsx_convert_utf16_to_latin1<endianness::BIG>(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -608,7 +608,7 @@ simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(
 simdutf_warn_unused result
 implementation::convert_utf16le_to_latin1_with_errors(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       lsx_convert_utf16_to_latin1_with_errors<endianness::LITTLE>(
           buf, len, latin1_output);
   if (ret.first.error) {
@@ -635,7 +635,7 @@ implementation::convert_utf16le_to_latin1_with_errors(
 simdutf_warn_unused result
 implementation::convert_utf16be_to_latin1_with_errors(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       lsx_convert_utf16_to_latin1_with_errors<endianness::BIG>(buf, len,
                                                                latin1_output);
   if (ret.first.error) {
@@ -675,7 +675,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_latin1(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t implementation::convert_utf16le_to_utf8(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       lsx_convert_utf16_to_utf8<endianness::LITTLE>(buf, len, utf8_output);
   if (ret.first == nullptr) {
     return 0;
@@ -695,7 +695,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_utf8(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_utf8(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       lsx_convert_utf16_to_utf8<endianness::BIG>(buf, len, utf8_output);
   if (ret.first == nullptr) {
     return 0;
@@ -717,7 +717,7 @@ simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       lsx_convert_utf16_to_utf8_with_errors<endianness::LITTLE>(buf, len,
                                                                 utf8_output);
   if (ret.first.error) {
@@ -745,7 +745,7 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       lsx_convert_utf16_to_utf8_with_errors<endianness::BIG>(buf, len,
                                                              utf8_output);
   if (ret.first.error) {
@@ -786,7 +786,7 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_utf8(
   if (simdutf_unlikely(len == 0)) {
     return 0;
   }
-  std::pair<const char32_t *, char *> ret =
+  internal::pair<const char32_t *, char *> ret =
       lsx_convert_utf32_to_utf8(buf, len, utf8_output);
   if (ret.first == nullptr) {
     return 0;
@@ -810,7 +810,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
   }
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       lsx_convert_utf32_to_utf8_with_errors(buf, len, utf8_output);
   if (ret.first.count != len) {
     result scalar_res = scalar::utf32_to_utf8::convert_with_errors(
@@ -832,7 +832,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::convert_utf16le_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char16_t *, char32_t *> ret =
+  internal::pair<const char16_t *, char32_t *> ret =
       lsx_convert_utf16_to_utf32<endianness::LITTLE>(buf, len, utf32_output);
   if (ret.first == nullptr) {
     return 0;
@@ -852,7 +852,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_utf32(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char16_t *, char32_t *> ret =
+  internal::pair<const char16_t *, char32_t *> ret =
       lsx_convert_utf16_to_utf32<endianness::BIG>(buf, len, utf32_output);
   if (ret.first == nullptr) {
     return 0;
@@ -874,7 +874,7 @@ simdutf_warn_unused result implementation::convert_utf16le_to_utf32_with_errors(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char32_t *> ret =
+  internal::pair<result, char32_t *> ret =
       lsx_convert_utf16_to_utf32_with_errors<endianness::LITTLE>(buf, len,
                                                                  utf32_output);
   if (ret.first.error) {
@@ -902,7 +902,7 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf32_with_errors(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char32_t *> ret =
+  internal::pair<result, char32_t *> ret =
       lsx_convert_utf16_to_utf32_with_errors<endianness::BIG>(buf, len,
                                                               utf32_output);
   if (ret.first.error) {
@@ -930,7 +930,7 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf32_with_errors(
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_utf32_to_latin1(
     const char32_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char32_t *, char *> ret =
+  internal::pair<const char32_t *, char *> ret =
       lsx_convert_utf32_to_latin1(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -950,7 +950,7 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_latin1(
 
 simdutf_warn_unused result implementation::convert_utf32_to_latin1_with_errors(
     const char32_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       lsx_convert_utf32_to_latin1_with_errors(buf, len, latin1_output);
   if (ret.first.error) {
     return ret.first;
@@ -974,7 +974,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_latin1_with_errors(
 
 simdutf_warn_unused size_t implementation::convert_valid_utf32_to_latin1(
     const char32_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char32_t *, char *> ret =
+  internal::pair<const char32_t *, char *> ret =
       lsx_convert_utf32_to_latin1(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -1001,7 +1001,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf32_to_utf8(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf16le(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char32_t *, char16_t *> ret =
+  internal::pair<const char32_t *, char16_t *> ret =
       lsx_convert_utf32_to_utf16<endianness::LITTLE>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -1022,7 +1022,7 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_utf16le(
 
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf16be(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char32_t *, char16_t *> ret =
+  internal::pair<const char32_t *, char16_t *> ret =
       lsx_convert_utf32_to_utf16<endianness::BIG>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -1044,7 +1044,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf16le_with_errors(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char16_t *> ret =
+  internal::pair<result, char16_t *> ret =
       lsx_convert_utf32_to_utf16_with_errors<endianness::LITTLE>(buf, len,
                                                                  utf16_output);
   if (ret.first.count != len) {
@@ -1068,7 +1068,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf16be_with_errors(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char16_t *> ret =
+  internal::pair<result, char16_t *> ret =
       lsx_convert_utf32_to_utf16_with_errors<endianness::BIG>(buf, len,
                                                               utf16_output);
   if (ret.first.count != len) {

--- a/src/lsx/lsx_base64.cpp
+++ b/src/lsx/lsx_base64.cpp
@@ -565,8 +565,8 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
           base64_decode_block(dst, buffer + i * 64);
           dst += 48;
         }
-        std::memcpy(buffer, buffer + (block_size - 1) * 64,
-                    64); // 64 might be too much
+        internal::memcpy(buffer, buffer + (block_size - 1) * 64,
+                         64); // 64 might be too much
         bufferptr -= (block_size - 1) * 64;
       }
     }
@@ -602,7 +602,7 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
                         << 8;
       // lsx is little-endian
       triple = scalar::u32_swap_bytes(triple);
-      std::memcpy(dst, &triple, 4);
+      internal::memcpy(dst, &triple, 4);
 
       dst += 3;
       buffer_start += 4;
@@ -615,7 +615,7 @@ compress_decode_base64(char *dst, const char_type *src, size_t srclen,
                         << 8;
       // lsx is little-endian
       triple = scalar::u32_swap_bytes(triple);
-      std::memcpy(dst, &triple, 3);
+      internal::memcpy(dst, &triple, 3);
 
       dst += 3;
       buffer_start += 4;

--- a/src/lsx/lsx_convert_latin1_to_utf16.cpp
+++ b/src/lsx/lsx_convert_latin1_to_utf16.cpp
@@ -1,4 +1,4 @@
-std::pair<const char *, char16_t *>
+internal::pair<const char *, char16_t *>
 lsx_convert_latin1_to_utf16le(const char *buf, size_t len,
                               char16_t *utf16_output) {
   const char *end = buf + len;
@@ -16,10 +16,10 @@ lsx_convert_latin1_to_utf16le(const char *buf, size_t len,
     buf += 16;
   }
 
-  return std::make_pair(buf, utf16_output);
+  return internal::make_pair(buf, utf16_output);
 }
 
-std::pair<const char *, char16_t *>
+internal::pair<const char *, char16_t *>
 lsx_convert_latin1_to_utf16be(const char *buf, size_t len,
                               char16_t *utf16_output) {
   const char *end = buf + len;
@@ -35,5 +35,5 @@ lsx_convert_latin1_to_utf16be(const char *buf, size_t len,
     buf += 16;
   }
 
-  return std::make_pair(buf, utf16_output);
+  return internal::make_pair(buf, utf16_output);
 }

--- a/src/lsx/lsx_convert_latin1_to_utf32.cpp
+++ b/src/lsx/lsx_convert_latin1_to_utf32.cpp
@@ -1,4 +1,4 @@
-std::pair<const char *, char32_t *>
+internal::pair<const char *, char32_t *>
 lsx_convert_latin1_to_utf32(const char *buf, size_t len,
                             char32_t *utf32_output) {
   const char *end = buf + len;
@@ -23,5 +23,5 @@ lsx_convert_latin1_to_utf32(const char *buf, size_t len,
     buf += 16;
   }
 
-  return std::make_pair(buf, utf32_output);
+  return internal::make_pair(buf, utf32_output);
 }

--- a/src/lsx/lsx_convert_latin1_to_utf8.cpp
+++ b/src/lsx/lsx_convert_latin1_to_utf8.cpp
@@ -3,7 +3,7 @@
   A scalar routing should carry on the conversion of the tail.
 */
 
-std::pair<const char *, char *>
+internal::pair<const char *, char *>
 lsx_convert_latin1_to_utf8(const char *latin1_input, size_t len,
                            char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
@@ -52,5 +52,6 @@ lsx_convert_latin1_to_utf8(const char *latin1_input, size_t len,
 
   } // while
 
-  return std::make_pair(latin1_input, reinterpret_cast<char *>(utf8_output));
+  return internal::make_pair(latin1_input,
+                             reinterpret_cast<char *>(utf8_output));
 }

--- a/src/lsx/lsx_convert_utf16_to_latin1.cpp
+++ b/src/lsx/lsx_convert_utf16_to_latin1.cpp
@@ -1,5 +1,5 @@
 template <endianness big_endian>
-std::pair<const char16_t *, char *>
+internal::pair<const char16_t *, char *>
 lsx_convert_utf16_to_latin1(const char16_t *buf, size_t len,
                             char *latin1_output) {
   const char16_t *end = buf + len;
@@ -19,14 +19,15 @@ lsx_convert_utf16_to_latin1(const char16_t *buf, size_t len,
       buf += 16;
       latin1_output += 16;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return internal::pair<const char16_t *, char *>{
+          nullptr, reinterpret_cast<char *>(latin1_output)};
     }
   } // while
-  return std::make_pair(buf, latin1_output);
+  return internal::make_pair(buf, latin1_output);
 }
 
 template <endianness big_endian>
-std::pair<result, char *>
+internal::pair<result, char *>
 lsx_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
                                         char *latin1_output) {
   const char16_t *start = buf;
@@ -53,12 +54,12 @@ lsx_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
         if (word <= 0xff) {
           *latin1_output++ = char(word);
         } else {
-          return std::make_pair(result(error_code::TOO_LARGE, buf - start + k),
-                                latin1_output);
+          return internal::make_pair(
+              result(error_code::TOO_LARGE, buf - start + k), latin1_output);
         }
       }
     }
   } // while
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        latin1_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             latin1_output);
 }

--- a/src/lsx/lsx_convert_utf16_to_utf32.cpp
+++ b/src/lsx/lsx_convert_utf16_to_utf32.cpp
@@ -1,5 +1,5 @@
 template <endianness big_endian>
-std::pair<const char16_t *, char32_t *>
+internal::pair<const char16_t *, char32_t *>
 lsx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
                            char32_t *utf32_out) {
   uint32_t *utf32_output = reinterpret_cast<uint32_t *>(utf32_out);
@@ -48,8 +48,8 @@ lsx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char32_t *>(utf32_output));
+            return internal::pair<const char16_t *, char32_t *>{
+                nullptr, reinterpret_cast<char32_t *>(utf32_output)};
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
           *utf32_output++ = char32_t(value);
@@ -58,7 +58,7 @@ lsx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
       buf += k;
     }
   } // while
-  return std::make_pair(buf, reinterpret_cast<char32_t *>(utf32_output));
+  return internal::make_pair(buf, reinterpret_cast<char32_t *>(utf32_output));
 }
 
 /*
@@ -69,7 +69,7 @@ lsx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
   tail if needed.
 */
 template <endianness big_endian>
-std::pair<result, char32_t *>
+internal::pair<result, char32_t *>
 lsx_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
                                        char32_t *utf32_out) {
   uint32_t *utf32_output = reinterpret_cast<uint32_t *>(utf32_out);
@@ -117,7 +117,7 @@ lsx_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k - 1),
                 reinterpret_cast<char32_t *>(utf32_output));
           }
@@ -128,6 +128,6 @@ lsx_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
       buf += k;
     }
   } // while
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        reinterpret_cast<char32_t *>(utf32_output));
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             reinterpret_cast<char32_t *>(utf32_output));
 }

--- a/src/lsx/lsx_convert_utf16_to_utf8.cpp
+++ b/src/lsx/lsx_convert_utf16_to_utf8.cpp
@@ -51,7 +51,7 @@
   A scalar routing should carry on the conversion of the tail.
 */
 template <endianness big_endian>
-std::pair<const char16_t *, char *>
+internal::pair<const char16_t *, char *>
 lsx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
   const char16_t *end = buf + len;
@@ -61,7 +61,7 @@ lsx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
           // https://github.com/simdutf/simdutf/issues/92
 
   __m128i v_07ff = __lsx_vreplgr2vr_h(uint16_t(0x7ff));
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= internal::ptrdiff_t(16 + safety_margin)) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
     if simdutf_constexpr (!match_system(big_endian)) {
       in = lsx_swap_bytes(in);
@@ -262,8 +262,8 @@ lsx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char *>(utf8_output));
+            return internal::pair<const char16_t *, char *>{
+                nullptr, reinterpret_cast<char *>(utf8_output)};
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
           *utf8_output++ = char((value >> 18) | 0b11110000);
@@ -275,7 +275,7 @@ lsx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
       buf += k;
     }
   } // while
-  return std::make_pair(buf, reinterpret_cast<char *>(utf8_output));
+  return internal::make_pair(buf, reinterpret_cast<char *>(utf8_output));
 }
 
 /*
@@ -286,7 +286,7 @@ lsx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
   tail if needed.
 */
 template <endianness big_endian>
-std::pair<result, char *>
+internal::pair<result, char *>
 lsx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
                                       char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
@@ -296,7 +296,7 @@ lsx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
   const size_t safety_margin =
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= internal::ptrdiff_t(16 + safety_margin)) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
     if simdutf_constexpr (!match_system(big_endian)) {
       in = lsx_swap_bytes(in);
@@ -498,7 +498,7 @@ lsx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k - 1),
                 reinterpret_cast<char *>(utf8_output));
           }
@@ -513,6 +513,6 @@ lsx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
     }
   } // while
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        reinterpret_cast<char *>(utf8_output));
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             reinterpret_cast<char *>(utf8_output));
 }

--- a/src/lsx/lsx_convert_utf32_to_latin1.cpp
+++ b/src/lsx/lsx_convert_utf32_to_latin1.cpp
@@ -1,4 +1,4 @@
-std::pair<const char32_t *, char *>
+internal::pair<const char32_t *, char *>
 lsx_convert_utf32_to_latin1(const char32_t *buf, size_t len,
                             char *latin1_output) {
   const char32_t *end = buf + len;
@@ -19,13 +19,14 @@ lsx_convert_utf32_to_latin1(const char32_t *buf, size_t len,
       buf += 8;
       latin1_output += 8;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return internal::pair<const char32_t *, char *>{
+          nullptr, reinterpret_cast<char *>(latin1_output)};
     }
   } // while
-  return std::make_pair(buf, latin1_output);
+  return internal::make_pair(buf, latin1_output);
 }
 
-std::pair<result, char *>
+internal::pair<result, char *>
 lsx_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
                                         char *latin1_output) {
   const char32_t *start = buf;
@@ -55,12 +56,12 @@ lsx_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
         if (word <= 0xff) {
           *latin1_output++ = char(word);
         } else {
-          return std::make_pair(result(error_code::TOO_LARGE, buf - start + k),
-                                latin1_output);
+          return internal::make_pair(
+              result(error_code::TOO_LARGE, buf - start + k), latin1_output);
         }
       }
     }
   } // while
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        latin1_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             latin1_output);
 }

--- a/src/lsx/lsx_convert_utf32_to_utf16.cpp
+++ b/src/lsx/lsx_convert_utf32_to_utf16.cpp
@@ -1,5 +1,5 @@
 template <endianness big_endian>
-std::pair<const char32_t *, char16_t *>
+internal::pair<const char32_t *, char16_t *>
 lsx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
                            char16_t *utf16_out) {
   uint16_t *utf16_output = reinterpret_cast<uint16_t *>(utf16_out);
@@ -38,8 +38,8 @@ lsx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
         if ((word & 0xFFFF0000) == 0) {
           // will not generate a surrogate pair
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char16_t *>(utf16_output));
+            return internal::pair<const char32_t *, char16_t *>{
+                nullptr, reinterpret_cast<char16_t *>(utf16_output)};
           }
           *utf16_output++ = !match_system(big_endian)
                                 ? char16_t(word >> 8 | word << 8)
@@ -47,8 +47,8 @@ lsx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
         } else {
           // will generate a surrogate pair
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char16_t *>(utf16_output));
+            return internal::pair<const char32_t *, char16_t *>{
+                nullptr, reinterpret_cast<char16_t *>(utf16_output)};
           }
           word -= 0x10000;
           uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
@@ -68,13 +68,14 @@ lsx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
 
   // check for invalid input
   if (__lsx_bnz_v(forbidden_bytemask)) {
-    return std::make_pair(nullptr, reinterpret_cast<char16_t *>(utf16_output));
+    return internal::pair<const char32_t *, char16_t *>{
+        nullptr, reinterpret_cast<char16_t *>(utf16_output)};
   }
-  return std::make_pair(buf, reinterpret_cast<char16_t *>(utf16_output));
+  return internal::make_pair(buf, reinterpret_cast<char16_t *>(utf16_output));
 }
 
 template <endianness big_endian>
-std::pair<result, char16_t *>
+internal::pair<result, char16_t *>
 lsx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
                                        char16_t *utf16_out) {
   uint16_t *utf16_output = reinterpret_cast<uint16_t *>(utf16_out);
@@ -98,8 +99,8 @@ lsx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
               __lsx_vsle_h(v_d800, utf16_packed)), // utf16_packed >= 0xd800
           forbidden_bytemask);
       if (__lsx_bnz_v(forbidden_bytemask)) {
-        return std::make_pair(result(error_code::SURROGATE, buf - start),
-                              reinterpret_cast<char16_t *>(utf16_output));
+        return internal::make_pair(result(error_code::SURROGATE, buf - start),
+                                   reinterpret_cast<char16_t *>(utf16_output));
       }
 
       if simdutf_constexpr (!match_system(big_endian)) {
@@ -120,7 +121,7 @@ lsx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
         if ((word & 0xFFFF0000) == 0) {
           // will not generate a surrogate pair
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k),
                 reinterpret_cast<char16_t *>(utf16_output));
           }
@@ -130,7 +131,7 @@ lsx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
         } else {
           // will generate a surrogate pair
           if (word > 0x10FFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::TOO_LARGE, buf - start + k),
                 reinterpret_cast<char16_t *>(utf16_output));
           }
@@ -150,6 +151,6 @@ lsx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
     }
   }
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        reinterpret_cast<char16_t *>(utf16_output));
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             reinterpret_cast<char16_t *>(utf16_output));
 }

--- a/src/lsx/lsx_convert_utf32_to_utf8.cpp
+++ b/src/lsx/lsx_convert_utf32_to_utf8.cpp
@@ -1,4 +1,4 @@
-std::pair<const char32_t *, char *>
+internal::pair<const char32_t *, char *>
 lsx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
   const char32_t *end = buf + len;
@@ -13,7 +13,7 @@ lsx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (end - buf > std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf > internal::ptrdiff_t(16 + safety_margin)) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m128i nextin = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 16);
 
@@ -197,16 +197,16 @@ lsx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) {
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char *>(utf8_output));
+            return internal::pair<const char32_t *, char *>{
+                nullptr, reinterpret_cast<char *>(utf8_output)};
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
           *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else {
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr,
-                                  reinterpret_cast<char *>(utf8_output));
+            return internal::pair<const char32_t *, char *>{
+                nullptr, reinterpret_cast<char *>(utf8_output)};
           }
           *utf8_output++ = char((word >> 18) | 0b11110000);
           *utf8_output++ = char(((word >> 12) & 0b111111) | 0b10000000);
@@ -220,13 +220,14 @@ lsx_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
 
   // check for invalid input
   if (__lsx_bnz_v(forbidden_bytemask)) {
-    return std::make_pair(nullptr, reinterpret_cast<char *>(utf8_output));
+    return internal::pair<const char32_t *, char *>{
+        nullptr, reinterpret_cast<char *>(utf8_output)};
   }
 
-  return std::make_pair(buf, reinterpret_cast<char *>(utf8_output));
+  return internal::make_pair(buf, reinterpret_cast<char *>(utf8_output));
 }
 
-std::pair<result, char *>
+internal::pair<result, char *>
 lsx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
                                       char *utf8_out) {
   uint8_t *utf8_output = reinterpret_cast<uint8_t *>(utf8_out);
@@ -242,7 +243,7 @@ lsx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (end - buf > std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf > internal::ptrdiff_t(16 + safety_margin)) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 0);
     __m128i nextin = __lsx_vld(reinterpret_cast<const uint32_t *>(buf), 16);
 
@@ -309,8 +310,8 @@ lsx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
                 __lsx_vsle_h(v_d800, utf16_packed)), // utf16_packed >= 0xd800
             forbidden_bytemask);
         if (__lsx_bnz_v(forbidden_bytemask)) {
-          return std::make_pair(result(error_code::SURROGATE, buf - start),
-                                reinterpret_cast<char *>(utf8_output));
+          return internal::make_pair(result(error_code::SURROGATE, buf - start),
+                                     reinterpret_cast<char *>(utf8_output));
         }
         /* In this branch we handle three cases:
     1. [0000|0000|0ccc|cccc] => [0ccc|cccc]                           - single
@@ -431,7 +432,7 @@ lsx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) {
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k),
                 reinterpret_cast<char *>(utf8_output));
           }
@@ -440,7 +441,7 @@ lsx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else {
           if (word > 0x10FFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::TOO_LARGE, buf - start + k),
                 reinterpret_cast<char *>(utf8_output));
           }
@@ -454,6 +455,6 @@ lsx_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
     }
   } // while
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        reinterpret_cast<char *>(utf8_output));
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             reinterpret_cast<char *>(utf8_output));
 }

--- a/src/lsx/lsx_convert_utf8_to_latin1.cpp
+++ b/src/lsx/lsx_convert_utf8_to_latin1.cpp
@@ -69,7 +69,7 @@ size_t convert_masked_utf8_to_latin1(const char *input,
   uint64_t buffer[2];
   // __lsx_vst(latin1_packed, reinterpret_cast<uint8_t *>(latin1_output), 0);
   __lsx_vst(latin1_packed, reinterpret_cast<uint8_t *>(buffer), 0);
-  std::memcpy(latin1_output, buffer, 6);
+  internal::memcpy(latin1_output, buffer, 6);
   latin1_output += 6; // We wrote 6 bytes.
   return consumed;
 }

--- a/src/lsx/lsx_convert_utf8_to_utf16.cpp
+++ b/src/lsx/lsx_convert_utf8_to_utf16.cpp
@@ -189,7 +189,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
       }
       // __lsx_vst(composed, reinterpret_cast<uint16_t *>(utf16_output), 0);
       __lsx_vst(composed, reinterpret_cast<uint16_t *>(buffer), 0);
-      std::memcpy(utf16_output, buffer, 12);
+      internal::memcpy(utf16_output, buffer, 12);
       utf16_output += 6; // We 3 32-bit surrogate pairs.
       return 12;         // We consumed 12 bytes.
     }

--- a/src/ppc64/ppc64_base64.cpp
+++ b/src/ppc64/ppc64_base64.cpp
@@ -314,7 +314,7 @@ static simdutf_really_inline void base64_decode_block_safe(char *out,
 
   char buffer[16];
   base64_decode(buffer, vector_u8::load(src + 3 * 16));
-  std::memcpy(out + 36, buffer, 12);
+  internal::memcpy(out + 36, buffer, 12);
 }
 
 // ---base64 decoding::block64 class --------------------------
@@ -475,6 +475,6 @@ public:
     base64_decode(out + 12 * 2, b.chunks[2]);
     char buffer[16];
     base64_decode(buffer, b.chunks[3]);
-    std::memcpy(out + 12 * 3, buffer, 12);
+    internal::memcpy(out + 12 * 3, buffer, 12);
   }
 };

--- a/src/ppc64/ppc64_convert_latin1_to_utf32.cpp
+++ b/src/ppc64/ppc64_convert_latin1_to_utf32.cpp
@@ -1,4 +1,4 @@
-std::pair<const char *, char32_t *>
+internal::pair<const char *, char32_t *>
 ppc64_convert_latin1_to_utf32(const char *buf, size_t len,
                               char32_t *utf32_output) {
   const size_t rounded_len = align_down<vector_u8::ELEMENTS>(len);
@@ -8,5 +8,5 @@ ppc64_convert_latin1_to_utf32(const char *buf, size_t len,
     in.store_bytes_as_utf32(&utf32_output[i]);
   }
 
-  return std::make_pair(buf + rounded_len, utf32_output + rounded_len);
+  return internal::make_pair(buf + rounded_len, utf32_output + rounded_len);
 }

--- a/src/ppc64/ppc64_convert_latin1_to_utf8.cpp
+++ b/src/ppc64/ppc64_convert_latin1_to_utf8.cpp
@@ -1,4 +1,4 @@
-std::pair<const char *const, char *const>
+internal::pair<const char *, char *>
 ppc64_convert_latin1_to_utf8(const char *latin_input,
                              const size_t latin_input_length,
                              char *utf8_output) {
@@ -72,5 +72,5 @@ ppc64_convert_latin1_to_utf8(const char *latin_input,
     }
   }
 
-  return std::make_pair(latin_input, utf8_output);
+  return internal::make_pair(latin_input, utf8_output);
 }

--- a/src/ppc64/ppc64_convert_utf16_to_utf8.cpp
+++ b/src/ppc64/ppc64_convert_utf16_to_utf8.cpp
@@ -183,7 +183,7 @@ utf16_to_utf8_t ppc64_convert_utf16_to_utf8(const char16_t *buf, size_t len,
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= internal::ptrdiff_t(16 + safety_margin)) {
     auto in = vector_u16::load(buf);
     if (not match_system(big_endian)) {
       in = in.swap_bytes();

--- a/src/ppc64/ppc64_convert_utf32_to_utf8.cpp
+++ b/src/ppc64/ppc64_convert_utf32_to_utf8.cpp
@@ -20,7 +20,7 @@ utf32_to_utf8_t ppc64_convert_utf32_to_utf8(const char32_t *buf, size_t len,
           // https://github.com/simdutf/simdutf/issues/92
 
   while (end - buf >=
-         std::ptrdiff_t(
+         internal::ptrdiff_t(
              16 + safety_margin)) { // buf is a char32_t pointer, each char32_t
                                     // has 4 bytes or 32 bits, thus buf + 16 *
                                     // char_32t = 512 bits = 64 bytes

--- a/src/ppc64/ppc64_utf8_length_from_latin1.cpp
+++ b/src/ppc64/ppc64_utf8_length_from_latin1.cpp
@@ -1,7 +1,7 @@
 template <typename T> T min(T a, T b) { return a <= b ? a : b; }
 
-std::pair<const char *, size_t> ppc64_utf8_length_from_latin1(const char *input,
-                                                              size_t length) {
+internal::pair<const char *, size_t>
+ppc64_utf8_length_from_latin1(const char *input, size_t length) {
   constexpr size_t N = vector_u8::ELEMENTS;
   length = (length / N);
 
@@ -33,5 +33,5 @@ std::pair<const char *, size_t> ppc64_utf8_length_from_latin1(const char *input,
     }
   }
 
-  return std::make_pair(input, count);
+  return internal::make_pair(input, count);
 }

--- a/src/rvv/rvv_utf8_to.inl.cpp
+++ b/src/rvv/rvv_utf8_to.inl.cpp
@@ -2,10 +2,10 @@
 template <typename Tdst, simdutf_ByteFlip bflip, bool validate = true>
 simdutf_really_inline static size_t rvv_utf8_to_common(char const *src,
                                                        size_t len, Tdst *dst) {
-  static_assert(std::is_same<Tdst, uint16_t>() ||
-                    std::is_same<Tdst, uint32_t>(),
+  static_assert(simdutf::internal::is_same<Tdst, uint16_t>::value ||
+                    simdutf::internal::is_same<Tdst, uint32_t>::value,
                 "invalid type");
-  constexpr bool is16 = std::is_same<Tdst, uint16_t>();
+  constexpr bool is16 = simdutf::internal::is_same<Tdst, uint16_t>::value;
   constexpr endianness endian =
       bflip == simdutf_ByteFlip::NONE ? endianness::LITTLE : endianness::BIG;
   const auto scalar = [](char const *in, size_t count, Tdst *out) {

--- a/src/simdutf/arm64/simd.h
+++ b/src/simdutf/arm64/simd.h
@@ -3,7 +3,6 @@
 
 #include "simdutf.h"
 #include "simdutf/arm64/bitmanipulation.h"
-#include <type_traits>
 
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {

--- a/src/simdutf/arm64/simd16-inl.h
+++ b/src/simdutf/arm64/simd16-inl.h
@@ -268,10 +268,12 @@ template <> struct simd16<uint16_t> : base16_numeric<uint16_t> {
   }
 
   void dump() const {
+#ifdef SIMDUTF_LOGGING
     uint16_t temp[8];
     vst1q_u16(temp, *this);
     printf("[%04x, %04x, %04x, %04x, %04x, %04x, %04x, %04x]\n", temp[0],
            temp[1], temp[2], temp[3], temp[4], temp[5], temp[6], temp[7]);
+#endif // SIMDUTF_LOGGING
   }
 
   simdutf_really_inline uint32_t sum() const { return vaddlvq_u16(value); }

--- a/src/simdutf/fallback/bitmanipulation.h
+++ b/src/simdutf/fallback/bitmanipulation.h
@@ -2,7 +2,6 @@
 #define SIMDUTF_FALLBACK_BITMANIPULATION_H
 
 #include "simdutf.h"
-#include <limits>
 
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {

--- a/src/simdutf/lasx/bitmanipulation.h
+++ b/src/simdutf/lasx/bitmanipulation.h
@@ -2,7 +2,6 @@
 #define SIMDUTF_LASX_BITMANIPULATION_H
 
 #include "simdutf.h"
-#include <limits>
 
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {

--- a/src/simdutf/lsx/bitmanipulation.h
+++ b/src/simdutf/lsx/bitmanipulation.h
@@ -2,7 +2,6 @@
 #define SIMDUTF_LSX_BITMANIPULATION_H
 
 #include "simdutf.h"
-#include <limits>
 
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {

--- a/src/simdutf/ppc64/simd.h
+++ b/src/simdutf/ppc64/simd.h
@@ -3,7 +3,7 @@
 
 #include "simdutf.h"
 #include "simdutf/ppc64/bitmanipulation.h"
-#include <type_traits>
+#include <stdio.h>
 
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
@@ -22,34 +22,50 @@ using vec_i32_t = __vector signed int;
 using vec_u64_t = __vector unsigned long long;
 using vec_i64_t = __vector signed long long;
 
-// clang-format off
 template <typename T> struct vector_u8_type_for_element_aux {
-  using type = typename std::conditional<std::is_same<T, bool>::value,    vec_bool_t,
-               typename std::conditional<std::is_same<T, uint8_t>::value, vec_u8_t,
-               typename std::conditional<std::is_same<T, int8_t>::value,  vec_i8_t, void>::type>::type>::type;
-
-  static_assert(not std::is_same<type, void>::value,
+  using type = void;
+  static_assert(!internal::is_same<T, T>::value,
                 "accepted element types are 8 bit integers or bool");
+};
+template <> struct vector_u8_type_for_element_aux<bool> {
+  using type = vec_bool_t;
+};
+template <> struct vector_u8_type_for_element_aux<uint8_t> {
+  using type = vec_u8_t;
+};
+template <> struct vector_u8_type_for_element_aux<int8_t> {
+  using type = vec_i8_t;
 };
 
 template <typename T> struct vector_u16_type_for_element_aux {
-  using type = typename std::conditional<std::is_same<T, bool>::value,     vec_bool16_t,
-               typename std::conditional<std::is_same<T, uint16_t>::value, vec_u16_t,
-               typename std::conditional<std::is_same<T, int16_t>::value,  vec_i16_t, void>::type>::type>::type;
-
-  static_assert(not std::is_same<type, void>::value,
+  using type = void;
+  static_assert(!internal::is_same<T, T>::value,
                 "accepted element types are 16 bit integers or bool");
+};
+template <> struct vector_u16_type_for_element_aux<bool> {
+  using type = vec_bool16_t;
+};
+template <> struct vector_u16_type_for_element_aux<uint16_t> {
+  using type = vec_u16_t;
+};
+template <> struct vector_u16_type_for_element_aux<int16_t> {
+  using type = vec_i16_t;
 };
 
 template <typename T> struct vector_u32_type_for_element_aux {
-  using type = typename std::conditional<std::is_same<T, bool>::value,     vec_bool32_t,
-               typename std::conditional<std::is_same<T, uint32_t>::value, vec_u32_t,
-               typename std::conditional<std::is_same<T, int32_t>::value,  vec_i32_t, void>::type>::type>::type;
-
-  static_assert(not std::is_same<type, void>::value,
+  using type = void;
+  static_assert(!internal::is_same<T, T>::value,
                 "accepted element types are 32 bit integers or bool");
 };
-// clang-format on
+template <> struct vector_u32_type_for_element_aux<bool> {
+  using type = vec_bool32_t;
+};
+template <> struct vector_u32_type_for_element_aux<uint32_t> {
+  using type = vec_u32_t;
+};
+template <> struct vector_u32_type_for_element_aux<int32_t> {
+  using type = vec_i32_t;
+};
 
 template <typename T>
 using vector_u8_type_for_element =

--- a/src/simdutf_c.cpp
+++ b/src/simdutf_c.cpp
@@ -8,6 +8,25 @@ static simdutf_result to_c_result(const simdutf::result &r) {
   return out;
 }
 
+using cpp_char16 = decltype(u'\0');
+using cpp_char32 = decltype(U'\0');
+
+static simdutf_really_inline const cpp_char16 *to_cpp_ptr(const char16_t *ptr) {
+  return reinterpret_cast<const cpp_char16 *>(ptr);
+}
+
+static simdutf_really_inline cpp_char16 *to_cpp_ptr(char16_t *ptr) {
+  return reinterpret_cast<cpp_char16 *>(ptr);
+}
+
+static simdutf_really_inline const cpp_char32 *to_cpp_ptr(const char32_t *ptr) {
+  return reinterpret_cast<const cpp_char32 *>(ptr);
+}
+
+static simdutf_really_inline cpp_char32 *to_cpp_ptr(char32_t *ptr) {
+  return reinterpret_cast<cpp_char32 *>(ptr);
+}
+
 /* The C wrapper depends on the library features. Only expose the C API
    when all relevant feature is enabled. This helps the
    single-header generator to omit the C wrapper when features are
@@ -43,66 +62,68 @@ simdutf_result simdutf_validate_ascii_with_errors(const char *buf, size_t len) {
 }
 
 bool simdutf_validate_utf16_as_ascii(const char16_t *buf, size_t len) {
-  return simdutf::validate_utf16_as_ascii(buf, len);
+  return simdutf::validate_utf16_as_ascii(to_cpp_ptr(buf), len);
 }
 bool simdutf_validate_utf16be_as_ascii(const char16_t *buf, size_t len) {
-  return simdutf::validate_utf16be_as_ascii(buf, len);
+  return simdutf::validate_utf16be_as_ascii(to_cpp_ptr(buf), len);
 }
 bool simdutf_validate_utf16le_as_ascii(const char16_t *buf, size_t len) {
-  return simdutf::validate_utf16le_as_ascii(buf, len);
+  return simdutf::validate_utf16le_as_ascii(to_cpp_ptr(buf), len);
 }
 
 bool simdutf_validate_utf16(const char16_t *buf, size_t len) {
-  return simdutf::validate_utf16(buf, len);
+  return simdutf::validate_utf16(to_cpp_ptr(buf), len);
 }
 bool simdutf_validate_utf16le(const char16_t *buf, size_t len) {
-  return simdutf::validate_utf16le(buf, len);
+  return simdutf::validate_utf16le(to_cpp_ptr(buf), len);
 }
 bool simdutf_validate_utf16be(const char16_t *buf, size_t len) {
-  return simdutf::validate_utf16be(buf, len);
+  return simdutf::validate_utf16be(to_cpp_ptr(buf), len);
 }
 simdutf_result simdutf_validate_utf16_with_errors(const char16_t *buf,
                                                   size_t len) {
-  return to_c_result(simdutf::validate_utf16_with_errors(buf, len));
+  return to_c_result(simdutf::validate_utf16_with_errors(to_cpp_ptr(buf), len));
 }
 simdutf_result simdutf_validate_utf16le_with_errors(const char16_t *buf,
                                                     size_t len) {
-  return to_c_result(simdutf::validate_utf16le_with_errors(buf, len));
+  return to_c_result(
+      simdutf::validate_utf16le_with_errors(to_cpp_ptr(buf), len));
 }
 simdutf_result simdutf_validate_utf16be_with_errors(const char16_t *buf,
                                                     size_t len) {
-  return to_c_result(simdutf::validate_utf16be_with_errors(buf, len));
+  return to_c_result(
+      simdutf::validate_utf16be_with_errors(to_cpp_ptr(buf), len));
 }
 
 bool simdutf_validate_utf32(const char32_t *buf, size_t len) {
-  return simdutf::validate_utf32(buf, len);
+  return simdutf::validate_utf32(to_cpp_ptr(buf), len);
 }
 simdutf_result simdutf_validate_utf32_with_errors(const char32_t *buf,
                                                   size_t len) {
-  return to_c_result(simdutf::validate_utf32_with_errors(buf, len));
+  return to_c_result(simdutf::validate_utf32_with_errors(to_cpp_ptr(buf), len));
 }
 
 void simdutf_to_well_formed_utf16le(const char16_t *input, size_t len,
                                     char16_t *output) {
-  simdutf::to_well_formed_utf16le(input, len, output);
+  simdutf::to_well_formed_utf16le(to_cpp_ptr(input), len, to_cpp_ptr(output));
 }
 void simdutf_to_well_formed_utf16be(const char16_t *input, size_t len,
                                     char16_t *output) {
-  simdutf::to_well_formed_utf16be(input, len, output);
+  simdutf::to_well_formed_utf16be(to_cpp_ptr(input), len, to_cpp_ptr(output));
 }
 void simdutf_to_well_formed_utf16(const char16_t *input, size_t len,
                                   char16_t *output) {
-  simdutf::to_well_formed_utf16(input, len, output);
+  simdutf::to_well_formed_utf16(to_cpp_ptr(input), len, to_cpp_ptr(output));
 }
 
 size_t simdutf_count_utf16(const char16_t *input, size_t length) {
-  return simdutf::count_utf16(input, length);
+  return simdutf::count_utf16(to_cpp_ptr(input), length);
 }
 size_t simdutf_count_utf16le(const char16_t *input, size_t length) {
-  return simdutf::count_utf16le(input, length);
+  return simdutf::count_utf16le(to_cpp_ptr(input), length);
 }
 size_t simdutf_count_utf16be(const char16_t *input, size_t length) {
-  return simdutf::count_utf16be(input, length);
+  return simdutf::count_utf16be(to_cpp_ptr(input), length);
 }
 size_t simdutf_count_utf8(const char *input, size_t length) {
   return simdutf::count_utf8(input, length);
@@ -127,34 +148,34 @@ size_t simdutf_utf32_length_from_utf8(const char *input, size_t length) {
   return simdutf::utf32_length_from_utf8(input, length);
 }
 size_t simdutf_utf8_length_from_utf16(const char16_t *input, size_t length) {
-  return simdutf::utf8_length_from_utf16(input, length);
+  return simdutf::utf8_length_from_utf16(to_cpp_ptr(input), length);
 }
 size_t simdutf_utf8_length_from_utf32(const char32_t *input, size_t length) {
-  return simdutf::utf8_length_from_utf32(input, length);
+  return simdutf::utf8_length_from_utf32(to_cpp_ptr(input), length);
 }
 simdutf_result
 simdutf_utf8_length_from_utf16_with_replacement(const char16_t *input,
                                                 size_t length) {
-  return to_c_result(
-      simdutf::utf8_length_from_utf16_with_replacement(input, length));
+  return to_c_result(simdutf::utf8_length_from_utf16_with_replacement(
+      to_cpp_ptr(input), length));
 }
 size_t simdutf_utf8_length_from_utf16le(const char16_t *input, size_t length) {
-  return simdutf::utf8_length_from_utf16le(input, length);
+  return simdutf::utf8_length_from_utf16le(to_cpp_ptr(input), length);
 }
 size_t simdutf_utf8_length_from_utf16be(const char16_t *input, size_t length) {
-  return simdutf::utf8_length_from_utf16be(input, length);
+  return simdutf::utf8_length_from_utf16be(to_cpp_ptr(input), length);
 }
 simdutf_result
 simdutf_utf8_length_from_utf16le_with_replacement(const char16_t *input,
                                                   size_t length) {
-  return to_c_result(
-      simdutf::utf8_length_from_utf16le_with_replacement(input, length));
+  return to_c_result(simdutf::utf8_length_from_utf16le_with_replacement(
+      to_cpp_ptr(input), length));
 }
 simdutf_result
 simdutf_utf8_length_from_utf16be_with_replacement(const char16_t *input,
                                                   size_t length) {
-  return to_c_result(
-      simdutf::utf8_length_from_utf16be_with_replacement(input, length));
+  return to_c_result(simdutf::utf8_length_from_utf16be_with_replacement(
+      to_cpp_ptr(input), length));
 }
 
 /* Conversions: latin1 <-> utf8, utf8 <-> utf16/utf32, utf16 <-> utf8, etc. */
@@ -169,19 +190,19 @@ size_t simdutf_convert_latin1_to_utf8_safe(const char *input, size_t length,
 }
 size_t simdutf_convert_latin1_to_utf16le(const char *input, size_t length,
                                          char16_t *output) {
-  return simdutf::convert_latin1_to_utf16le(input, length, output);
+  return simdutf::convert_latin1_to_utf16le(input, length, to_cpp_ptr(output));
 }
 size_t simdutf_convert_latin1_to_utf16be(const char *input, size_t length,
                                          char16_t *output) {
-  return simdutf::convert_latin1_to_utf16be(input, length, output);
+  return simdutf::convert_latin1_to_utf16be(input, length, to_cpp_ptr(output));
 }
 size_t simdutf_convert_latin1_to_utf16(const char *input, size_t length,
                                        char16_t *output) {
-  return simdutf::convert_latin1_to_utf16(input, length, output);
+  return simdutf::convert_latin1_to_utf16(input, length, to_cpp_ptr(output));
 }
 size_t simdutf_convert_latin1_to_utf32(const char *input, size_t length,
                                        char32_t *output) {
-  return simdutf::convert_latin1_to_utf32(input, length, output);
+  return simdutf::convert_latin1_to_utf32(input, length, to_cpp_ptr(output));
 }
 
 size_t simdutf_convert_utf8_to_latin1(const char *input, size_t length,
@@ -190,19 +211,19 @@ size_t simdutf_convert_utf8_to_latin1(const char *input, size_t length,
 }
 size_t simdutf_convert_utf8_to_utf16le(const char *input, size_t length,
                                        char16_t *output) {
-  return simdutf::convert_utf8_to_utf16le(input, length, output);
+  return simdutf::convert_utf8_to_utf16le(input, length, to_cpp_ptr(output));
 }
 size_t simdutf_convert_utf8_to_utf16(const char *input, size_t length,
                                      char16_t *output) {
-  return simdutf::convert_utf8_to_utf16(input, length, output);
+  return simdutf::convert_utf8_to_utf16(input, length, to_cpp_ptr(output));
 }
 size_t simdutf_convert_utf8_to_utf16be(const char *input, size_t length,
                                        char16_t *output) {
-  return simdutf::convert_utf8_to_utf16be(input, length, output);
+  return simdutf::convert_utf8_to_utf16be(input, length, to_cpp_ptr(output));
 }
 size_t simdutf_convert_utf8_to_utf32(const char *input, size_t length,
                                      char32_t *output) {
-  return simdutf::convert_utf8_to_utf32(input, length, output);
+  return simdutf::convert_utf8_to_utf32(input, length, to_cpp_ptr(output));
 }
 simdutf_result simdutf_convert_utf8_to_latin1_with_errors(const char *input,
                                                           size_t length,
@@ -213,26 +234,26 @@ simdutf_result simdutf_convert_utf8_to_latin1_with_errors(const char *input,
 simdutf_result simdutf_convert_utf8_to_utf16_with_errors(const char *input,
                                                          size_t length,
                                                          char16_t *output) {
-  return to_c_result(
-      simdutf::convert_utf8_to_utf16_with_errors(input, length, output));
+  return to_c_result(simdutf::convert_utf8_to_utf16_with_errors(
+      input, length, to_cpp_ptr(output)));
 }
 simdutf_result simdutf_convert_utf8_to_utf16le_with_errors(const char *input,
                                                            size_t length,
                                                            char16_t *output) {
-  return to_c_result(
-      simdutf::convert_utf8_to_utf16le_with_errors(input, length, output));
+  return to_c_result(simdutf::convert_utf8_to_utf16le_with_errors(
+      input, length, to_cpp_ptr(output)));
 }
 simdutf_result simdutf_convert_utf8_to_utf16be_with_errors(const char *input,
                                                            size_t length,
                                                            char16_t *output) {
-  return to_c_result(
-      simdutf::convert_utf8_to_utf16be_with_errors(input, length, output));
+  return to_c_result(simdutf::convert_utf8_to_utf16be_with_errors(
+      input, length, to_cpp_ptr(output)));
 }
 simdutf_result simdutf_convert_utf8_to_utf32_with_errors(const char *input,
                                                          size_t length,
                                                          char32_t *output) {
-  return to_c_result(
-      simdutf::convert_utf8_to_utf32_with_errors(input, length, output));
+  return to_c_result(simdutf::convert_utf8_to_utf32_with_errors(
+      input, length, to_cpp_ptr(output)));
 }
 
 /* Conversions assuming valid input */
@@ -242,190 +263,210 @@ size_t simdutf_convert_valid_utf8_to_latin1(const char *input, size_t length,
 }
 size_t simdutf_convert_valid_utf8_to_utf16le(const char *input, size_t length,
                                              char16_t *output) {
-  return simdutf::convert_valid_utf8_to_utf16le(input, length, output);
+  return simdutf::convert_valid_utf8_to_utf16le(input, length,
+                                                to_cpp_ptr(output));
 }
 size_t simdutf_convert_valid_utf8_to_utf16be(const char *input, size_t length,
                                              char16_t *output) {
-  return simdutf::convert_valid_utf8_to_utf16be(input, length, output);
+  return simdutf::convert_valid_utf8_to_utf16be(input, length,
+                                                to_cpp_ptr(output));
 }
 size_t simdutf_convert_valid_utf8_to_utf32(const char *input, size_t length,
                                            char32_t *output) {
-  return simdutf::convert_valid_utf8_to_utf32(input, length, output);
+  return simdutf::convert_valid_utf8_to_utf32(input, length,
+                                              to_cpp_ptr(output));
 }
 
 /* UTF-16 -> UTF-8 and related conversions */
 size_t simdutf_convert_utf16_to_utf8(const char16_t *input, size_t length,
                                      char *output) {
-  return simdutf::convert_utf16_to_utf8(input, length, output);
+  return simdutf::convert_utf16_to_utf8(to_cpp_ptr(input), length, output);
 }
 size_t simdutf_convert_utf16_to_utf8_safe(const char16_t *input, size_t length,
                                           char *output, size_t utf8_len) {
-  return simdutf::convert_utf16_to_utf8_safe(input, length, output, utf8_len);
+  return simdutf::convert_utf16_to_utf8_safe(to_cpp_ptr(input), length, output,
+                                             utf8_len);
 }
 size_t simdutf_convert_utf16_to_latin1(const char16_t *input, size_t length,
                                        char *output) {
-  return simdutf::convert_utf16_to_latin1(input, length, output);
+  return simdutf::convert_utf16_to_latin1(to_cpp_ptr(input), length, output);
 }
 size_t simdutf_convert_utf16le_to_latin1(const char16_t *input, size_t length,
                                          char *output) {
-  return simdutf::convert_utf16le_to_latin1(input, length, output);
+  return simdutf::convert_utf16le_to_latin1(to_cpp_ptr(input), length, output);
 }
 size_t simdutf_convert_utf16be_to_latin1(const char16_t *input, size_t length,
                                          char *output) {
-  return simdutf::convert_utf16be_to_latin1(input, length, output);
+  return simdutf::convert_utf16be_to_latin1(to_cpp_ptr(input), length, output);
 }
 simdutf_result
 simdutf_convert_utf16_to_latin1_with_errors(const char16_t *input,
                                             size_t length, char *output) {
-  return to_c_result(
-      simdutf::convert_utf16_to_latin1_with_errors(input, length, output));
+  return to_c_result(simdutf::convert_utf16_to_latin1_with_errors(
+      to_cpp_ptr(input), length, output));
 }
 simdutf_result
 simdutf_convert_utf16le_to_latin1_with_errors(const char16_t *input,
                                               size_t length, char *output) {
-  return to_c_result(
-      simdutf::convert_utf16le_to_latin1_with_errors(input, length, output));
+  return to_c_result(simdutf::convert_utf16le_to_latin1_with_errors(
+      to_cpp_ptr(input), length, output));
 }
 simdutf_result
 simdutf_convert_utf16be_to_latin1_with_errors(const char16_t *input,
                                               size_t length, char *output) {
-  return to_c_result(
-      simdutf::convert_utf16be_to_latin1_with_errors(input, length, output));
+  return to_c_result(simdutf::convert_utf16be_to_latin1_with_errors(
+      to_cpp_ptr(input), length, output));
 }
 
 simdutf_result simdutf_convert_utf16_to_utf8_with_errors(const char16_t *input,
                                                          size_t length,
                                                          char *output) {
-  return to_c_result(
-      simdutf::convert_utf16_to_utf8_with_errors(input, length, output));
+  return to_c_result(simdutf::convert_utf16_to_utf8_with_errors(
+      to_cpp_ptr(input), length, output));
 }
 simdutf_result
 simdutf_convert_utf16le_to_utf8_with_errors(const char16_t *input,
                                             size_t length, char *output) {
-  return to_c_result(
-      simdutf::convert_utf16le_to_utf8_with_errors(input, length, output));
+  return to_c_result(simdutf::convert_utf16le_to_utf8_with_errors(
+      to_cpp_ptr(input), length, output));
 }
 simdutf_result
 simdutf_convert_utf16be_to_utf8_with_errors(const char16_t *input,
                                             size_t length, char *output) {
-  return to_c_result(
-      simdutf::convert_utf16be_to_utf8_with_errors(input, length, output));
+  return to_c_result(simdutf::convert_utf16be_to_utf8_with_errors(
+      to_cpp_ptr(input), length, output));
 }
 
 size_t simdutf_convert_utf16le_to_utf8(const char16_t *input, size_t length,
                                        char *output) {
-  return simdutf::convert_utf16le_to_utf8(input, length, output);
+  return simdutf::convert_utf16le_to_utf8(to_cpp_ptr(input), length, output);
 }
 size_t simdutf_convert_utf16be_to_utf8(const char16_t *input, size_t length,
                                        char *output) {
-  return simdutf::convert_utf16be_to_utf8(input, length, output);
+  return simdutf::convert_utf16be_to_utf8(to_cpp_ptr(input), length, output);
 }
 
 size_t simdutf_convert_valid_utf16_to_utf8(const char16_t *input, size_t length,
                                            char *output) {
-  return simdutf::convert_valid_utf16_to_utf8(input, length, output);
+  return simdutf::convert_valid_utf16_to_utf8(to_cpp_ptr(input), length,
+                                              output);
 }
 size_t simdutf_convert_valid_utf16_to_latin1(const char16_t *input,
                                              size_t length, char *output) {
-  return simdutf::convert_valid_utf16_to_latin1(input, length, output);
+  return simdutf::convert_valid_utf16_to_latin1(to_cpp_ptr(input), length,
+                                                output);
 }
 size_t simdutf_convert_valid_utf16le_to_latin1(const char16_t *input,
                                                size_t length, char *output) {
-  return simdutf::convert_valid_utf16le_to_latin1(input, length, output);
+  return simdutf::convert_valid_utf16le_to_latin1(to_cpp_ptr(input), length,
+                                                  output);
 }
 size_t simdutf_convert_valid_utf16be_to_latin1(const char16_t *input,
                                                size_t length, char *output) {
-  return simdutf::convert_valid_utf16be_to_latin1(input, length, output);
+  return simdutf::convert_valid_utf16be_to_latin1(to_cpp_ptr(input), length,
+                                                  output);
 }
 
 size_t simdutf_convert_valid_utf16le_to_utf8(const char16_t *input,
                                              size_t length, char *output) {
-  return simdutf::convert_valid_utf16le_to_utf8(input, length, output);
+  return simdutf::convert_valid_utf16le_to_utf8(to_cpp_ptr(input), length,
+                                                output);
 }
 size_t simdutf_convert_valid_utf16be_to_utf8(const char16_t *input,
                                              size_t length, char *output) {
-  return simdutf::convert_valid_utf16be_to_utf8(input, length, output);
+  return simdutf::convert_valid_utf16be_to_utf8(to_cpp_ptr(input), length,
+                                                output);
 }
 
 /* UTF-16 <-> UTF-32 conversions */
 size_t simdutf_convert_utf16_to_utf32(const char16_t *input, size_t length,
                                       char32_t *output) {
-  return simdutf::convert_utf16_to_utf32(input, length, output);
+  return simdutf::convert_utf16_to_utf32(to_cpp_ptr(input), length,
+                                         to_cpp_ptr(output));
 }
 size_t simdutf_convert_utf16le_to_utf32(const char16_t *input, size_t length,
                                         char32_t *output) {
-  return simdutf::convert_utf16le_to_utf32(input, length, output);
+  return simdutf::convert_utf16le_to_utf32(to_cpp_ptr(input), length,
+                                           to_cpp_ptr(output));
 }
 size_t simdutf_convert_utf16be_to_utf32(const char16_t *input, size_t length,
                                         char32_t *output) {
-  return simdutf::convert_utf16be_to_utf32(input, length, output);
+  return simdutf::convert_utf16be_to_utf32(to_cpp_ptr(input), length,
+                                           to_cpp_ptr(output));
 }
 simdutf_result simdutf_convert_utf16_to_utf32_with_errors(const char16_t *input,
                                                           size_t length,
                                                           char32_t *output) {
-  return to_c_result(
-      simdutf::convert_utf16_to_utf32_with_errors(input, length, output));
+  return to_c_result(simdutf::convert_utf16_to_utf32_with_errors(
+      to_cpp_ptr(input), length, to_cpp_ptr(output)));
 }
 simdutf_result
 simdutf_convert_utf16le_to_utf32_with_errors(const char16_t *input,
                                              size_t length, char32_t *output) {
-  return to_c_result(
-      simdutf::convert_utf16le_to_utf32_with_errors(input, length, output));
+  return to_c_result(simdutf::convert_utf16le_to_utf32_with_errors(
+      to_cpp_ptr(input), length, to_cpp_ptr(output)));
 }
 simdutf_result
 simdutf_convert_utf16be_to_utf32_with_errors(const char16_t *input,
                                              size_t length, char32_t *output) {
-  return to_c_result(
-      simdutf::convert_utf16be_to_utf32_with_errors(input, length, output));
+  return to_c_result(simdutf::convert_utf16be_to_utf32_with_errors(
+      to_cpp_ptr(input), length, to_cpp_ptr(output)));
 }
 
 /* Valid UTF-16 conversions */
 size_t simdutf_convert_valid_utf16_to_utf32(const char16_t *input,
                                             size_t length, char32_t *output) {
-  return simdutf::convert_valid_utf16_to_utf32(input, length, output);
+  return simdutf::convert_valid_utf16_to_utf32(to_cpp_ptr(input), length,
+                                               to_cpp_ptr(output));
 }
 size_t simdutf_convert_valid_utf16le_to_utf32(const char16_t *input,
                                               size_t length, char32_t *output) {
-  return simdutf::convert_valid_utf16le_to_utf32(input, length, output);
+  return simdutf::convert_valid_utf16le_to_utf32(to_cpp_ptr(input), length,
+                                                 to_cpp_ptr(output));
 }
 size_t simdutf_convert_valid_utf16be_to_utf32(const char16_t *input,
                                               size_t length, char32_t *output) {
-  return simdutf::convert_valid_utf16be_to_utf32(input, length, output);
+  return simdutf::convert_valid_utf16be_to_utf32(to_cpp_ptr(input), length,
+                                                 to_cpp_ptr(output));
 }
 
 /* UTF-32 -> ... conversions */
 size_t simdutf_convert_utf32_to_utf8(const char32_t *input, size_t length,
                                      char *output) {
-  return simdutf::convert_utf32_to_utf8(input, length, output);
+  return simdutf::convert_utf32_to_utf8(to_cpp_ptr(input), length, output);
 }
 simdutf_result simdutf_convert_utf32_to_utf8_with_errors(const char32_t *input,
                                                          size_t length,
                                                          char *output) {
-  return to_c_result(
-      simdutf::convert_utf32_to_utf8_with_errors(input, length, output));
+  return to_c_result(simdutf::convert_utf32_to_utf8_with_errors(
+      to_cpp_ptr(input), length, output));
 }
 size_t simdutf_convert_valid_utf32_to_utf8(const char32_t *input, size_t length,
                                            char *output) {
-  return simdutf::convert_valid_utf32_to_utf8(input, length, output);
+  return simdutf::convert_valid_utf32_to_utf8(to_cpp_ptr(input), length,
+                                              output);
 }
 
 size_t simdutf_convert_utf32_to_utf16(const char32_t *input, size_t length,
                                       char16_t *output) {
-  return simdutf::convert_utf32_to_utf16(input, length, output);
+  return simdutf::convert_utf32_to_utf16(to_cpp_ptr(input), length,
+                                         to_cpp_ptr(output));
 }
 size_t simdutf_convert_utf32_to_utf16le(const char32_t *input, size_t length,
                                         char16_t *output) {
-  return simdutf::convert_utf32_to_utf16le(input, length, output);
+  return simdutf::convert_utf32_to_utf16le(to_cpp_ptr(input), length,
+                                           to_cpp_ptr(output));
 }
 size_t simdutf_convert_utf32_to_utf16be(const char32_t *input, size_t length,
                                         char16_t *output) {
-  return simdutf::convert_utf32_to_utf16be(input, length, output);
+  return simdutf::convert_utf32_to_utf16be(to_cpp_ptr(input), length,
+                                           to_cpp_ptr(output));
 }
 simdutf_result
 simdutf_convert_utf32_to_latin1_with_errors(const char32_t *input,
                                             size_t length, char *output) {
-  return to_c_result(
-      simdutf::convert_utf32_to_latin1_with_errors(input, length, output));
+  return to_c_result(simdutf::convert_utf32_to_latin1_with_errors(
+      to_cpp_ptr(input), length, output));
 }
 
 /* --- find helpers --- */
@@ -434,7 +475,8 @@ const char *simdutf_find(const char *start, const char *end, char character) {
 }
 const char16_t *simdutf_find_utf16(const char16_t *start, const char16_t *end,
                                    char16_t character) {
-  return simdutf::find(start, end, character);
+  return reinterpret_cast<const char16_t *>(simdutf::find(
+      to_cpp_ptr(start), to_cpp_ptr(end), static_cast<cpp_char16>(character)));
 }
 
 /* --- base64 helpers --- */
@@ -444,7 +486,7 @@ size_t simdutf_maximal_binary_length_from_base64(const char *input,
 }
 size_t simdutf_maximal_binary_length_from_base64_utf16(const char16_t *input,
                                                        size_t length) {
-  return simdutf::maximal_binary_length_from_base64(input, length);
+  return simdutf::maximal_binary_length_from_base64(to_cpp_ptr(input), length);
 }
 
 simdutf_result simdutf_base64_to_binary(
@@ -460,7 +502,8 @@ simdutf_result simdutf_base64_to_binary_utf16(
     simdutf_base64_options options,
     simdutf_last_chunk_handling_options last_chunk_options) {
   return to_c_result(simdutf::base64_to_binary(
-      input, length, output, static_cast<simdutf::base64_options>(options),
+      to_cpp_ptr(input), length, output,
+      static_cast<simdutf::base64_options>(options),
       static_cast<simdutf::last_chunk_handling_options>(last_chunk_options)));
 }
 
@@ -510,7 +553,7 @@ simdutf_result simdutf_base64_to_binary_safe_utf16(
     bool decode_up_to_bad_char) {
   size_t local_out = outlen ? *outlen : 0;
   simdutf::result r = simdutf::base64_to_binary_safe(
-      input, length, output, local_out,
+      to_cpp_ptr(input), length, output, local_out,
       static_cast<simdutf::base64_options>(options),
       static_cast<simdutf::last_chunk_handling_options>(last_chunk_options),
       decode_up_to_bad_char);
@@ -540,7 +583,8 @@ simdutf_full_result simdutf_base64_to_binary_details_utf16(
     simdutf_base64_options options,
     simdutf_last_chunk_handling_options last_chunk_options) {
   return to_c_full_result(simdutf::base64_to_binary_details(
-      input, length, output, static_cast<simdutf::base64_options>(options),
+      to_cpp_ptr(input), length, output,
+      static_cast<simdutf::base64_options>(options),
       static_cast<simdutf::last_chunk_handling_options>(last_chunk_options)));
 }
 
@@ -550,7 +594,7 @@ bool simdutf_base64_valid(char input, simdutf_base64_options options) {
 }
 bool simdutf_base64_valid_utf16(char16_t input,
                                 simdutf_base64_options options) {
-  return simdutf::base64_valid(input,
+  return simdutf::base64_valid(static_cast<cpp_char16>(input),
                                static_cast<simdutf::base64_options>(options));
 }
 

--- a/src/tables/utf8_to_utf16_tables.h
+++ b/src/tables/utf8_to_utf16_tables.h
@@ -1,6 +1,10 @@
 #ifndef SIMDUTF_UTF8_TO_UTF16_TABLES_H
 #define SIMDUTF_UTF8_TO_UTF16_TABLES_H
-#include <cstdint>
+#ifdef SIMDUTF_NO_LIBCXX
+  #include <stdint.h>
+#else
+  #include <cstdint>
+#endif
 
 namespace simdutf {
 namespace {

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -223,7 +223,7 @@ implementation::detect_encodings(const char *input,
 
   uint8_t block[64]{};
   size_t idx = reader.block_index();
-  std::memcpy(block, &input[idx], length - idx);
+  internal::memcpy(block, &input[idx], length - idx);
   simd::simd8x64<uint8_t> in(block);
   c.check_next_input(in);
 
@@ -438,7 +438,7 @@ simdutf_warn_unused result implementation::validate_utf32_with_errors(
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(
     const char *buf, size_t len, char *utf8_output) const noexcept {
 
-  std::pair<const char *, char *> ret =
+  internal::pair<const char *, char *> ret =
       sse_convert_latin1_to_utf8(buf, len, utf8_output);
   size_t converted_chars = ret.second - utf8_output;
 
@@ -455,7 +455,7 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf8(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16le(
     const char *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char *, char16_t *> ret =
+  internal::pair<const char *, char16_t *> ret =
       sse_convert_latin1_to_utf16<endianness::LITTLE>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -475,7 +475,7 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf16le(
 
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(
     const char *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char *, char16_t *> ret =
+  internal::pair<const char *, char16_t *> ret =
       sse_convert_latin1_to_utf16<endianness::BIG>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -497,7 +497,7 @@ simdutf_warn_unused size_t implementation::convert_latin1_to_utf16be(
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_latin1_to_utf32(
     const char *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char *, char32_t *> ret =
+  internal::pair<const char *, char32_t *> ret =
       sse_convert_latin1_to_utf32(buf, len, utf32_output);
   if (ret.first == nullptr) {
     return 0;
@@ -595,7 +595,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf8_to_utf32(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       sse_convert_utf16_to_latin1<endianness::LITTLE>(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -616,7 +616,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_latin1(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       sse_convert_utf16_to_latin1<endianness::BIG>(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -638,7 +638,7 @@ simdutf_warn_unused size_t implementation::convert_utf16be_to_latin1(
 simdutf_warn_unused result
 implementation::convert_utf16le_to_latin1_with_errors(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       sse_convert_utf16_to_latin1_with_errors<endianness::LITTLE>(
           buf, len, latin1_output);
   if (ret.first.error) {
@@ -665,7 +665,7 @@ implementation::convert_utf16le_to_latin1_with_errors(
 simdutf_warn_unused result
 implementation::convert_utf16be_to_latin1_with_errors(
     const char16_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       sse_convert_utf16_to_latin1_with_errors<endianness::BIG>(buf, len,
                                                                latin1_output);
   if (ret.first.error) {
@@ -705,7 +705,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_latin1(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 simdutf_warn_unused size_t implementation::convert_utf16le_to_utf8(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       sse_convert_utf16_to_utf8<endianness::LITTLE>(buf, len, utf8_output);
   if (ret.first == nullptr) {
     return 0;
@@ -725,7 +725,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_utf8(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_utf8(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char16_t *, char *> ret =
+  internal::pair<const char16_t *, char *> ret =
       sse_convert_utf16_to_utf8<endianness::BIG>(buf, len, utf8_output);
   if (ret.first == nullptr) {
     return 0;
@@ -747,7 +747,7 @@ simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       westmere::sse_convert_utf16_to_utf8_with_errors<endianness::LITTLE>(
           buf, len, utf8_output);
   if (ret.first.error) {
@@ -775,7 +775,7 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       westmere::sse_convert_utf16_to_utf8_with_errors<endianness::BIG>(
           buf, len, utf8_output);
   if (ret.first.error) {
@@ -813,7 +813,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf16be_to_utf8(
 #if SIMDUTF_FEATURE_UTF32 && SIMDUTF_FEATURE_LATIN1
 simdutf_warn_unused size_t implementation::convert_utf32_to_latin1(
     const char32_t *buf, size_t len, char *latin1_output) const noexcept {
-  std::pair<const char32_t *, char *> ret =
+  internal::pair<const char32_t *, char *> ret =
       sse_convert_utf32_to_latin1(buf, len, latin1_output);
   if (ret.first == nullptr) {
     return 0;
@@ -835,7 +835,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_latin1_with_errors(
     const char32_t *buf, size_t len, char *latin1_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       westmere::sse_convert_utf32_to_latin1_with_errors(buf, len,
                                                         latin1_output);
   if (ret.first.count != len) {
@@ -864,7 +864,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf32_to_latin1(
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf8(
     const char32_t *buf, size_t len, char *utf8_output) const noexcept {
-  std::pair<const char32_t *, char *> ret =
+  internal::pair<const char32_t *, char *> ret =
       sse_convert_utf32_to_utf8(buf, len, utf8_output);
   if (ret.first == nullptr) {
     return 0;
@@ -885,7 +885,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
     const char32_t *buf, size_t len, char *utf8_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char *> ret =
+  internal::pair<result, char *> ret =
       westmere::sse_convert_utf32_to_utf8_with_errors(buf, len, utf8_output);
   if (ret.first.count != len) {
     result scalar_res = scalar::utf32_to_utf8::convert_with_errors(
@@ -907,7 +907,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::convert_utf16le_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char16_t *, char32_t *> ret =
+  internal::pair<const char16_t *, char32_t *> ret =
       sse_convert_utf16_to_utf32<endianness::LITTLE>(buf, len, utf32_output);
   if (ret.first == nullptr) {
     return 0;
@@ -927,7 +927,7 @@ simdutf_warn_unused size_t implementation::convert_utf16le_to_utf32(
 
 simdutf_warn_unused size_t implementation::convert_utf16be_to_utf32(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
-  std::pair<const char16_t *, char32_t *> ret =
+  internal::pair<const char16_t *, char32_t *> ret =
       sse_convert_utf16_to_utf32<endianness::BIG>(buf, len, utf32_output);
   if (ret.first == nullptr) {
     return 0;
@@ -949,7 +949,7 @@ simdutf_warn_unused result implementation::convert_utf16le_to_utf32_with_errors(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char32_t *> ret =
+  internal::pair<result, char32_t *> ret =
       westmere::sse_convert_utf16_to_utf32_with_errors<endianness::LITTLE>(
           buf, len, utf32_output);
   if (ret.first.error) {
@@ -977,7 +977,7 @@ simdutf_warn_unused result implementation::convert_utf16be_to_utf32_with_errors(
     const char16_t *buf, size_t len, char32_t *utf32_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char32_t *> ret =
+  internal::pair<result, char32_t *> ret =
       westmere::sse_convert_utf16_to_utf32_with_errors<endianness::BIG>(
           buf, len, utf32_output);
   if (ret.first.error) {
@@ -1012,7 +1012,7 @@ simdutf_warn_unused size_t implementation::convert_valid_utf32_to_utf8(
 #if SIMDUTF_FEATURE_UTF16 && SIMDUTF_FEATURE_UTF32
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf16le(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char32_t *, char16_t *> ret =
+  internal::pair<const char32_t *, char16_t *> ret =
       sse_convert_utf32_to_utf16<endianness::LITTLE>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -1032,7 +1032,7 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_utf16le(
 
 simdutf_warn_unused size_t implementation::convert_utf32_to_utf16be(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
-  std::pair<const char32_t *, char16_t *> ret =
+  internal::pair<const char32_t *, char16_t *> ret =
       sse_convert_utf32_to_utf16<endianness::BIG>(buf, len, utf16_output);
   if (ret.first == nullptr) {
     return 0;
@@ -1054,7 +1054,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf16le_with_errors(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char16_t *> ret =
+  internal::pair<result, char16_t *> ret =
       westmere::sse_convert_utf32_to_utf16_with_errors<endianness::LITTLE>(
           buf, len, utf16_output);
   if (ret.first.count != len) {
@@ -1078,7 +1078,7 @@ simdutf_warn_unused result implementation::convert_utf32_to_utf16be_with_errors(
     const char32_t *buf, size_t len, char16_t *utf16_output) const noexcept {
   // ret.first.count is always the position in the buffer, not the number of
   // code units written even if finished
-  std::pair<result, char16_t *> ret =
+  internal::pair<result, char16_t *> ret =
       westmere::sse_convert_utf32_to_utf16_with_errors<endianness::BIG>(
           buf, len, utf16_output);
   if (ret.first.count != len) {

--- a/src/westmere/internal/loader.cpp
+++ b/src/westmere/internal/loader.cpp
@@ -1,4 +1,14 @@
 namespace internal {
+
+using simdutf::internal::find;
+using simdutf::internal::make_pair;
+using simdutf::internal::memcpy;
+using simdutf::internal::memmove;
+using simdutf::internal::memset;
+using simdutf::internal::min_value;
+using simdutf::internal::pair;
+using simdutf::internal::ptrdiff_t;
+
 namespace westmere {
 
 #include "westmere/internal/write_v_u16_11bits_to_utf8.cpp"

--- a/src/westmere/sse_base64.cpp
+++ b/src/westmere/sse_base64.cpp
@@ -219,7 +219,7 @@ size_t encode_base64_impl(char *dst, const char *src, size_t srclen,
         _mm_storeu_si128(reinterpret_cast<__m128i *>(buffer + 16), t1);
         _mm_storeu_si128(reinterpret_cast<__m128i *>(buffer + 32), t2);
         _mm_storeu_si128(reinterpret_cast<__m128i *>(buffer + 48), t3);
-        std::memcpy(out, buffer, 64);
+        internal::memcpy(out, buffer, 64);
         size_t out_pos = 0;
         size_t local_offset = offset;
         for (size_t j = 0; j < 64;) {
@@ -287,7 +287,8 @@ size_t encode_base64_impl(char *dst, const char *src, size_t srclen,
         if (offset + 16 > line_length) {
           size_t location_end = line_length - offset;
           size_t to_move = 16 - location_end;
-          std::memmove(out + location_end + 1, out + location_end, to_move);
+          internal::memmove(out + location_end + 1, out + location_end,
+                            to_move);
           out[location_end] = '\n';
           offset = to_move;
           out += 16 + 1;
@@ -399,7 +400,7 @@ static inline void base64_decode_block_safe(char *out, const char *src) {
   char buffer[16];
   base64_decode(buffer,
                 _mm_loadu_si128(reinterpret_cast<const __m128i *>(src + 48)));
-  std::memcpy(out + 36, buffer, 12);
+  internal::memcpy(out + 36, buffer, 12);
 }
 
 // --- decoding - base64 class --------------------------------
@@ -667,6 +668,6 @@ public:
     base64_decode(out + 24, chunks[2]);
     char buffer[16];
     base64_decode(buffer, chunks[3]);
-    std::memcpy(out + 36, buffer, 12);
+    internal::memcpy(out + 36, buffer, 12);
   }
 };

--- a/src/westmere/sse_convert_latin1_to_utf16.cpp
+++ b/src/westmere/sse_convert_latin1_to_utf16.cpp
@@ -1,5 +1,5 @@
 template <endianness big_endian>
-std::pair<const char *, char16_t *>
+internal::pair<const char *, char16_t *>
 sse_convert_latin1_to_utf16(const char *latin1_input, size_t len,
                             char16_t *utf16_output) {
   size_t rounded_len = len & ~0xF; // Round down to nearest multiple of 16
@@ -17,5 +17,6 @@ sse_convert_latin1_to_utf16(const char *latin1_input, size_t len,
     _mm_storeu_si128(reinterpret_cast<__m128i *>(&utf16_output[i + 8]), out2);
   }
   // return pointers pointing to where we left off
-  return std::make_pair(latin1_input + rounded_len, utf16_output + rounded_len);
+  return internal::make_pair(latin1_input + rounded_len,
+                             utf16_output + rounded_len);
 }

--- a/src/westmere/sse_convert_latin1_to_utf32.cpp
+++ b/src/westmere/sse_convert_latin1_to_utf32.cpp
@@ -1,4 +1,4 @@
-std::pair<const char *, char32_t *>
+internal::pair<const char *, char32_t *>
 sse_convert_latin1_to_utf32(const char *buf, size_t len,
                             char32_t *utf32_output) {
   const char *end = buf + len;
@@ -27,5 +27,5 @@ sse_convert_latin1_to_utf32(const char *buf, size_t len,
     buf += 16;
   }
 
-  return std::make_pair(buf, utf32_output);
+  return internal::make_pair(buf, utf32_output);
 }

--- a/src/westmere/sse_convert_latin1_to_utf8.cpp
+++ b/src/westmere/sse_convert_latin1_to_utf8.cpp
@@ -1,4 +1,4 @@
-std::pair<const char *const, char *const>
+internal::pair<const char *, char *>
 sse_convert_latin1_to_utf8(const char *latin_input,
                            const size_t latin_input_length, char *utf8_output) {
   const char *end = latin_input + latin_input_length;
@@ -67,5 +67,5 @@ sse_convert_latin1_to_utf8(const char *latin_input,
     }
   }
 
-  return std::make_pair(latin_input, utf8_output);
+  return internal::make_pair(latin_input, utf8_output);
 }

--- a/src/westmere/sse_convert_utf16_to_latin1.cpp
+++ b/src/westmere/sse_convert_utf16_to_latin1.cpp
@@ -1,5 +1,5 @@
 template <endianness big_endian>
-std::pair<const char16_t *, char *>
+internal::pair<const char16_t *, char *>
 sse_convert_utf16_to_latin1(const char16_t *buf, size_t len,
                             char *latin1_output) {
   const char16_t *end = buf + len;
@@ -23,14 +23,15 @@ sse_convert_utf16_to_latin1(const char16_t *buf, size_t len,
       buf += 8;
       latin1_output += 8;
     } else {
-      return std::make_pair(nullptr, reinterpret_cast<char *>(latin1_output));
+      return internal::pair<const char16_t *, char *>{
+          nullptr, reinterpret_cast<char *>(latin1_output)};
     }
   } // while
-  return std::make_pair(buf, latin1_output);
+  return internal::make_pair(buf, latin1_output);
 }
 
 template <endianness big_endian>
-std::pair<result, char *>
+internal::pair<result, char *>
 sse_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
                                         char *latin1_output) {
   const char16_t *start = buf;
@@ -58,13 +59,13 @@ sse_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
         if (word <= 0xff) {
           *latin1_output++ = char(word);
         } else {
-          return std::make_pair(result(error_code::TOO_LARGE, buf - start + k),
-                                latin1_output);
+          return internal::make_pair(
+              result(error_code::TOO_LARGE, buf - start + k), latin1_output);
         }
       }
       buf += 8;
     }
   } // while
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        latin1_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             latin1_output);
 }

--- a/src/westmere/sse_convert_utf16_to_utf32.cpp
+++ b/src/westmere/sse_convert_utf16_to_utf32.cpp
@@ -52,7 +52,7 @@
   A scalar routine should carry on the conversion of the tail.
 */
 template <endianness big_endian>
-std::pair<const char16_t *, char32_t *>
+internal::pair<const char16_t *, char32_t *>
 sse_convert_utf16_to_utf32(const char16_t *buf, size_t len,
                            char32_t *utf32_output) {
   const char16_t *end = buf + len;
@@ -111,7 +111,8 @@ sse_convert_utf16_to_utf32(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr, utf32_output);
+            return internal::pair<const char16_t *, char32_t *>{nullptr,
+                                                                utf32_output};
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
           *utf32_output++ = char32_t(value);
@@ -120,7 +121,7 @@ sse_convert_utf16_to_utf32(const char16_t *buf, size_t len,
       buf += k;
     }
   } // while
-  return std::make_pair(buf, utf32_output);
+  return internal::make_pair(buf, utf32_output);
 }
 
 /*
@@ -131,7 +132,7 @@ sse_convert_utf16_to_utf32(const char16_t *buf, size_t len,
   tail if needed.
 */
 template <endianness big_endian>
-std::pair<result, char32_t *>
+internal::pair<result, char32_t *>
 sse_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
                                        char32_t *utf32_output) {
   const char16_t *start = buf;
@@ -191,7 +192,7 @@ sse_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k - 1),
                 utf32_output);
           }
@@ -202,5 +203,6 @@ sse_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
       buf += k;
     }
   } // while
-  return std::make_pair(result(error_code::SUCCESS, buf - start), utf32_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             utf32_output);
 }

--- a/src/westmere/sse_convert_utf16_to_utf8.cpp
+++ b/src/westmere/sse_convert_utf16_to_utf8.cpp
@@ -52,7 +52,7 @@
   A scalar routing should carry on the conversion of the tail.
 */
 template <endianness big_endian>
-std::pair<const char16_t *, char *>
+internal::pair<const char16_t *, char *>
 sse_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_output) {
 
   const char16_t *end = buf + len;
@@ -64,7 +64,7 @@ sse_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_output) {
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= internal::ptrdiff_t(16 + safety_margin)) {
     __m128i in = _mm_loadu_si128((__m128i *)buf);
     if (big_endian) {
       const __m128i swap =
@@ -256,7 +256,8 @@ sse_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_output) {
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(nullptr, utf8_output);
+            return internal::pair<const char16_t *, char *>{nullptr,
+                                                            utf8_output};
           }
           uint32_t value = (diff << 10) + diff2 + 0x10000;
           *utf8_output++ = char((value >> 18) | 0b11110000);
@@ -269,7 +270,7 @@ sse_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_output) {
     }
   } // while
 
-  return std::make_pair(buf, utf8_output);
+  return internal::make_pair(buf, utf8_output);
 }
 
 /*
@@ -280,7 +281,7 @@ sse_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_output) {
   tail if needed.
 */
 template <endianness big_endian>
-std::pair<result, char *>
+internal::pair<result, char *>
 sse_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
                                       char *utf8_output) {
   const char16_t *start = buf;
@@ -293,7 +294,7 @@ sse_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= internal::ptrdiff_t(16 + safety_margin)) {
     __m128i in = _mm_loadu_si128((__m128i *)buf);
     if (big_endian) {
       const __m128i swap =
@@ -485,7 +486,7 @@ sse_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
           k++;
           uint16_t diff2 = uint16_t(next_word - 0xDC00);
           if ((diff | diff2) > 0x3FF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k - 1),
                 utf8_output);
           }
@@ -500,5 +501,6 @@ sse_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
     }
   } // while
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start), utf8_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             utf8_output);
 }

--- a/src/westmere/sse_convert_utf32_to_latin1.cpp
+++ b/src/westmere/sse_convert_utf32_to_latin1.cpp
@@ -1,4 +1,4 @@
-std::pair<const char32_t *, char *>
+internal::pair<const char32_t *, char *>
 sse_convert_utf32_to_latin1(const char32_t *buf, size_t len,
                             char *latin1_output) {
   const size_t rounded_len = len & ~0xF; // Round down to nearest multiple of 16
@@ -18,7 +18,7 @@ sse_convert_utf32_to_latin1(const char32_t *buf, size_t len,
     check_combined = _mm_or_si128(check_combined, in4);
 
     if (!_mm_testz_si128(check_combined, high_bytes_mask)) {
-      return std::make_pair(nullptr, latin1_output);
+      return internal::pair<const char32_t *, char *>{nullptr, latin1_output};
     }
     __m128i pack1 = _mm_unpacklo_epi32(_mm_shuffle_epi8(in1, shufmask),
                                        _mm_shuffle_epi8(in2, shufmask));
@@ -30,10 +30,10 @@ sse_convert_utf32_to_latin1(const char32_t *buf, size_t len,
     buf += 16;
   }
 
-  return std::make_pair(buf, latin1_output);
+  return internal::make_pair(buf, latin1_output);
 }
 
-std::pair<result, char *>
+internal::pair<result, char *>
 sse_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
                                         char *latin1_output) {
   const char32_t *start = buf;
@@ -60,8 +60,8 @@ sse_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
         if (codepoint <= 0xff) {
           *latin1_output++ = char(codepoint);
         } else {
-          return std::make_pair(result(error_code::TOO_LARGE, buf - start + k),
-                                latin1_output);
+          return internal::make_pair(
+              result(error_code::TOO_LARGE, buf - start + k), latin1_output);
         }
       }
       buf += 16;
@@ -77,6 +77,6 @@ sse_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
     buf += 16;
   }
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start),
-                        latin1_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             latin1_output);
 }

--- a/src/westmere/sse_convert_utf32_to_utf16.cpp
+++ b/src/westmere/sse_convert_utf32_to_utf16.cpp
@@ -53,7 +53,7 @@ simdutf_really_inline bool validate_utf32(const __m128i a, const __m128i b) {
 }
 
 template <endianness big_endian>
-std::pair<const char32_t *, char16_t *>
+internal::pair<const char32_t *, char16_t *>
 sse_convert_utf32_to_utf16(const char32_t *buf, size_t len,
                            char16_t *utf16_output) {
 
@@ -97,7 +97,8 @@ sse_convert_utf32_to_utf16(const char32_t *buf, size_t len,
       buf += 16;
     } else {
       if (!validate_utf32(in0, in1) || !validate_utf32(in2, in3)) {
-        return std::make_pair(nullptr, utf16_output);
+        return internal::pair<const char32_t *, char16_t *>{nullptr,
+                                                            utf16_output};
       }
 
       const auto ret0 = sse_expand_surrogate<big_endian>(in0);
@@ -122,14 +123,14 @@ sse_convert_utf32_to_utf16(const char32_t *buf, size_t len,
 
   // check for invalid input
   if (static_cast<uint32_t>(_mm_movemask_epi8(forbidden_bytemask)) != 0) {
-    return std::make_pair(nullptr, utf16_output);
+    return internal::pair<const char32_t *, char16_t *>{nullptr, utf16_output};
   }
 
-  return std::make_pair(buf, utf16_output);
+  return internal::make_pair(buf, utf16_output);
 }
 
 template <endianness big_endian>
-std::pair<result, char16_t *>
+internal::pair<result, char16_t *>
 sse_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
                                        char16_t *utf16_output) {
   const char32_t *start = buf;
@@ -151,8 +152,8 @@ sse_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
       const __m128i forbidden_bytemask =
           _mm_cmpeq_epi16(_mm_and_si128(utf16_packed, v_f800), v_d800);
       if (static_cast<uint32_t>(_mm_movemask_epi8(forbidden_bytemask)) != 0) {
-        return std::make_pair(result(error_code::SURROGATE, buf - start),
-                              utf16_output);
+        return internal::make_pair(result(error_code::SURROGATE, buf - start),
+                                   utf16_output);
       }
 
       if (big_endian) {
@@ -175,7 +176,7 @@ sse_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
         if ((word & 0xFFFF0000) == 0) {
           // will not generate a surrogate pair
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k), utf16_output);
           }
           *utf16_output++ =
@@ -185,7 +186,7 @@ sse_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
         } else {
           // will generate a surrogate pair
           if (word > 0x10FFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::TOO_LARGE, buf - start + k), utf16_output);
           }
           word -= 0x10000;
@@ -205,5 +206,6 @@ sse_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
     }
   }
 
-  return std::make_pair(result(error_code::SUCCESS, buf - start), utf16_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             utf16_output);
 }

--- a/src/westmere/sse_convert_utf32_to_utf8.cpp
+++ b/src/westmere/sse_convert_utf32_to_utf8.cpp
@@ -1,4 +1,4 @@
-std::pair<const char32_t *, char *>
+internal::pair<const char32_t *, char *>
 sse_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
   const char32_t *end = buf + len;
 
@@ -20,7 +20,7 @@ sse_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
           // https://github.com/simdutf/simdutf/issues/92
 
   while (end - buf >=
-         std::ptrdiff_t(
+         internal::ptrdiff_t(
              16 + safety_margin)) { // buf is a char32_t pointer, each char32_t
                                     // has 4 bytes or 32 bits, thus buf + 16 *
                                     // char_32t = 512 bits = 64 bytes
@@ -295,14 +295,16 @@ sse_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) {
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(nullptr, utf8_output);
+            return internal::pair<const char32_t *, char *>{nullptr,
+                                                            utf8_output};
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
           *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else {
           if (word > 0x10FFFF) {
-            return std::make_pair(nullptr, utf8_output);
+            return internal::pair<const char32_t *, char *>{nullptr,
+                                                            utf8_output};
           }
           *utf8_output++ = char((word >> 18) | 0b11110000);
           *utf8_output++ = char(((word >> 12) & 0b111111) | 0b10000000);
@@ -318,17 +320,17 @@ sse_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
   const __m128i v_10ffff = _mm_set1_epi32((uint32_t)0x10ffff);
   if (static_cast<uint16_t>(_mm_movemask_epi8(_mm_cmpeq_epi32(
           _mm_max_epu32(running_max, v_10ffff), v_10ffff))) != 0xffff) {
-    return std::make_pair(nullptr, utf8_output);
+    return internal::pair<const char32_t *, char *>{nullptr, utf8_output};
   }
 
   if (static_cast<uint32_t>(_mm_movemask_epi8(forbidden_bytemask)) != 0) {
-    return std::make_pair(nullptr, utf8_output);
+    return internal::pair<const char32_t *, char *>{nullptr, utf8_output};
   }
 
-  return std::make_pair(buf, utf8_output);
+  return internal::make_pair(buf, utf8_output);
 }
 
-std::pair<result, char *>
+internal::pair<result, char *>
 sse_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
                                       char *utf8_output) {
   const char32_t *end = buf + len;
@@ -346,7 +348,7 @@ sse_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
       12; // to avoid overruns, see issue
           // https://github.com/simdutf/simdutf/issues/92
 
-  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+  while (end - buf >= internal::ptrdiff_t(16 + safety_margin)) {
     // We load two 16 bytes registers for a total of 32 bytes or 8 characters.
     __m128i in = _mm_loadu_si128((__m128i *)buf);
     __m128i nextin = _mm_loadu_si128((__m128i *)buf + 1);
@@ -354,8 +356,8 @@ sse_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
     __m128i max_input = _mm_max_epu32(_mm_max_epu32(in, nextin), v_10ffff);
     if (static_cast<uint16_t>(_mm_movemask_epi8(
             _mm_cmpeq_epi32(max_input, v_10ffff))) != 0xffff) {
-      return std::make_pair(result(error_code::TOO_LARGE, buf - start),
-                            utf8_output);
+      return internal::make_pair(result(error_code::TOO_LARGE, buf - start),
+                                 utf8_output);
     }
 
     // Pack 32-bit UTF-32 code units to 16-bit UTF-16 code units with unsigned
@@ -451,8 +453,8 @@ sse_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
       const __m128i forbidden_bytemask =
           _mm_cmpeq_epi16(_mm_and_si128(in_16, v_f800), v_d800);
       if (static_cast<uint32_t>(_mm_movemask_epi8(forbidden_bytemask)) != 0) {
-        return std::make_pair(result(error_code::SURROGATE, buf - start),
-                              utf8_output);
+        return internal::make_pair(result(error_code::SURROGATE, buf - start),
+                                   utf8_output);
       }
 
       const __m128i dup_even = _mm_setr_epi16(0x0000, 0x0202, 0x0404, 0x0606,
@@ -565,7 +567,7 @@ sse_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else if ((word & 0xFFFF0000) == 0) {
           if (word >= 0xD800 && word <= 0xDFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::SURROGATE, buf - start + k), utf8_output);
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
@@ -573,7 +575,7 @@ sse_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
         } else {
           if (word > 0x10FFFF) {
-            return std::make_pair(
+            return internal::make_pair(
                 result(error_code::TOO_LARGE, buf - start + k), utf8_output);
           }
           *utf8_output++ = char((word >> 18) | 0b11110000);
@@ -585,5 +587,6 @@ sse_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
       buf += k;
     }
   } // while
-  return std::make_pair(result(error_code::SUCCESS, buf - start), utf8_output);
+  return internal::make_pair(result(error_code::SUCCESS, buf - start),
+                             utf8_output);
 }

--- a/tests/helpers/test.cpp
+++ b/tests/helpers/test.cpp
@@ -110,10 +110,10 @@ void print_architectures(FILE *file) {
       abort();
     }
     if (implementation->supported_by_runtime_system()) {
-      fprintf(file, "- %s\n", implementation->name().c_str());
+      fprintf(file, "- %s\n", simdutf::internal::c_str(implementation->name()));
     } else {
       fprintf(file, "- %s [unsupported by current processor]\n",
-              implementation->name().c_str());
+              simdutf::internal::c_str(implementation->name()));
     }
   }
 }
@@ -165,7 +165,7 @@ void run(const CommandLine &cmdline) {
     }
     if (!implementation->supported_by_runtime_system()) {
       printf("Implementation %s is unsupported by the current processor.\n",
-             implementation->name().c_str());
+             simdutf::internal::c_str(implementation->name()));
       continue;
     }
     if (not cmdline.architectures.empty()) {
@@ -175,7 +175,8 @@ void run(const CommandLine &cmdline) {
     }
     matching_implementation++;
 
-    printf("Checking implementation %s\n", implementation->name().c_str());
+    printf("Checking implementation %s\n",
+           simdutf::internal::c_str(implementation->name()));
 
     auto filter = [&cmdline](const simdutf::test::test_entry &test) -> bool {
       if (cmdline.tests.empty())

--- a/tests/random_fuzzer.cpp
+++ b/tests/random_fuzzer.cpp
@@ -20,7 +20,7 @@ static void print_input(const std::string &s,
   }
   printf("\n");
   printf("string length: %zu\n", s.size());
-  printf("implementation->name() = %s", e->name().c_str());
+  printf("implementation->name() = %s", simdutf::internal::c_str(e->name()));
 }
 
 extern "C" {
@@ -751,7 +751,7 @@ int main(int argc, char *argv[]) {
     if (!e->supported_by_runtime_system()) {
       continue;
     }
-    printf("testing: %s\n", e->name().c_str());
+    printf("testing: %s\n", simdutf::internal::c_str(e->name()));
   }
 #ifndef SIMDUTF_TEST_FUZZER_TRIALS
   #error "SIMDUTF_TEST_FUZZER_TRIALS not set."

--- a/tests/select_implementation.cpp
+++ b/tests/select_implementation.cpp
@@ -17,12 +17,12 @@ int main() {
     if (!validutf8) {
       return EXIT_FAILURE;
     }
-    printf("%s: %s\n", implementation->name().c_str(),
-           implementation->description().c_str());
+    printf("%s: %s\n", simdutf::internal::c_str(implementation->name()),
+           simdutf::internal::c_str(implementation->description()));
     chosen_implementation = implementation->name();
   }
   auto my_implementation =
-      simdutf::get_available_implementations()[chosen_implementation];
+      simdutf::get_available_implementations()[chosen_implementation.c_str()];
   if (!my_implementation) {
     return EXIT_FAILURE;
   }
@@ -34,10 +34,12 @@ int main() {
   if (!validutf8) {
     return EXIT_FAILURE;
   }
-  if (simdutf::get_active_implementation()->name() != chosen_implementation) {
+  if (chosen_implementation !=
+      simdutf::internal::c_str(simdutf::get_active_implementation()->name())) {
     return EXIT_FAILURE;
   }
-  printf("Manually selected: %s\n",
-         simdutf::get_active_implementation()->name().c_str());
+  printf(
+      "Manually selected: %s\n",
+      simdutf::internal::c_str(simdutf::get_active_implementation()->name()));
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Resolves https://github.com/simdutf/simdutf/issues/158

This adds a new define `SIMDUTF_NO_LIBCXX` that can be used to build simdutf without libc++ or libc++abi. This is very useful for environments where these dependencies are undesirable. I already have a [Ghostty PR verifying this change](https://github.com/ghostty-org/ghostty/pull/12291) using a custom amalgam build from my fork.

This is similar to Google Highway's [`HWY_NO_LIBCXX`](https://github.com/google/highway/blob/a02e5fa3f00248f613c30172e36bf5f607871ef0/hwy/base.h#L29-L31) define that achieves the same thing .

When SIMDUTF_NO_LIBCXX is present, we strive as much as possible to avoid breaking ABI but some is necessary since some of the public ABI relies  on libc++ (e.g. returns `std::string` and such). As such, the presence of the define should be considered a separate ABI for all intents and purposes.

When SIMDUTF_NO_LIBCXX is _not present_, we strive to _change nothing_. There is some additional noise in this PR towards that goal (e.g. in `implementation.cpp`). The idea is that the standard build should remain ABI, functionally, and stylistically as identical as possible.

**AI Disclaimer:** I did this work alongside Codex. I'm not a C++ expert but I'm a very experienced systems-level programmer. I constantly changed direction and nudged the AI in different directions and also did a final pass on the set of changes.

I'm happy to make adjustments as requested if this is desired and I can understand and explain any part of this diff. This PR description was fully hand-written by me. 

Type of change
- [ ] Bug fix
- [ ] Optimization
- [x] New feature
- [x] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

> [!IMPORTANT]
>
> **I'm sorry this diff is so big.** I know the importance of smaller PRs, but this is one of those things that's hard to break into smaller pieces because it either works or doesn't...

## Why?

I'm the author of the Ghostty terminal. Ghostty has used simdutf for many years and it's a critical dependency we're happy with. Recently, we've been pursuing `libghostty-vt`
(https://libghostty.tip.ghostty.org/), a C library that exposes a rich set of functionality for complete terminal emulation.

One of the beautiful things about `libghostty-vt` is that if you disable our SIMD features, it has on dependencies at all (not even libc!). It is completely freestanding. 

But if you enable SIMD, it requires libc and libc++. The only libc++  requirement is for simdutf. So I'm interested in rectifying that and making it possible to use simdutf in a way that doesn't require libc++ so that `libghostty-vt` doesn't either.

I ultimately intend to not require libc either, but that's a much bigger lift. In the mean time, we can provide fully static builds of `libghostty-vt` that have only the libc symbols we use. Much harder for C++. :) 

## Build

This mode is enabled explicitly by defining `SIMDUTF_NO_LIBCXX=1` when building simdutf.

The important detail is that this is an all-or-nothing build contract: every translation unit that compiles simdutf sources or includes simdutf headers must see the same define. In practice, that means passing `-DSIMDUTF_NO_LIBCXX=1` consistently to both simdutf itself and any code that includes `simdutf.h`.

A typical build looks like:

```
c++ -std=c++17 \
  -DSIMDUTF_NO_LIBCXX=1 \
  -fno-exceptions -fno-rtti \
  -Iinclude -Isrc \
  -c src/simdutf.cpp -o simdutf.o
```

If the goal is a stricter environment with no C++ standard library in the final artifact, this can also be paired with `-nostdinc++` and `-nostdlib++`, which is what the CI coverage exercises for the single-header build to ensure that there's no access to libc++ at all and that it also can't be linked.

## Approach

### Type Shims

I try to achieve this in a minimally invasive way. The main idea is to provide a header `stl_compat.h` that shims the libc++ types in  the NO_LIBCXX case. In the standard case (libc++), the types are zero overhead aliases or inline passthroughs. In the NO_LIBCXX case, the types are minimally implemented for only what simdutf directly needs.

Therefore, the **diff is very large, but almost all the changes are trivial replacements from e.g. `std::pair` to
`simdutf::internal::pair`.**

There are some types I didn't want to shim at all, e.g. `std::span`, but these were necessary for some of the benchmarks (e.g. the base64 ones). That's why that's there.

### Reduced Surface Area

This is intentionally a reduced-surface contract rather than an attempt to fully emulate the standard C++ functionality.

Any public API that directly exposes `std::*` either changes shape or is compiled out in this mode. In practice this means things like `implementation::name()` and `implementation::description()` return `const char *` instead of `std::string`, and helpers such as `to_string(encoding_type)` similarly return C strings.

APIs that inherently depend on stdlib facilities are not available at all. That includes `std::span` convenience overloads, `std::text_encoding` interop, and the `std::atomic_ref`-based helpers. 

### Avoiding C++ Runtime Hooks

Avoiding libc++ headers is only part of the problem. There are also a few compiler-emitted ABI hooks that can sneak in even when the source no longer mentions `std::*`.

The big one is function-local statics, which can introduce `__cxa_guard_*` references for thread-safe initialization. In the NO_LIBCXX path I move the implementation singletons and dispatch storage to translation-unit scope so the runtime detection model stays the same without requiring those guard functions.

There is also a weak `__cxa_pure_virtual` trap shim for the abstract implementation vtable case. Correct dispatch should never hit it, but without it some toolchains still insist on a `libc++abi` dependency just for that unreachable symbol. It is marked weak so that in compilation units that do pull in libc++abi, the real `__cxa_pure_virtual` will take precedence.

The C wrapper is also adjusted to bridge through compiler-native char16_t/char32_t forms without assuming the normal C++ stdlib type machinery is available.

## Verification

This type of feature can regress easily, so I added explicit verification.

There is now a dedicated script and CI workflow that:

- compiles the core sources with SIMDUTF_NO_LIBCXX
- checks their undefined symbols for forbidden C++ ABI/runtime entries such as __cxa_guard_*, exception machinery, RTTI, and dynamic-cast support
- links smoke tests without the C++ standard library and verifies the resulting binaries do not depend on libc++, libc++abi, libstdc++, or libsupc++
- exercises both the normal runtime-dispatch path and the fallback-only/single-implementation path
- verifies that the single-header build still works with `-nostdinc++` and `-nostdlib++`

The goal here is not just "make it compile on my machine" but also to make it maintainable.

## Performance

I ran paired benchmarks for the standard build and the `SIMDUTF_NO_LIBCXX` build. The benchmarks included all possible benchmark programs in this repo and all modes.

The conclusion is that performance is broadly unchanged. On the main throughput benchmarks, most realistic-input results move by only low-single-digit percentages, and many are effectively flat. I reran them a few times and they're sometimes faster sometimes slower so I'm going to say its noise.

The important part is there is no real difference.

**AI Disclosure:** I'm repeating this again at the bottom in case you missed it at the top. I hand-wrote this entire PR description, I manually reviewed every change in this PR and can understand and discuss it intelligently with you, I did use Codex to assist in writing this, though!