### PR TITLE
simpler approach to removing the C++ lib dependency at runtime

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cxxversion: [11, 17, 20]
+        cxxversion: [17, 20]
         compiler: [g++, clang++-19]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/selective-amalgamation.yml
+++ b/.github/workflows/selective-amalgamation.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        cppversion: [11, 23]
+        cppversion: [17, 23]
         compiler: [g++, clang++]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ubuntu24-cxxstandards.yml
+++ b/.github/workflows/ubuntu24-cxxstandards.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         compiler: [g++-14, clang++-18]
-        cppversion: [11, 14, 17, 20, 23]
+        cppversion: [17, 20, 23]
         cversion: [11,]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ubuntu24-unsignedchar.yml
+++ b/.github/workflows/ubuntu24-unsignedchar.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         compiler: [g++-14]
-        cppversion: [11, 23]
+        cppversion: [17, 23]
         charflag: [-fsigned-char, -funsigned-char]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/vs17-cxxstandards.yml
+++ b/.github/workflows/vs17-cxxstandards.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cppversion: [11, 14, 17, 20, 23]
+        cppversion: [17, 20, 23]
         gen: ["Visual Studio 17 2022"]
         arch: [x64]
         shared: [ON]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.18)
 
 project(simdutf
   DESCRIPTION "Fast Unicode validation, transcoding and processing"
@@ -36,6 +36,7 @@ option(SIMDUTF_FUZZERS "Whether to build the fuzzers." OFF)
 option(SIMDUTF_COVERAGE "Enable code coverage collection during tests (only GCC and Clang)." OFF)
 option(SIMDUTF_INTERNAL_TESTS "Whether to test also internal procedures. Useful mostly for developers, not users." OFF)
 option(SIMDUTF_LOGGING "Whether to enable logging (this should never be used in binary releases)." OFF)
+option(SIMDUTF_USE_STATIC_INITIALIZATION "Whether to use translation-unit-scope static variables for implementation singletons (faster, but unsafe before main() when used in a library)." OFF)
 option(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION "Whether to enable unsafe fuzzing mode." OFF)
 
 set(SIMDUTF_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,10 +38,6 @@ option(SIMDUTF_INTERNAL_TESTS "Whether to test also internal procedures. Useful 
 option(SIMDUTF_LOGGING "Whether to enable logging (this should never be used in binary releases)." OFF)
 option(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION "Whether to enable unsafe fuzzing mode." OFF)
 
-if(SIMDUTF_LOGGING AND DEFINED CMAKE_CXX_STANDARD AND CMAKE_CXX_STANDARD LESS 17)
-    set(CMAKE_CXX_STANDARD 17)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
 set(SIMDUTF_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_subdirectory(src)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ To contribute code or documentation:
 To set up your environment:
 
 Requirements:
-- We recommend a C++20-compatible compiler (e.g., GCC, Clang, MSVC). Although the library can be built with a C++11 compatible compiler, some of our tools and functionality requires C++20.
+- We recommend a C++20-compatible compiler (e.g., GCC, Clang, MSVC). Although the library can be built with a C++17 compatible compiler, some of our tools and functionality requires C++20.
 - A recent version of CMake.
 - Git.
 - Optional: SIMD support (SSE, AVX, NEON) for your platform.

--- a/README.md
+++ b/README.md
@@ -2999,7 +2999,7 @@ This will benchmark the selected function on the input file, testing sizes from 
 
 The simdutf library can be compiled without linking against the C++ standard library. This is useful when targeting bare-metal or highly constrained environments where the standard library is unavailable or undesirable. It might be useful when linking against the simdutf library from other languages such as C or Zig.
 
-It is only support on GCC and LLVM/clang. We do not support this functionality under Visual Studio. When compiling the simdutf library yourself, set the `SIMDUTF_NO_LIBCXX` macro to 1. E.g., you might do:
+It is only supported on GCC and LLVM/clang. We do not support this functionality under Visual Studio. When compiling the simdutf library yourself, set the `SIMDUTF_NO_LIBCXX` macro to 1. E.g., you might do:
 
 ```
 c++ -c simdutf.cpp  -nostdlib++ -fno-rtti -fno-exceptions -DSIMDUTF_NO_LIBCXX=1 -std=c++17
@@ -3097,6 +3097,8 @@ Or define the macro directly if you build simdutf yourself (`SIMDUTF_USE_STATIC_
 
 When building without the C++ standard library (`SIMDUTF_NO_LIBCXX=1`), static initialization is always used because the C++ runtime's thread-safe function-local static initialization relies on the standard library.
 
+
+*Further reading*: [Static Initialization Order Fiasco](https://en.cppreference.com/cpp/language/siof)
 
 ## Thread safety
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Please refer to our benchmarking tool for a proper interpretation of the numbers
 
 ## Requirements
 
-- C++11 compatible compiler. We support LLVM clang, GCC, Visual Studio. (Our tests and benchmark tools requires C++17.) Be aware that GCC under Windows is buggy and thus unsupported.
+- C++17 compatible compiler. We support LLVM clang, GCC, Visual Studio. Be aware that GCC under Windows is buggy and thus unsupported.
 - For high speed, you should have a recent 64-bit system (e.g., ARM, x64, RISC-V with vector extensions, Loongson, POWER). On Loongson processors, LASX runtime dispatching is only enabled on GCC 15+, not on LLVM or older versions of GCC.
 - If you rely on CMake, you should use a recent CMake (at least 3.15); otherwise you may use the [single header version](#single-header-version). The library is also available from [Microsoft's vcpkg](https://github.com/simdutf/simdutf-vcpkg), from [conan](https://conan.io/center/recipes/simdutf), from [FreeBSD's port](https://cgit.freebsd.org/ports/tree/converters/simdutf), from [brew](https://formulae.brew.sh/formula/simdutf), and many other systems.
 - AVX-512 support require a processor with AVX512-VBMI2 (Ice Lake or better, AMD Zen 4 or better) and a recent compiler (GCC 8 or better, Visual Studio 2022 or better, LLVM clang 6 or better). You need a correspondingly recent assembler such as gas (2.30+) or nasm (2.14+): recent compilers usually come with recent assemblers. If you mix a recent compiler with an incompatible/old assembler (e.g., when using a recent compiler with an old Linux distribution), you may get errors at build time because the compiler produces instructions that the assembler does not recognize: you should update your assembler to match your compiler (e.g., upgrade binutils to version 2.30 or better under Linux) or use an older compiler matching the capabilities of your assembler.
@@ -335,7 +335,7 @@ also have a span overload. Here is an example:
 
 ```cpp
 std::vector<char> data{1, 2, 3, 4, 5};
-// C++11 API
+// C++17 API
 auto cpp11 = simdutf::autodetect_encoding(data.data(), data.size());
 // C++20 API
 auto cpp20 = simdutf::autodetect_encoding(data);

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@
   - [Command-line tools](#command-line-tools)
   - [Manual implementation selection](#manual-implementation-selection)
   - [Benchmarks](#benchmarks)
+  - [Compiling without the C++ standard library](#compiling-without-the-c-standard-library)
+  - [C API](#c-api-c11-or-better)
+  - [SIMDUTF\_USE\_STATIC\_INITIALIZATION](#simdutf_use_static_initialization)
   - [Thread safety](#thread-safety)
   - [References](#references)
   - [License](#license)
@@ -2990,11 +2993,115 @@ To run short benchmarks on various SIMDUTF functions with incremental input size
 This will benchmark the selected function on the input file, testing sizes from 1 byte up to the specified max size (default 128), and output a table with timing and performance metrics.
 
 
+## Compiling without the C++ standard library
+
+*This is currently experimental.*
+
+The simdutf library can be compiled without linking against the C++ standard library. This is useful when targeting bare-metal or highly constrained environments where the standard library is unavailable or undesirable. It might be useful when linking against the simdutf library from other languages such as C or Zig.
+
+It is only support on GCC and LLVM/clang. We do not support this functionality under Visual Studio. When compiling the simdutf library yourself, set the `SIMDUTF_NO_LIBCXX` macro to 1. E.g., you might do:
+
+```
+c++ -c simdutf.cpp  -nostdlib++ -fno-rtti -fno-exceptions -DSIMDUTF_NO_LIBCXX=1 -std=c++17
+```
+
+When `SIMDUTF_NO_LIBCXX` is active:
+
+- `SIMDUTF_USE_STATIC_INITIALIZATION` is automatically set to `1` (see the section on [SIMDUTF\_USE\_STATIC\_INITIALIZATION](#simdutf_use_static_initialization)), since thread-safe function-local statics depend on the standard library. Importantly, it means that you should be careful if you are using the simdutf library in a static context (before the `main()` function is called).
+- Weak stub implementations of `__cxa_pure_virtual` and `__glibcxx_assert_fail` are compiled in so that the abstract-class vtable machinery does not pull in libstdc++/libc++abi. A real definition from the runtime will take priority if one is linked in.
+
+
+## C API (C11 or better)
+
+*This is currently experimental. We are committed to maintaining the C API but there might be issues with
+our implementation.*
+
+We provide a thin C API that wraps the C++ `simdutf` library. It is intended
+for applications that prefer or require a plain C interface. The `simdutf_c.h`
+defines the interface.
+
+The C API exposes functions for validation, transcoding, size estimation, `find` helpers,
+and Base64 encode/decode helpers. Results are returned using the `simdutf_result` struct
+which contains an `error_code` field and additional fields when relevant.
+
+We provide a simple C demo using the C wrapper at `amalgamation_demo.c`.
+It shows validating UTF-8, converting UTF-8 to UTF-16LE and back, and checking the round-trip.
+Refer to `singleheader/README.md` for instructions. 
+
+
+You need the files `simdutf.cpp`, `simdutf_c.h`, `simdutf.h` provided with each release.
+
+As an example, given the following C program in the file `demo.c`...
+
+```c
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "simdutf_c.h"
+
+int main(void) {
+  printf("SIMDUTF C API demo\n");
+  const char *source = "1234";
+  /* validate UTF-8 */
+  if (!simdutf_validate_utf8(source, 4)) {
+    puts("invalid UTF-8");
+    return EXIT_FAILURE;
+  }
+}
+```
+
+You may build it as follows.
+
+```
+c++ -c simdutf.cpp -std=c++17
+cc -c amalgamation_demo.c
+c++  amalgamation_demo.o simdutf.o -o cdemo
+./cdemo
+```
+
+
+
+By default, the simdutf library requires a C++ standard library (e.g., libstdc++, libc++) at runtime, either statically or dynamically linked. If you want to avoid linking against the C++ standard library entirely, you need to set the `DSIMDUTF_NO_LIBCXX` macro to 1, see [Compiling without the C++ standard library](#compiling-without-the-c-standard-library).
+
+
+You might be able to build our small C program like so:
+
+```
+c++ -c simdutf.cpp  -nostdlib++ -fno-rtti -fno-exceptions -DSIMDUTF_NO_LIBCXX=1 -std=c++17
+cc demo.c simdutf.o -o demo
+```
+
+
+The resulting program `demo` does not depend on the C++ standard library. If you opt for this option, be aware that the downside is that you should be careful when using simdutf in the static context (before the `main` function has been called).
+
+
+Note: The C API is currently not aware of amalgamation with limited features. It expects the full simdutf library.
+
+
+## SIMDUTF_USE_STATIC_INITIALIZATION
+
+*This is currently experimental.*
+
+By default, simdutf avoids translation-unit-scope (global) static variables for its implementation singletons. Instead, it relies on function-local statics, which are initialized in a thread-safe manner by the C++ runtime. This means the very first call to the library — even before `main()` starts — is safe and will not cause crashes.
+
+If you need to avoid the small synchronization overhead associated with function-local statics (checked on every call until initialization completes), you can opt in to translation-unit-scope static initialization:
+
+```cmake
+cmake -DSIMDUTF_USE_STATIC_INITIALIZATION=ON ...
+```
+
+Or define the macro directly if you build simdutf yourself (`SIMDUTF_USE_STATIC_INITIALIZATION=1`).
+
+**Trade-off:** with this option enabled, simdutf's implementation objects are initialized as translation-unit-scope globals. The C++ standard does not guarantee a deterministic initialization order across translation units, so if your own global variables call into simdutf during their construction (i.e., before `main()` begins), you may encounter a crash due to the static initialization order fiasco. Do not enable this option if simdutf might be used from another library's global constructor.
+
+When building without the C++ standard library (`SIMDUTF_NO_LIBCXX=1`), static initialization is always used because the C++ runtime's thread-safe function-local static initialization relies on the standard library.
+
+
 ## Thread safety
 
 We built simdutf with thread safety in mind. The simdutf library is single-threaded throughout.
 The CPU detection, which runs the first time parsing is attempted and switches to the fastest parser for your CPU, is transparent and thread-safe. Our runtime dispatching is based on global objects that are instantiated at the beginning of the main thread and may be discarded at the end of the main thread. If you have multiple threads running and some threads use the library while the main thread is cleaning up resources, you may encounter issues. If you expect such problems, you may consider using [std::quick_exit](https://en.cppreference.com/w/cpp/utility/program/quick_exit).
-
 
 ## References
 
@@ -3017,27 +3124,6 @@ If you use this library in your research, please cite our work:
   note={\url{https://github.com/simdutf/simdutf}}
 }
 ```
-
-## C wrapper (C11 or better)
-
-*This is currently experimental. We are committed to maintaining the C API but there might be issues with
-our implementation.*
-
-We provide a thin C API that wraps the C++ `simdutf` library. It is intended
-for applications that prefer or require a plain C interface. The `simdutf_c.h`
-defines the interface.
-
-The C API exposes functions for validation, transcoding, size estimation, `find` helpers,
-and Base64 encode/decode helpers. Results are returned using the `simdutf_result` struct
-which contains an `error_code` field and additional fields when relevant.
-
-We provide a simple C demo using the C wrapper at `amalgamation_demo.c`.
-It shows validating UTF-8, converting UTF-8 to UTF-16LE and back, and checking the round-trip.
-Refer to `singleheader/README.md` for instructions. Note that the simdutf library requires
-a C++ standard library (e.g., libstdc++, libc++) at runtime, either statically or dynamically linked.
-
-Note: The C API is currently not aware of amalgamation with limited features. It expects the full simdutf library.
-
 
 ## Stars
 

--- a/benchmarks/alignment.cpp
+++ b/benchmarks/alignment.cpp
@@ -120,7 +120,7 @@ void run_from_utf8_output(const std::vector<char> &input_data) {
 
 int main(int argc, char **argv) {
   printf("# current system detected as %s.\n",
-         simdutf::get_active_implementation()->name().c_str());
+         simdutf::get_active_implementation()->name());
   if (argc < 2) {
     std::cerr << "Please provide a file argument." << std::endl;
     return EXIT_FAILURE;
@@ -136,8 +136,7 @@ int main(int argc, char **argv) {
                     std::istreambuf_iterator<char>());
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
-  printf("# input detected as %s.\n",
-         simdutf::to_string(detected_encoding).c_str());
+  printf("# input detected as %s.\n", simdutf::to_string(detected_encoding));
   if (detected_encoding == simdutf::encoding_type::UTF8) {
     run_from_utf8_output(input_data);
     std::cout << "----" << std::endl;

--- a/benchmarks/alignment.cpp
+++ b/benchmarks/alignment.cpp
@@ -119,7 +119,8 @@ void run_from_utf8_output(const std::vector<char> &input_data) {
 }
 
 int main(int argc, char **argv) {
-  printf("# current system detected as %s.\n",
+  printf("# current system detected as %.*s.\n",
+         int(simdutf::get_active_implementation()->name().size()),
          simdutf::get_active_implementation()->name().data());
   if (argc < 2) {
     std::cerr << "Please provide a file argument." << std::endl;
@@ -136,7 +137,9 @@ int main(int argc, char **argv) {
                     std::istreambuf_iterator<char>());
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
-  printf("# input detected as %s.\n", simdutf::to_string(detected_encoding).data());
+  printf("# input detected as %.*s.\n",
+         int(simdutf::to_string(detected_encoding).size()),
+         simdutf::to_string(detected_encoding).data());
   if (detected_encoding == simdutf::encoding_type::UTF8) {
     run_from_utf8_output(input_data);
     std::cout << "----" << std::endl;

--- a/benchmarks/alignment.cpp
+++ b/benchmarks/alignment.cpp
@@ -120,7 +120,7 @@ void run_from_utf8_output(const std::vector<char> &input_data) {
 
 int main(int argc, char **argv) {
   printf("# current system detected as %s.\n",
-         simdutf::get_active_implementation()->name());
+         simdutf::get_active_implementation()->name().data());
   if (argc < 2) {
     std::cerr << "Please provide a file argument." << std::endl;
     return EXIT_FAILURE;
@@ -136,7 +136,7 @@ int main(int argc, char **argv) {
                     std::istreambuf_iterator<char>());
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
-  printf("# input detected as %s.\n", simdutf::to_string(detected_encoding));
+  printf("# input detected as %s.\n", simdutf::to_string(detected_encoding).data());
   if (detected_encoding == simdutf::encoding_type::UTF8) {
     run_from_utf8_output(input_data);
     std::cout << "----" << std::endl;

--- a/benchmarks/base64/benchmark_base64.cpp
+++ b/benchmarks/base64/benchmark_base64.cpp
@@ -408,7 +408,8 @@ private:
         continue;
       }
       simdutf::get_active_implementation() = e;
-      summarize(std::string("simdutf::") + std::string(e->name()), [this, &e]() {
+      summarize(std::string("simdutf::") + std::string(e->name()), [this,
+                                                                    &e]() {
         for (const std::vector<char> &source : data) {
           size_t base64_size =
               e->binary_to_base64(source.data(), source.size(), buffer1.data(),
@@ -462,7 +463,8 @@ private:
                         source.data(), source.size(), buffer1.data());
                   }
                 });
-      summarize(std::string("simdutf::") + std::string(e->name()) + "_with_lines",
+      summarize(std::string("simdutf::") + std::string(e->name()) +
+                    "_with_lines",
                 [this, &e, &base64_size]() {
                   for (const std::vector<char> &source : data) {
                     base64_size = e->binary_to_base64_with_lines(
@@ -470,15 +472,15 @@ private:
                   }
                 });
 #if SIMDUTF_COMPILED_CXX_VERSION >= 20
-      summarize(std::string("simdutf::atomic_binary_to_base64_") +
-                    std::string(
-                        (simdutf::get_active_implementation() = e)->name()),
-                [this, &base64_size]() {
-                  for (const std::vector<char> &source : data) {
-                    base64_size = simdutf::atomic_binary_to_base64(
-                        source.data(), source.size(), buffer1.data());
-                  }
-                });
+      summarize(
+          std::string("simdutf::atomic_binary_to_base64_") +
+              std::string((simdutf::get_active_implementation() = e)->name()),
+          [this, &base64_size]() {
+            for (const std::vector<char> &source : data) {
+              base64_size = simdutf::atomic_binary_to_base64(
+                  source.data(), source.size(), buffer1.data());
+            }
+          });
 #endif
     }
   }
@@ -495,7 +497,8 @@ private:
         continue;
       }
       simdutf::get_active_implementation() = e;
-      summarize(std::string("simdutf::") + std::string(e->name()), [this, &e]() {
+      summarize(std::string("simdutf::") + std::string(e->name()), [this,
+                                                                    &e]() {
         for (const std::vector<char> &source : data) {
           size_t base64_size =
               e->binary_to_base64(source.data(), source.size(), buffer1.data(),
@@ -581,7 +584,8 @@ private:
       }
       simdutf::get_active_implementation() = e;
 
-      summarize(std::string("simdutf::") + std::string(e->name()), [this, &e]() {
+      summarize(std::string("simdutf::") + std::string(e->name()), [this,
+                                                                    &e]() {
         for (const std::vector<char> &source : data) {
           auto err =
               e->base64_to_binary(source.data(), source.size(), buffer1.data());
@@ -599,7 +603,8 @@ private:
         }
       });
 
-      summarize(std::string("simdutf::") + std::string(e->name()) + " (accept garbage)",
+      summarize(std::string("simdutf::") + std::string(e->name()) +
+                    " (accept garbage)",
                 [this, &e]() {
                   for (const std::vector<char> &source : data) {
                     auto err = e->base64_to_binary(
@@ -621,28 +626,28 @@ private:
                 });
 
 #if SIMDUTF_COMPILED_CXX_VERSION >= 20
-      summarize(std::string("simdutf::atomic_base64_to_binary_") +
-                    std::string(
-                        (simdutf::get_active_implementation() = e)->name()),
-                [this]() {
-                  for (const std::vector<char> &source : data) {
-                    size_t len = buffer1.size();
-                    auto err = simdutf::atomic_base64_to_binary_safe(
-                        source.data(), source.size(), buffer1.data(), len);
-                    if (err.error) {
-                      std::cerr << "Error: at position " << err.count
-                                << " out of " << source.size() << std::endl;
-                      for (size_t i = err.count; i < source.size(); i++) {
-                        printf("0x%02x (%c) ", uint8_t(source[i]), source[i]);
-                      }
-                      printf("\n");
-                      throw std::runtime_error(
-                          "Error: is input valid base64? " +
-                          std::to_string(err.error) + " at position " +
-                          std::to_string(err.count));
-                    }
-                  }
-                });
+      summarize(
+          std::string("simdutf::atomic_base64_to_binary_") +
+              std::string((simdutf::get_active_implementation() = e)->name()),
+          [this]() {
+            for (const std::vector<char> &source : data) {
+              size_t len = buffer1.size();
+              auto err = simdutf::atomic_base64_to_binary_safe(
+                  source.data(), source.size(), buffer1.data(), len);
+              if (err.error) {
+                std::cerr << "Error: at position " << err.count << " out of "
+                          << source.size() << std::endl;
+                for (size_t i = err.count; i < source.size(); i++) {
+                  printf("0x%02x (%c) ", uint8_t(source[i]), source[i]);
+                }
+                printf("\n");
+                throw std::runtime_error("Error: is input valid base64? " +
+                                         std::to_string(err.error) +
+                                         " at position " +
+                                         std::to_string(err.count));
+              }
+            }
+          });
 #endif
     }
   }
@@ -669,13 +674,14 @@ private:
                   }
                 });
 
-      summarize(
-          std::string("simdutf::") + std::string(e->name()) + "_binary_length_from_base64",
-          [this, &e, &len]() {
-            for (const std::vector<char> &source : data) {
-              len = e->binary_length_from_base64(source.data(), source.size());
-            }
-          });
+      summarize(std::string("simdutf::") + std::string(e->name()) +
+                    "_binary_length_from_base64",
+                [this, &e, &len]() {
+                  for (const std::vector<char> &source : data) {
+                    len = e->binary_length_from_base64(source.data(),
+                                                       source.size());
+                  }
+                });
     }
   }
 };
@@ -728,7 +734,8 @@ void bench_bun() {
         continue;
       }
       simdutf::get_active_implementation() = e;
-      pretty_print(1, source.size(), std::string("simdutf::") + std::string(e->name()),
+      pretty_print(1, source.size(),
+                   std::string("simdutf::") + std::string(e->name()),
                    bench([&source, &buffer1, &e, &base64_size]() {
                      base64_size = e->binary_to_base64(
                          source.data(), source.size(), buffer1.data());

--- a/benchmarks/base64/benchmark_base64.cpp
+++ b/benchmarks/base64/benchmark_base64.cpp
@@ -408,7 +408,7 @@ private:
         continue;
       }
       simdutf::get_active_implementation() = e;
-      summarize("simdutf::" + e->name(), [this, &e]() {
+      summarize(std::string("simdutf::") + e->name(), [this, &e]() {
         for (const std::vector<char> &source : data) {
           size_t base64_size =
               e->binary_to_base64(source.data(), source.size(), buffer1.data(),
@@ -455,14 +455,14 @@ private:
         continue;
       }
       simdutf::get_active_implementation() = e;
-      summarize("simdutf::" + e->name() + "_standard", [this, &e,
-                                                        &base64_size]() {
-        for (const std::vector<char> &source : data) {
-          base64_size =
-              e->binary_to_base64(source.data(), source.size(), buffer1.data());
-        }
-      });
-      summarize("simdutf::" + e->name() + "_with_lines",
+      summarize(std::string("simdutf::") + e->name() + "_standard",
+                [this, &e, &base64_size]() {
+                  for (const std::vector<char> &source : data) {
+                    base64_size = e->binary_to_base64(
+                        source.data(), source.size(), buffer1.data());
+                  }
+                });
+      summarize(std::string("simdutf::") + e->name() + "_with_lines",
                 [this, &e, &base64_size]() {
                   for (const std::vector<char> &source : data) {
                     base64_size = e->binary_to_base64_with_lines(
@@ -470,7 +470,7 @@ private:
                   }
                 });
 #if SIMDUTF_COMPILED_CXX_VERSION >= 20
-      summarize("simdutf::atomic_binary_to_base64_" +
+      summarize(std::string("simdutf::atomic_binary_to_base64_") +
                     (simdutf::get_active_implementation() = e)->name(),
                 [this, &base64_size]() {
                   for (const std::vector<char> &source : data) {
@@ -494,7 +494,7 @@ private:
         continue;
       }
       simdutf::get_active_implementation() = e;
-      summarize("simdutf::" + e->name(), [this, &e]() {
+      summarize(std::string("simdutf::") + e->name(), [this, &e]() {
         for (const std::vector<char> &source : data) {
           size_t base64_size =
               e->binary_to_base64(source.data(), source.size(), buffer1.data(),
@@ -580,7 +580,7 @@ private:
       }
       simdutf::get_active_implementation() = e;
 
-      summarize("simdutf::" + e->name(), [this, &e]() {
+      summarize(std::string("simdutf::") + e->name(), [this, &e]() {
         for (const std::vector<char> &source : data) {
           auto err =
               e->base64_to_binary(source.data(), source.size(), buffer1.data());
@@ -598,27 +598,29 @@ private:
         }
       });
 
-      summarize("simdutf::" + e->name() + " (accept garbage)", [this, &e]() {
-        for (const std::vector<char> &source : data) {
-          auto err =
-              e->base64_to_binary(source.data(), source.size(), buffer1.data(),
-                                  simdutf::base64_default_accept_garbage);
-          if (err.error) {
-            std::cerr << "Error: at position " << err.count << " out of "
-                      << source.size() << std::endl;
-            for (size_t i = err.count; i < source.size(); i++) {
-              printf("0x%02x (%c) ", uint8_t(source[i]), source[i]);
-            }
-            printf("\n");
-            throw std::runtime_error(
-                "Error: is input valid base64? " + std::to_string(err.error) +
-                " at position " + std::to_string(err.count));
-          }
-        }
-      });
+      summarize(std::string("simdutf::") + e->name() + " (accept garbage)",
+                [this, &e]() {
+                  for (const std::vector<char> &source : data) {
+                    auto err = e->base64_to_binary(
+                        source.data(), source.size(), buffer1.data(),
+                        simdutf::base64_default_accept_garbage);
+                    if (err.error) {
+                      std::cerr << "Error: at position " << err.count
+                                << " out of " << source.size() << std::endl;
+                      for (size_t i = err.count; i < source.size(); i++) {
+                        printf("0x%02x (%c) ", uint8_t(source[i]), source[i]);
+                      }
+                      printf("\n");
+                      throw std::runtime_error(
+                          "Error: is input valid base64? " +
+                          std::to_string(err.error) + " at position " +
+                          std::to_string(err.count));
+                    }
+                  }
+                });
 
 #if SIMDUTF_COMPILED_CXX_VERSION >= 20
-      summarize("simdutf::atomic_base64_to_binary_" +
+      summarize(std::string("simdutf::atomic_base64_to_binary_") +
                     (simdutf::get_active_implementation() = e)->name(),
                 [this]() {
                   for (const std::vector<char> &source : data) {
@@ -656,7 +658,8 @@ private:
       simdutf::get_active_implementation() = e;
 
       volatile size_t len = 0;
-      summarize("simdutf::" + e->name() + "_maximal_binary_length_from_base64",
+      summarize(std::string("simdutf::") + e->name() +
+                    "_maximal_binary_length_from_base64",
                 [this, &e, &len]() {
                   for (const std::vector<char> &source : data) {
                     len = e->maximal_binary_length_from_base64(source.data(),
@@ -664,13 +667,13 @@ private:
                   }
                 });
 
-      summarize("simdutf::" + e->name() + "_binary_length_from_base64",
-                [this, &e, &len]() {
-                  for (const std::vector<char> &source : data) {
-                    len = e->binary_length_from_base64(source.data(),
-                                                       source.size());
-                  }
-                });
+      summarize(
+          std::string("simdutf::") + e->name() + "_binary_length_from_base64",
+          [this, &e, &len]() {
+            for (const std::vector<char> &source : data) {
+              len = e->binary_length_from_base64(source.data(), source.size());
+            }
+          });
     }
   }
 };
@@ -723,7 +726,7 @@ void bench_bun() {
         continue;
       }
       simdutf::get_active_implementation() = e;
-      pretty_print(1, source.size(), "simdutf::" + e->name(),
+      pretty_print(1, source.size(), std::string("simdutf::") + e->name(),
                    bench([&source, &buffer1, &e, &base64_size]() {
                      base64_size = e->binary_to_base64(
                          source.data(), source.size(), buffer1.data());
@@ -839,7 +842,7 @@ int main(int argc, char **argv) {
   }
 
   printf("# current system detected as %s.\n",
-         simdutf::get_active_implementation()->name().c_str());
+         simdutf::get_active_implementation()->name());
 
   std::vector<std::vector<char>> input;
   if (options.benchmark_mode != BenchmarkMode::bun and

--- a/benchmarks/base64/benchmark_base64.cpp
+++ b/benchmarks/base64/benchmark_base64.cpp
@@ -478,7 +478,7 @@ private:
                 });
 #if SIMDUTF_COMPILED_CXX_VERSION >= 20
       summarize(concatenate("simdutf::atomic_binary_to_base64_",
-                            (simdutf::get_active_implementation() = e)->name()),
+                            simdutf::get_active_implementation()->name()),
                 [this, &base64_size]() {
                   for (const std::vector<char> &source : data) {
                     base64_size = simdutf::atomic_binary_to_base64(
@@ -627,28 +627,27 @@ private:
                 });
 
 #if SIMDUTF_COMPILED_CXX_VERSION >= 20
-      summarize(
-          std::string("simdutf::atomic_base64_to_binary_") +
-              std::string((simdutf::get_active_implementation() = e)->name()),
-          [this]() {
-            for (const std::vector<char> &source : data) {
-              size_t len = buffer1.size();
-              auto err = simdutf::atomic_base64_to_binary_safe(
-                  source.data(), source.size(), buffer1.data(), len);
-              if (err.error) {
-                std::cerr << "Error: at position " << err.count << " out of "
-                          << source.size() << std::endl;
-                for (size_t i = err.count; i < source.size(); i++) {
-                  printf("0x%02x (%c) ", uint8_t(source[i]), source[i]);
-                }
-                printf("\n");
-                throw std::runtime_error("Error: is input valid base64? " +
-                                         std::to_string(err.error) +
-                                         " at position " +
-                                         std::to_string(err.count));
-              }
-            }
-          });
+      summarize(concatenate("simdutf::atomic_base64_to_binary_",
+                            simdutf::get_active_implementation()->name()),
+                [this]() {
+                  for (const std::vector<char> &source : data) {
+                    size_t len = buffer1.size();
+                    auto err = simdutf::atomic_base64_to_binary_safe(
+                        source.data(), source.size(), buffer1.data(), len);
+                    if (err.error) {
+                      std::cerr << "Error: at position " << err.count
+                                << " out of " << source.size() << std::endl;
+                      for (size_t i = err.count; i < source.size(); i++) {
+                        printf("0x%02x (%c) ", uint8_t(source[i]), source[i]);
+                      }
+                      printf("\n");
+                      throw std::runtime_error(
+                          "Error: is input valid base64? " +
+                          std::to_string(err.error) + " at position " +
+                          std::to_string(err.count));
+                    }
+                  }
+                });
 #endif
     }
   }

--- a/benchmarks/base64/benchmark_base64.cpp
+++ b/benchmarks/base64/benchmark_base64.cpp
@@ -408,7 +408,7 @@ private:
         continue;
       }
       simdutf::get_active_implementation() = e;
-      summarize(std::string("simdutf::") + e->name(), [this, &e]() {
+      summarize(std::string("simdutf::") + std::string(e->name()), [this, &e]() {
         for (const std::vector<char> &source : data) {
           size_t base64_size =
               e->binary_to_base64(source.data(), source.size(), buffer1.data(),
@@ -455,14 +455,14 @@ private:
         continue;
       }
       simdutf::get_active_implementation() = e;
-      summarize(std::string("simdutf::") + e->name() + "_standard",
+      summarize(std::string("simdutf::") + std::string(e->name()) + "_standard",
                 [this, &e, &base64_size]() {
                   for (const std::vector<char> &source : data) {
                     base64_size = e->binary_to_base64(
                         source.data(), source.size(), buffer1.data());
                   }
                 });
-      summarize(std::string("simdutf::") + e->name() + "_with_lines",
+      summarize(std::string("simdutf::") + std::string(e->name()) + "_with_lines",
                 [this, &e, &base64_size]() {
                   for (const std::vector<char> &source : data) {
                     base64_size = e->binary_to_base64_with_lines(
@@ -471,7 +471,8 @@ private:
                 });
 #if SIMDUTF_COMPILED_CXX_VERSION >= 20
       summarize(std::string("simdutf::atomic_binary_to_base64_") +
-                    (simdutf::get_active_implementation() = e)->name(),
+                    std::string(
+                        (simdutf::get_active_implementation() = e)->name()),
                 [this, &base64_size]() {
                   for (const std::vector<char> &source : data) {
                     base64_size = simdutf::atomic_binary_to_base64(
@@ -494,7 +495,7 @@ private:
         continue;
       }
       simdutf::get_active_implementation() = e;
-      summarize(std::string("simdutf::") + e->name(), [this, &e]() {
+      summarize(std::string("simdutf::") + std::string(e->name()), [this, &e]() {
         for (const std::vector<char> &source : data) {
           size_t base64_size =
               e->binary_to_base64(source.data(), source.size(), buffer1.data(),
@@ -580,7 +581,7 @@ private:
       }
       simdutf::get_active_implementation() = e;
 
-      summarize(std::string("simdutf::") + e->name(), [this, &e]() {
+      summarize(std::string("simdutf::") + std::string(e->name()), [this, &e]() {
         for (const std::vector<char> &source : data) {
           auto err =
               e->base64_to_binary(source.data(), source.size(), buffer1.data());
@@ -598,7 +599,7 @@ private:
         }
       });
 
-      summarize(std::string("simdutf::") + e->name() + " (accept garbage)",
+      summarize(std::string("simdutf::") + std::string(e->name()) + " (accept garbage)",
                 [this, &e]() {
                   for (const std::vector<char> &source : data) {
                     auto err = e->base64_to_binary(
@@ -621,7 +622,8 @@ private:
 
 #if SIMDUTF_COMPILED_CXX_VERSION >= 20
       summarize(std::string("simdutf::atomic_base64_to_binary_") +
-                    (simdutf::get_active_implementation() = e)->name(),
+                    std::string(
+                        (simdutf::get_active_implementation() = e)->name()),
                 [this]() {
                   for (const std::vector<char> &source : data) {
                     size_t len = buffer1.size();
@@ -658,7 +660,7 @@ private:
       simdutf::get_active_implementation() = e;
 
       volatile size_t len = 0;
-      summarize(std::string("simdutf::") + e->name() +
+      summarize(std::string("simdutf::") + std::string(e->name()) +
                     "_maximal_binary_length_from_base64",
                 [this, &e, &len]() {
                   for (const std::vector<char> &source : data) {
@@ -668,7 +670,7 @@ private:
                 });
 
       summarize(
-          std::string("simdutf::") + e->name() + "_binary_length_from_base64",
+          std::string("simdutf::") + std::string(e->name()) + "_binary_length_from_base64",
           [this, &e, &len]() {
             for (const std::vector<char> &source : data) {
               len = e->binary_length_from_base64(source.data(), source.size());
@@ -726,7 +728,7 @@ void bench_bun() {
         continue;
       }
       simdutf::get_active_implementation() = e;
-      pretty_print(1, source.size(), std::string("simdutf::") + e->name(),
+      pretty_print(1, source.size(), std::string("simdutf::") + std::string(e->name()),
                    bench([&source, &buffer1, &e, &base64_size]() {
                      base64_size = e->binary_to_base64(
                          source.data(), source.size(), buffer1.data());
@@ -842,7 +844,7 @@ int main(int argc, char **argv) {
   }
 
   printf("# current system detected as %s.\n",
-         simdutf::get_active_implementation()->name());
+         simdutf::get_active_implementation()->name().data());
 
   std::vector<std::vector<char>> input;
   if (options.benchmark_mode != BenchmarkMode::bun and

--- a/benchmarks/base64/benchmark_base64.cpp
+++ b/benchmarks/base64/benchmark_base64.cpp
@@ -589,7 +589,7 @@ private:
 
       summarize(concatenate("simdutf::", e->name()), [this, &e]() {
         for (const std::vector<char> &source : data) {
-          concatenate auto err =
+          auto err =
               e->base64_to_binary(source.data(), source.size(), buffer1.data());
           if (err.error) {
             std::cerr << "Error: at position " << err.count << " out of "

--- a/benchmarks/base64/benchmark_base64.cpp
+++ b/benchmarks/base64/benchmark_base64.cpp
@@ -843,7 +843,8 @@ int main(int argc, char **argv) {
     return EXIT_SUCCESS;
   }
 
-  printf("# current system detected as %s.\n",
+  printf("# current system detected as %.*s.\n",
+         int(simdutf::get_active_implementation()->name().size()),
          simdutf::get_active_implementation()->name().data());
 
   std::vector<std::vector<char>> input;

--- a/benchmarks/base64/benchmark_base64.cpp
+++ b/benchmarks/base64/benchmark_base64.cpp
@@ -398,8 +398,8 @@ private:
 
   /// concatenates two stringlike variables (const char*, string_view or
   /// std::string) into a std::string
-  std::string concatenate(const auto &string_like_1,
-                          const auto &string_like_2) {
+  template <typename T1, typename T2>
+  std::string concatenate(const T1 &string_like_1, const T2 &string_like_2) {
     return std::string(string_like_1) + std::string(string_like_2);
   }
 
@@ -589,7 +589,7 @@ private:
 
       summarize(concatenate("simdutf::", e->name()), [this, &e]() {
         for (const std::vector<char> &source : data) {
-          auto err =
+          concatenate auto err =
               e->base64_to_binary(source.data(), source.size(), buffer1.data());
           if (err.error) {
             std::cerr << "Error: at position " << err.count << " out of "

--- a/benchmarks/base64/benchmark_base64.cpp
+++ b/benchmarks/base64/benchmark_base64.cpp
@@ -271,6 +271,13 @@ struct NameMatcher {
 
 void bench_bun();
 
+/// concatenates two stringlike variables (const char*, string_view or
+/// std::string) into a std::string
+template <typename T1, typename T2>
+std::string concatenate(const T1 &string_like_1, const T2 &string_like_2) {
+  return std::string(string_like_1) + std::string(string_like_2);
+}
+
 class Application {
   std::vector<std::vector<char>> data;
   size_t volume;
@@ -394,13 +401,6 @@ private:
     const event_aggregate agg = bench(closure);
 
     pretty_print(data.size(), volume, name, agg);
-  }
-
-  /// concatenates two stringlike variables (const char*, string_view or
-  /// std::string) into a std::string
-  template <typename T1, typename T2>
-  std::string concatenate(const T1 &string_like_1, const T2 &string_like_2) {
-    return std::string(string_like_1) + std::string(string_like_2);
   }
 
   void roundtrip() {

--- a/benchmarks/base64/benchmark_base64.cpp
+++ b/benchmarks/base64/benchmark_base64.cpp
@@ -396,6 +396,13 @@ private:
     pretty_print(data.size(), volume, name, agg);
   }
 
+  /// concatenates two stringlike variables (const char*, string_view or
+  /// std::string) into a std::string
+  std::string concatenate(const auto &string_like_1,
+                          const auto &string_like_2) {
+    return std::string(string_like_1) + std::string(string_like_2);
+  }
+
   void roundtrip() {
     if (benchmark_mode != BenchmarkMode::list) {
       printf("# roundtrip (url)\n");
@@ -408,8 +415,7 @@ private:
         continue;
       }
       simdutf::get_active_implementation() = e;
-      summarize(std::string("simdutf::") + std::string(e->name()), [this,
-                                                                    &e]() {
+      summarize(concatenate("simdutf::", e->name()), [this, &e]() {
         for (const std::vector<char> &source : data) {
           size_t base64_size =
               e->binary_to_base64(source.data(), source.size(), buffer1.data(),
@@ -456,15 +462,14 @@ private:
         continue;
       }
       simdutf::get_active_implementation() = e;
-      summarize(std::string("simdutf::") + std::string(e->name()) + "_standard",
+      summarize(concatenate("simdutf::", e->name()) + "_standard",
                 [this, &e, &base64_size]() {
                   for (const std::vector<char> &source : data) {
                     base64_size = e->binary_to_base64(
                         source.data(), source.size(), buffer1.data());
                   }
                 });
-      summarize(std::string("simdutf::") + std::string(e->name()) +
-                    "_with_lines",
+      summarize(concatenate("simdutf::", e->name()) + "_with_lines",
                 [this, &e, &base64_size]() {
                   for (const std::vector<char> &source : data) {
                     base64_size = e->binary_to_base64_with_lines(
@@ -472,15 +477,14 @@ private:
                   }
                 });
 #if SIMDUTF_COMPILED_CXX_VERSION >= 20
-      summarize(
-          std::string("simdutf::atomic_binary_to_base64_") +
-              std::string((simdutf::get_active_implementation() = e)->name()),
-          [this, &base64_size]() {
-            for (const std::vector<char> &source : data) {
-              base64_size = simdutf::atomic_binary_to_base64(
-                  source.data(), source.size(), buffer1.data());
-            }
-          });
+      summarize(concatenate("simdutf::atomic_binary_to_base64_",
+                            (simdutf::get_active_implementation() = e)->name()),
+                [this, &base64_size]() {
+                  for (const std::vector<char> &source : data) {
+                    base64_size = simdutf::atomic_binary_to_base64(
+                        source.data(), source.size(), buffer1.data());
+                  }
+                });
 #endif
     }
   }
@@ -497,8 +501,7 @@ private:
         continue;
       }
       simdutf::get_active_implementation() = e;
-      summarize(std::string("simdutf::") + std::string(e->name()), [this,
-                                                                    &e]() {
+      summarize(concatenate("simdutf::", e->name()), [this, &e]() {
         for (const std::vector<char> &source : data) {
           size_t base64_size =
               e->binary_to_base64(source.data(), source.size(), buffer1.data(),
@@ -584,8 +587,7 @@ private:
       }
       simdutf::get_active_implementation() = e;
 
-      summarize(std::string("simdutf::") + std::string(e->name()), [this,
-                                                                    &e]() {
+      summarize(concatenate("simdutf::", e->name()), [this, &e]() {
         for (const std::vector<char> &source : data) {
           auto err =
               e->base64_to_binary(source.data(), source.size(), buffer1.data());
@@ -603,8 +605,7 @@ private:
         }
       });
 
-      summarize(std::string("simdutf::") + std::string(e->name()) +
-                    " (accept garbage)",
+      summarize(concatenate("simdutf::", e->name()) + " (accept garbage)",
                 [this, &e]() {
                   for (const std::vector<char> &source : data) {
                     auto err = e->base64_to_binary(
@@ -665,7 +666,7 @@ private:
       simdutf::get_active_implementation() = e;
 
       volatile size_t len = 0;
-      summarize(std::string("simdutf::") + std::string(e->name()) +
+      summarize(concatenate("simdutf::", e->name()) +
                     "_maximal_binary_length_from_base64",
                 [this, &e, &len]() {
                   for (const std::vector<char> &source : data) {
@@ -674,14 +675,13 @@ private:
                   }
                 });
 
-      summarize(std::string("simdutf::") + std::string(e->name()) +
-                    "_binary_length_from_base64",
-                [this, &e, &len]() {
-                  for (const std::vector<char> &source : data) {
-                    len = e->binary_length_from_base64(source.data(),
-                                                       source.size());
-                  }
-                });
+      summarize(
+          concatenate("simdutf::", e->name()) + "_binary_length_from_base64",
+          [this, &e, &len]() {
+            for (const std::vector<char> &source : data) {
+              len = e->binary_length_from_base64(source.data(), source.size());
+            }
+          });
     }
   }
 };
@@ -734,8 +734,7 @@ void bench_bun() {
         continue;
       }
       simdutf::get_active_implementation() = e;
-      pretty_print(1, source.size(),
-                   std::string("simdutf::") + std::string(e->name()),
+      pretty_print(1, source.size(), concatenate("simdutf::", e->name()),
                    bench([&source, &buffer1, &e, &base64_size]() {
                      base64_size = e->binary_to_base64(
                          source.data(), source.size(), buffer1.data());

--- a/benchmarks/benchmark_to_well_formed_utf16.cpp
+++ b/benchmarks/benchmark_to_well_formed_utf16.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 #include <random>
 #include <stdexcept>
+#include <string>
 #include <functional>
 #include "benchmark_base.h"
 #include "simdutf.h"

--- a/benchmarks/benchmark_to_well_formed_utf16.cpp
+++ b/benchmarks/benchmark_to_well_formed_utf16.cpp
@@ -318,7 +318,7 @@ int main(int argc, char *argv[]) {
                            char16_t *output) {
       e->to_well_formed_utf16le(input, length, output);
     };
-    std::string name = e->name();
+    std::string name{e->name()};
     utf16_fixe_implementation fix_implementation{fix, name};
 
     fixers.push_back(fix_implementation);

--- a/benchmarks/shortbench.cpp
+++ b/benchmarks/shortbench.cpp
@@ -511,7 +511,7 @@ int main(int argc, char *argv[]) {
         printf("# Input size: %zu bytes\n", file_size);
         printf("# Max benchmark size: %zu bytes\n", actual_max);
         printf("# Current system: %s\n",
-               simdutf::get_active_implementation()->name().c_str());
+               simdutf::get_active_implementation()->name());
         printf("\n");
 
         print_table_header(has_events);
@@ -532,7 +532,7 @@ int main(int argc, char *argv[]) {
       printf("# Input size: %zu bytes\n", file_size);
       printf("# Max benchmark size: %zu bytes\n", actual_max);
       printf("# Current system: %s\n",
-             simdutf::get_active_implementation()->name().c_str());
+             simdutf::get_active_implementation()->name());
       printf("\n");
 
       print_table_header(has_events);

--- a/benchmarks/shortbench.cpp
+++ b/benchmarks/shortbench.cpp
@@ -511,7 +511,7 @@ int main(int argc, char *argv[]) {
         printf("# Input size: %zu bytes\n", file_size);
         printf("# Max benchmark size: %zu bytes\n", actual_max);
         printf("# Current system: %s\n",
-               simdutf::get_active_implementation()->name());
+               simdutf::get_active_implementation()->name().data());
         printf("\n");
 
         print_table_header(has_events);
@@ -532,7 +532,7 @@ int main(int argc, char *argv[]) {
       printf("# Input size: %zu bytes\n", file_size);
       printf("# Max benchmark size: %zu bytes\n", actual_max);
       printf("# Current system: %s\n",
-             simdutf::get_active_implementation()->name());
+             simdutf::get_active_implementation()->name().data());
       printf("\n");
 
       print_table_header(has_events);

--- a/benchmarks/shortbench.cpp
+++ b/benchmarks/shortbench.cpp
@@ -510,7 +510,8 @@ int main(int argc, char *argv[]) {
                input_desc.c_str());
         printf("# Input size: %zu bytes\n", file_size);
         printf("# Max benchmark size: %zu bytes\n", actual_max);
-        printf("# Current system: %s\n",
+        printf("# Current system: %.*s\n",
+               int(simdutf::get_active_implementation()->name().size()),
                simdutf::get_active_implementation()->name().data());
         printf("\n");
 
@@ -531,7 +532,8 @@ int main(int argc, char *argv[]) {
              input_desc.c_str());
       printf("# Input size: %zu bytes\n", file_size);
       printf("# Max benchmark size: %zu bytes\n", actual_max);
-      printf("# Current system: %s\n",
+      printf("# Current system: %.*s\n",
+             int(simdutf::get_active_implementation()->name().size()),
              simdutf::get_active_implementation()->name().data());
       printf("\n");
 

--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -79,7 +79,7 @@ void Benchmark::register_function(std::string name, Fn function,
   if (name.find('+') == std::string::npos) {
     // adding simdutf benchmark, populate for all known architectures
     for (const auto &impl : simdutf::get_available_implementations()) {
-      const auto full_name = name + '+' + impl->name();
+      const auto full_name = name + '+' + std::string(impl->name());
       benchmarks.insert({full_name, std::make_pair(function, set)});
     }
   } else {
@@ -572,8 +572,7 @@ void Benchmark::run(const std::string &procedure_name, size_t iterations) {
     const std::string name{procedure_name.substr(0, p)};
     const std::string impl{procedure_name.substr(p + 1)};
 
-    auto implementation =
-        simdutf::get_available_implementations()[impl.c_str()];
+    auto implementation = simdutf::get_available_implementations()[impl];
     if (implementation == nullptr) {
       throw std::runtime_error("Wrong implementation " + impl);
     }

--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -572,7 +572,8 @@ void Benchmark::run(const std::string &procedure_name, size_t iterations) {
     const std::string name{procedure_name.substr(0, p)};
     const std::string impl{procedure_name.substr(p + 1)};
 
-    auto implementation = simdutf::get_available_implementations()[impl];
+    auto implementation =
+        simdutf::get_available_implementations()[impl.c_str()];
     if (implementation == nullptr) {
       throw std::runtime_error("Wrong implementation " + impl);
     }

--- a/benchmarks/src/benchmark_base.cpp
+++ b/benchmarks/src/benchmark_base.cpp
@@ -22,7 +22,7 @@ void BenchmarkBase::run(const input::Testcase &testcase) {
   prepare_input(testcase);
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
-  printf("input detected as %s\n", simdutf::to_string(detected_encoding));
+  printf("input detected as %s\n", simdutf::to_string(detected_encoding).data());
   printf("===========================\n");
 
   const auto &known_procedures = all_procedures();

--- a/benchmarks/src/benchmark_base.cpp
+++ b/benchmarks/src/benchmark_base.cpp
@@ -22,7 +22,9 @@ void BenchmarkBase::run(const input::Testcase &testcase) {
   prepare_input(testcase);
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
-  printf("input detected as %s\n", simdutf::to_string(detected_encoding).data());
+  printf("input detected as %.*s\n",
+         int(simdutf::to_string(detected_encoding).size()),
+         simdutf::to_string(detected_encoding).data());
   printf("===========================\n");
 
   const auto &known_procedures = all_procedures();

--- a/benchmarks/src/benchmark_base.cpp
+++ b/benchmarks/src/benchmark_base.cpp
@@ -22,8 +22,7 @@ void BenchmarkBase::run(const input::Testcase &testcase) {
   prepare_input(testcase);
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
-  printf("input detected as %s\n",
-         simdutf::to_string(detected_encoding).c_str());
+  printf("input detected as %s\n", simdutf::to_string(detected_encoding));
   printf("===========================\n");
 
   const auto &known_procedures = all_procedures();

--- a/benchmarks/stream.cpp
+++ b/benchmarks/stream.cpp
@@ -179,7 +179,7 @@ void run_from_utf16(const std::vector<char> &input_data,
 
 int main(int argc, char **argv) {
   printf("# current system detected as %s.\n",
-         simdutf::get_active_implementation()->name().c_str());
+         simdutf::get_active_implementation()->name());
   if (argc < 2) {
     std::cerr << "Please provide a file argument." << std::endl;
     std::cerr << "The file should contain either UTF-8 or UTF-16 text."
@@ -198,8 +198,7 @@ int main(int argc, char **argv) {
                     std::istreambuf_iterator<char>());
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
-  printf("# input detected as %s.\n",
-         simdutf::to_string(detected_encoding).c_str());
+  printf("# input detected as %s.\n", simdutf::to_string(detected_encoding));
   if (detected_encoding == simdutf::encoding_type::UTF16_LE) {
     run_from_utf16(input_data);
   } else if (detected_encoding == simdutf::encoding_type::UTF8) {

--- a/benchmarks/stream.cpp
+++ b/benchmarks/stream.cpp
@@ -178,7 +178,8 @@ void run_from_utf16(const std::vector<char> &input_data,
 }
 
 int main(int argc, char **argv) {
-  printf("# current system detected as %s.\n",
+  printf("# current system detected as %.*s.\n",
+         int(simdutf::get_active_implementation()->name().size()),
          simdutf::get_active_implementation()->name().data());
   if (argc < 2) {
     std::cerr << "Please provide a file argument." << std::endl;
@@ -198,7 +199,9 @@ int main(int argc, char **argv) {
                     std::istreambuf_iterator<char>());
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
-  printf("# input detected as %s.\n", simdutf::to_string(detected_encoding).data());
+  printf("# input detected as %.*s.\n",
+         int(simdutf::to_string(detected_encoding).size()),
+         simdutf::to_string(detected_encoding).data());
   if (detected_encoding == simdutf::encoding_type::UTF16_LE) {
     run_from_utf16(input_data);
   } else if (detected_encoding == simdutf::encoding_type::UTF8) {

--- a/benchmarks/stream.cpp
+++ b/benchmarks/stream.cpp
@@ -179,7 +179,7 @@ void run_from_utf16(const std::vector<char> &input_data,
 
 int main(int argc, char **argv) {
   printf("# current system detected as %s.\n",
-         simdutf::get_active_implementation()->name());
+         simdutf::get_active_implementation()->name().data());
   if (argc < 2) {
     std::cerr << "Please provide a file argument." << std::endl;
     std::cerr << "The file should contain either UTF-8 or UTF-16 text."
@@ -198,7 +198,7 @@ int main(int argc, char **argv) {
                     std::istreambuf_iterator<char>());
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
-  printf("# input detected as %s.\n", simdutf::to_string(detected_encoding));
+  printf("# input detected as %s.\n", simdutf::to_string(detected_encoding).data());
   if (detected_encoding == simdutf::encoding_type::UTF16_LE) {
     run_from_utf16(input_data);
   } else if (detected_encoding == simdutf::encoding_type::UTF8) {

--- a/benchmarks/threaded.cpp
+++ b/benchmarks/threaded.cpp
@@ -95,7 +95,7 @@ void run_from_utf8(const std::vector<char> &input_data) {
 
 int main(int argc, char **argv) {
   printf("# current system detected as %s.\n",
-         simdutf::get_active_implementation()->name().c_str());
+         simdutf::get_active_implementation()->name());
   if (argc < 2) {
     std::cerr << "Please provide a file argument." << std::endl;
     return EXIT_FAILURE;
@@ -111,8 +111,7 @@ int main(int argc, char **argv) {
                     std::istreambuf_iterator<char>());
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
-  printf("# input detected as %s.\n",
-         simdutf::to_string(detected_encoding).c_str());
+  printf("# input detected as %s.\n", simdutf::to_string(detected_encoding));
   if (detected_encoding == simdutf::encoding_type::UTF8) {
 
     run_from_utf8(input_data);

--- a/benchmarks/threaded.cpp
+++ b/benchmarks/threaded.cpp
@@ -95,7 +95,7 @@ void run_from_utf8(const std::vector<char> &input_data) {
 
 int main(int argc, char **argv) {
   printf("# current system detected as %s.\n",
-         simdutf::get_active_implementation()->name());
+         simdutf::get_active_implementation()->name().data());
   if (argc < 2) {
     std::cerr << "Please provide a file argument." << std::endl;
     return EXIT_FAILURE;
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
                     std::istreambuf_iterator<char>());
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
-  printf("# input detected as %s.\n", simdutf::to_string(detected_encoding));
+  printf("# input detected as %s.\n", simdutf::to_string(detected_encoding).data());
   if (detected_encoding == simdutf::encoding_type::UTF8) {
 
     run_from_utf8(input_data);

--- a/benchmarks/threaded.cpp
+++ b/benchmarks/threaded.cpp
@@ -94,7 +94,8 @@ void run_from_utf8(const std::vector<char> &input_data) {
 }
 
 int main(int argc, char **argv) {
-  printf("# current system detected as %s.\n",
+  printf("# current system detected as %.*s.\n",
+         int(simdutf::get_active_implementation()->name().size()),
          simdutf::get_active_implementation()->name().data());
   if (argc < 2) {
     std::cerr << "Please provide a file argument." << std::endl;
@@ -111,7 +112,9 @@ int main(int argc, char **argv) {
                     std::istreambuf_iterator<char>());
   auto detected_encoding =
       simdutf::autodetect_encoding(input_data.data(), input_data.size());
-  printf("# input detected as %s.\n", simdutf::to_string(detected_encoding).data());
+  printf("# input detected as %.*s.\n",
+         int(simdutf::to_string(detected_encoding).size()),
+         simdutf::to_string(detected_encoding).data());
   if (detected_encoding == simdutf::encoding_type::UTF8) {
 
     run_from_utf8(input_data);

--- a/cmake/simdutf-flags.cmake
+++ b/cmake/simdutf-flags.cmake
@@ -18,8 +18,11 @@ endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
 
-# We compile tools, tests, etc. with C++11 by default.
-set(SIMDUTF_CXX_STANDARD 11 CACHE STRING "the C++ standard to use for simdutf")
+# simdutf requires C++17 or later.
+set(SIMDUTF_CXX_STANDARD 17 CACHE STRING "the C++ standard to use for simdutf")
+if(SIMDUTF_CXX_STANDARD LESS 17)
+  message(FATAL_ERROR "simdutf requires C++17 or later (got ${SIMDUTF_CXX_STANDARD}).")
+endif()
 
 set(CMAKE_CXX_STANDARD ${SIMDUTF_CXX_STANDARD})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/simdutf/common_defs.h
+++ b/include/simdutf/common_defs.h
@@ -123,13 +123,6 @@
 
 #endif // MSC_VER
 
-// Conditional constexpr macro: expands to constexpr for C++17+, empty otherwise
-#if SIMDUTF_CPLUSPLUS17
-  #define simdutf_constexpr constexpr
-#else
-  #define simdutf_constexpr
-#endif
-
 // Will evaluate to constexpr in C++23 or later. This makes it possible to mark
 // functions constexpr if the "if consteval" feature is available to use.
 #if SIMDUTF_CPLUSPLUS23

--- a/include/simdutf/compiler_check.h
+++ b/include/simdutf/compiler_check.h
@@ -43,8 +43,8 @@
   #define SIMDUTF_CPLUSPLUS11 1
 #endif
 
-#ifndef SIMDUTF_CPLUSPLUS11
-  #error simdutf requires a compiler compliant with the C++11 standard
+#ifndef SIMDUTF_CPLUSPLUS17
+  #error simdutf requires a compiler compliant with the C++17 standard
 #endif
 
 #endif // SIMDUTF_COMPILER_CHECK_H

--- a/include/simdutf/encoding_types.h
+++ b/include/simdutf/encoding_types.h
@@ -1,5 +1,6 @@
 #ifndef SIMDUTF_ENCODING_TYPES_H
 #define SIMDUTF_ENCODING_TYPES_H
+#include <string_view>
 #include "simdutf/portability.h"
 #include "simdutf/common_defs.h"
 
@@ -42,7 +43,7 @@ match_system(endianness e) {
   return e == endianness::NATIVE;
 }
 
-simdutf_warn_unused const char *to_string(encoding_type bom);
+simdutf_warn_unused std::string_view to_string(encoding_type bom);
 
 // Note that BOM for UTF8 is discouraged.
 namespace BOM {

--- a/include/simdutf/encoding_types.h
+++ b/include/simdutf/encoding_types.h
@@ -1,6 +1,5 @@
 #ifndef SIMDUTF_ENCODING_TYPES_H
 #define SIMDUTF_ENCODING_TYPES_H
-#include <string>
 #include "simdutf/portability.h"
 #include "simdutf/common_defs.h"
 
@@ -43,7 +42,7 @@ match_system(endianness e) {
   return e == endianness::NATIVE;
 }
 
-simdutf_warn_unused std::string to_string(encoding_type bom);
+simdutf_warn_unused const char *to_string(encoding_type bom);
 
 // Note that BOM for UTF8 is discouraged.
 namespace BOM {

--- a/include/simdutf/error.h
+++ b/include/simdutf/error.h
@@ -1,8 +1,7 @@
 #ifndef SIMDUTF_ERROR_H
 #define SIMDUTF_ERROR_H
-#if SIMDUTF_CPLUSPLUS17
-  #include <string_view>
-#endif
+#include <string_view>
+
 namespace simdutf {
 
 enum error_code {
@@ -44,7 +43,7 @@ enum error_code {
   OUTPUT_BUFFER_TOO_SMALL,  // The provided buffer is too small.
   OTHER                     // Not related to validation/transcoding.
 };
-#if SIMDUTF_CPLUSPLUS17
+
 inline std::string_view error_to_string(error_code code) noexcept {
   switch (code) {
   case SUCCESS:
@@ -73,7 +72,6 @@ inline std::string_view error_to_string(error_code code) noexcept {
     return "OTHER";
   }
 }
-#endif
 
 struct result {
   error_code error;

--- a/include/simdutf/error.h
+++ b/include/simdutf/error.h
@@ -1,5 +1,8 @@
 #ifndef SIMDUTF_ERROR_H
 #define SIMDUTF_ERROR_H
+#if SIMDUTF_CPLUSPLUS17
+  #include <string_view>
+#endif
 namespace simdutf {
 
 enum error_code {

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -4176,7 +4176,6 @@ find(const char16_t *start, const char16_t *end, char16_t character) noexcept {
 
 namespace simdutf {
 
-
 inline std::string_view to_string(base64_options options) {
   switch (options) {
   case base64_default:

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -18,6 +18,7 @@
   #include <type_traits>
   #include <span>
   #include <tuple>
+  #include <utility> // for std::unreachable
 #endif
 // The following defines are conditionally enabled/disabled during amalgamation.
 // By default all features are enabled, regular code shouldn't check them. Only

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -4176,7 +4176,7 @@ find(const char16_t *start, const char16_t *end, char16_t character) noexcept {
 
 namespace simdutf {
 
-  #if SIMDUTF_CPLUSPLUS17
+
 inline std::string_view to_string(base64_options options) {
   switch (options) {
   case base64_default:
@@ -4198,9 +4198,7 @@ inline std::string_view to_string(base64_options options) {
   }
   return "<unknown>";
 }
-  #endif // SIMDUTF_CPLUSPLUS17
 
-  #if SIMDUTF_CPLUSPLUS17
 inline std::string_view to_string(last_chunk_handling_options options) {
   switch (options) {
   case loose:
@@ -4214,7 +4212,6 @@ inline std::string_view to_string(last_chunk_handling_options options) {
   }
   return "<unknown>";
 }
-  #endif
 
 /**
  * Provide the maximal binary length in bytes given the base64 input.

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -6,13 +6,13 @@
 #ifdef SIMDUTF_INTERNAL_TESTS
   #include <vector>
 #endif
-#include <string_view>
 #include "simdutf/common_defs.h"
 #include "simdutf/compiler_check.h"
 #include "simdutf/encoding_types.h"
 #include "simdutf/error.h"
 #include "simdutf/internal/isadetection.h"
 
+#include <string_view>
 #if SIMDUTF_SPAN
   #include <concepts>
   #include <type_traits>

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -3,7 +3,6 @@
 #if !defined(SIMDUTF_NO_THREADS)
   #include <atomic>
 #endif
-#include <string>
 #ifdef SIMDUTF_INTERNAL_TESTS
   #include <vector>
 #endif
@@ -5093,7 +5092,7 @@ public:
    *
    * @return the name of the implementation, e.g. "haswell", "westmere", "arm64"
    */
-  virtual std::string name() const { return std::string(_name); }
+  virtual const char *name() const noexcept { return _name; }
 
   /**
    * The description of this implementation.
@@ -5104,7 +5103,7 @@ public:
    *
    * @return the name of the implementation, e.g. "haswell", "westmere", "arm64"
    */
-  virtual std::string description() const { return std::string(_description); }
+  virtual const char *description() const noexcept { return _description; }
 
   /**
    * The instruction sets this implementation is compiled against
@@ -7008,7 +7007,7 @@ public:
 
   struct TestProcedure {
     // display name
-    std::string name;
+    const char *name;
 
     // procedure should return whether given test pass or not
     void (*procedure)(const implementation &);
@@ -7076,9 +7075,15 @@ public:
    * @param name the implementation to find, e.g. "westmere", "haswell", "arm64"
    * @return the implementation, or nullptr if the parse failed.
    */
-  const implementation *operator[](const std::string &name) const noexcept {
+  const implementation *operator[](const char *name) const noexcept {
     for (const implementation *impl : *this) {
-      if (impl->name() == name) {
+      const char *a = impl->name();
+      const char *b = name;
+      while (*a && *a == *b) {
+        ++a;
+        ++b;
+      }
+      if (*a == '\0' && *b == '\0') {
         return impl;
       }
     }

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -7267,7 +7267,7 @@ consteval auto base64_decode_literal(const char *str) {
   auto r = scalar::base64::base64_to_binary_details_impl(
       str, InputLen, result.buffer.data(), base64_default, loose);
   if (r.error != error_code::SUCCESS) {
-    (void)(1 / 0); // invalid base64 input in _base64 literal
+    std::unreachable(); // invalid base64 input in _base64 literal
   }
   result.output_count = r.output_count;
   return result;

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -7267,7 +7267,7 @@ consteval auto base64_decode_literal(const char *str) {
   auto r = scalar::base64::base64_to_binary_details_impl(
       str, InputLen, result.buffer.data(), base64_default, loose);
   if (r.error != error_code::SUCCESS) {
-    1 / 0; // invalid base64 input in _base64 literal
+    (void)(1 / 0); // invalid base64 input in _base64 literal
   }
   result.output_count = r.output_count;
   return result;

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -7267,7 +7267,7 @@ consteval auto base64_decode_literal(const char *str) {
   auto r = scalar::base64::base64_to_binary_details_impl(
       str, InputLen, result.buffer.data(), base64_default, loose);
   if (r.error != error_code::SUCCESS) {
-    throw "invalid base64 input in _base64 literal";
+    1 / 0; // invalid base64 input in _base64 literal
   }
   result.output_count = r.output_count;
   return result;

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -6,6 +6,7 @@
 #ifdef SIMDUTF_INTERNAL_TESTS
   #include <vector>
 #endif
+#include <string_view>
 #include "simdutf/common_defs.h"
 #include "simdutf/compiler_check.h"
 #include "simdutf/encoding_types.h"
@@ -17,9 +18,6 @@
   #include <type_traits>
   #include <span>
   #include <tuple>
-#endif
-#if SIMDUTF_CPLUSPLUS17
-  #include <string_view>
 #endif
 // The following defines are conditionally enabled/disabled during amalgamation.
 // By default all features are enabled, regular code shouldn't check them. Only
@@ -5092,7 +5090,7 @@ public:
    *
    * @return the name of the implementation, e.g. "haswell", "westmere", "arm64"
    */
-  virtual const char *name() const noexcept { return _name; }
+  virtual std::string_view name() const noexcept { return _name; }
 
   /**
    * The description of this implementation.
@@ -5103,7 +5101,7 @@ public:
    *
    * @return the name of the implementation, e.g. "haswell", "westmere", "arm64"
    */
-  virtual const char *description() const noexcept { return _description; }
+  virtual std::string_view description() const noexcept { return _description; }
 
   /**
    * The instruction sets this implementation is compiled against
@@ -7007,7 +7005,7 @@ public:
 
   struct TestProcedure {
     // display name
-    const char *name;
+    std::string_view name;
 
     // procedure should return whether given test pass or not
     void (*procedure)(const implementation &);
@@ -7075,15 +7073,9 @@ public:
    * @param name the implementation to find, e.g. "westmere", "haswell", "arm64"
    * @return the implementation, or nullptr if the parse failed.
    */
-  const implementation *operator[](const char *name) const noexcept {
+  const implementation *operator[](std::string_view name) const noexcept {
     for (const implementation *impl : *this) {
-      const char *a = impl->name();
-      const char *b = name;
-      while (*a && *a == *b) {
-        ++a;
-        ++b;
-      }
-      if (*a == '\0' && *b == '\0') {
+      if (impl->name() == name) {
         return impl;
       }
     }

--- a/include/simdutf/portability.h
+++ b/include/simdutf/portability.h
@@ -6,6 +6,7 @@
 #include <cfloat>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #ifndef _WIN32
   // strcasecmp, strncasecmp

--- a/include/simdutf/scalar/base64.h
+++ b/include/simdutf/scalar/base64.h
@@ -5,7 +5,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <iostream>
 
 namespace simdutf {
 namespace scalar {

--- a/include/simdutf/scalar/base64.h
+++ b/include/simdutf/scalar/base64.h
@@ -18,7 +18,7 @@ template <class char_type> bool is_ascii_white_space(char_type c) {
 }
 
 template <class char_type> simdutf_constexpr23 bool is_eight_byte(char_type c) {
-  if simdutf_constexpr (sizeof(char_type) == 1) {
+  if constexpr (sizeof(char_type) == 1) {
     return true;
   }
   return uint8_t(c) == c;
@@ -417,7 +417,7 @@ template <bool use_lines = false>
 simdutf_constexpr23 size_t tail_encode_base64_impl(
     char *dst, const char *src, size_t srclen, base64_options options,
     size_t line_length = simdutf::default_line_length, size_t line_offset = 0) {
-  if simdutf_constexpr (use_lines) {
+  if constexpr (use_lines) {
     // sanitize line_length and starting_line_offset.
     // line_length must be greater than 3.
     if (line_length < 4) {
@@ -452,7 +452,7 @@ simdutf_constexpr23 size_t tail_encode_base64_impl(
     t1 = uint8_t(src[i]);
     t2 = uint8_t(src[i + 1]);
     t3 = uint8_t(src[i + 2]);
-    if simdutf_constexpr (use_lines) {
+    if constexpr (use_lines) {
       if (line_offset + 3 >= line_length) {
         if (line_offset == line_length) {
           *out++ = '\n';
@@ -502,7 +502,7 @@ simdutf_constexpr23 size_t tail_encode_base64_impl(
     break;
   case 1:
     t1 = uint8_t(src[i]);
-    if simdutf_constexpr (use_lines) {
+    if constexpr (use_lines) {
       if (use_padding) {
         if (line_offset + 3 >= line_length) {
           if (line_offset == line_length) {
@@ -568,7 +568,7 @@ simdutf_constexpr23 size_t tail_encode_base64_impl(
   default: /* case 2 */
     t1 = uint8_t(src[i]);
     t2 = uint8_t(src[i + 1]);
-    if simdutf_constexpr (use_lines) {
+    if constexpr (use_lines) {
       if (use_padding) {
         if (line_offset + 3 >= line_length) {
           if (line_offset == line_length) {

--- a/include/simdutf/scalar/utf16.h
+++ b/include/simdutf/scalar/utf16.h
@@ -135,13 +135,13 @@ trim_partial_utf16(const char16_t *input, size_t length) {
 }
 
 template <endianness big_endian>
-simdutf_constexpr bool is_high_surrogate(char16_t c) {
+constexpr bool is_high_surrogate(char16_t c) {
   c = scalar::utf16::swap_if_needed<big_endian>(c);
   return (0xd800 <= c && c <= 0xdbff);
 }
 
 template <endianness big_endian>
-simdutf_constexpr bool is_low_surrogate(char16_t c) {
+constexpr bool is_low_surrogate(char16_t c) {
   c = scalar::utf16::swap_if_needed<big_endian>(c);
   return (0xdc00 <= c && c <= 0xdfff);
 }

--- a/include/simdutf/scalar/utf16.h
+++ b/include/simdutf/scalar/utf16.h
@@ -134,14 +134,12 @@ trim_partial_utf16(const char16_t *input, size_t length) {
   return length;
 }
 
-template <endianness big_endian>
-constexpr bool is_high_surrogate(char16_t c) {
+template <endianness big_endian> constexpr bool is_high_surrogate(char16_t c) {
   c = scalar::utf16::swap_if_needed<big_endian>(c);
   return (0xd800 <= c && c <= 0xdbff);
 }
 
-template <endianness big_endian>
-constexpr bool is_low_surrogate(char16_t c) {
+template <endianness big_endian> constexpr bool is_low_surrogate(char16_t c) {
   c = scalar::utf16::swap_if_needed<big_endian>(c);
   return (0xdc00 <= c && c <= 0xdfff);
 }

--- a/include/simdutf/scalar/utf16_to_latin1/utf16_to_latin1.h
+++ b/include/simdutf/scalar/utf16_to_latin1/utf16_to_latin1.h
@@ -63,16 +63,16 @@ simdutf_constexpr23 result convert_with_errors(InputPtr data, size_t len,
         ::memcpy(&v3, data + pos + 8, sizeof(uint64_t));
         ::memcpy(&v4, data + pos + 12, sizeof(uint64_t));
 
-        if simdutf_constexpr (!match_system(big_endian)) {
+        if constexpr (!match_system(big_endian)) {
           v1 = (v1 >> 8) | (v1 << (64 - 8));
         }
-        if simdutf_constexpr (!match_system(big_endian)) {
+        if constexpr (!match_system(big_endian)) {
           v2 = (v2 >> 8) | (v2 << (64 - 8));
         }
-        if simdutf_constexpr (!match_system(big_endian)) {
+        if constexpr (!match_system(big_endian)) {
           v3 = (v3 >> 8) | (v3 << (64 - 8));
         }
-        if simdutf_constexpr (!match_system(big_endian)) {
+        if constexpr (!match_system(big_endian)) {
           v4 = (v4 >> 8) | (v4 << (64 - 8));
         }
 

--- a/include/simdutf/scalar/utf16_to_utf8/utf16_to_utf8.h
+++ b/include/simdutf/scalar/utf16_to_utf8/utf16_to_utf8.h
@@ -25,7 +25,7 @@ simdutf_constexpr23 size_t convert(InputPtr data, size_t len,
                             // they are ascii
         uint64_t v;
         ::memcpy(&v, data + pos, sizeof(uint64_t));
-        if simdutf_constexpr (!match_system(big_endian)) {
+        if constexpr (!match_system(big_endian)) {
           v = (v >> 8) | (v << (64 - 8));
         }
         if ((v & 0xFF80FF80FF80FF80) == 0) {
@@ -115,7 +115,7 @@ simdutf_constexpr23 full_result convert_with_errors(InputPtr data, size_t len,
                             // they are ascii
         uint64_t v;
         ::memcpy(&v, data + pos, sizeof(uint64_t));
-        if simdutf_constexpr (!match_system(big_endian))
+        if constexpr (!match_system(big_endian))
           v = (v >> 8) | (v << (64 - 8));
         if ((v & 0xFF80FF80FF80FF80) == 0) {
           size_t final_pos = pos + 4;
@@ -222,7 +222,7 @@ simdutf_constexpr23 size_t convert_with_replacement(const char16_t *data,
                             // they are ascii
         uint64_t v;
         ::memcpy(&v, data + pos, sizeof(uint64_t));
-        if simdutf_constexpr (!match_system(big_endian)) {
+        if constexpr (!match_system(big_endian)) {
           v = (v >> 8) | (v << (64 - 8));
         }
         if ((v & 0xFF80FF80FF80FF80) == 0) {

--- a/include/simdutf/scalar/utf16_to_utf8/valid_utf16_to_utf8.h
+++ b/include/simdutf/scalar/utf16_to_utf8/valid_utf16_to_utf8.h
@@ -25,7 +25,7 @@ simdutf_constexpr23 size_t convert_valid(InputPtr data, size_t len,
                             // they are ascii
         uint64_t v;
         ::memcpy(&v, data + pos, sizeof(uint64_t));
-        if simdutf_constexpr (!match_system(big_endian)) {
+        if constexpr (!match_system(big_endian)) {
           v = (v >> 8) | (v << (64 - 8));
         }
         if ((v & 0xFF80FF80FF80FF80) == 0) {

--- a/include/simdutf/scalar/utf32_to_utf16/utf32_to_utf16.h
+++ b/include/simdutf/scalar/utf32_to_utf16/utf32_to_utf16.h
@@ -29,7 +29,7 @@ simdutf_constexpr23 size_t convert(const char32_t *data, size_t len,
       word -= 0x10000;
       uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
       uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         high_surrogate = u16_swap_bytes(high_surrogate);
         low_surrogate = u16_swap_bytes(low_surrogate);
       }
@@ -64,7 +64,7 @@ simdutf_constexpr23 result convert_with_errors(const char32_t *data, size_t len,
       word -= 0x10000;
       uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
       uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         high_surrogate = u16_swap_bytes(high_surrogate);
         low_surrogate = u16_swap_bytes(low_surrogate);
       }

--- a/include/simdutf/scalar/utf32_to_utf16/valid_utf32_to_utf16.h
+++ b/include/simdutf/scalar/utf32_to_utf16/valid_utf32_to_utf16.h
@@ -24,7 +24,7 @@ simdutf_constexpr23 size_t convert_valid(const char32_t *data, size_t len,
       word -= 0x10000;
       uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
       uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         high_surrogate = u16_swap_bytes(high_surrogate);
         low_surrogate = u16_swap_bytes(low_surrogate);
       }

--- a/include/simdutf/scalar/utf8_to_utf16/utf8_to_utf16.h
+++ b/include/simdutf/scalar/utf8_to_utf16/utf8_to_utf16.h
@@ -62,7 +62,7 @@ simdutf_constexpr23 size_t convert(InputPtr data, size_t len,
       if (code_point < 0x80 || 0x7ff < code_point) {
         return 0;
       }
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         code_point = uint32_t(u16_swap_bytes(uint16_t(code_point)));
       }
       *utf16_output++ = char16_t(code_point);
@@ -88,7 +88,7 @@ simdutf_constexpr23 size_t convert(InputPtr data, size_t len,
           (0xd7ff < code_point && code_point < 0xe000)) {
         return 0;
       }
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         code_point = uint32_t(u16_swap_bytes(uint16_t(code_point)));
       }
       *utf16_output++ = char16_t(code_point);
@@ -119,7 +119,7 @@ simdutf_constexpr23 size_t convert(InputPtr data, size_t len,
       code_point -= 0x10000;
       uint16_t high_surrogate = uint16_t(0xD800 + (code_point >> 10));
       uint16_t low_surrogate = uint16_t(0xDC00 + (code_point & 0x3FF));
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         high_surrogate = u16_swap_bytes(high_surrogate);
         low_surrogate = u16_swap_bytes(low_surrogate);
       }
@@ -189,7 +189,7 @@ simdutf_constexpr23 result convert_with_errors(InputPtr data, size_t len,
       if (code_point < 0x80 || 0x7ff < code_point) {
         return result(error_code::OVERLONG, pos);
       }
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         code_point = uint32_t(u16_swap_bytes(uint16_t(code_point)));
       }
       *utf16_output++ = char16_t(code_point);
@@ -217,7 +217,7 @@ simdutf_constexpr23 result convert_with_errors(InputPtr data, size_t len,
       if (0xd7ff < code_point && code_point < 0xe000) {
         return result(error_code::SURROGATE, pos);
       }
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         code_point = uint32_t(u16_swap_bytes(uint16_t(code_point)));
       }
       *utf16_output++ = char16_t(code_point);
@@ -251,7 +251,7 @@ simdutf_constexpr23 result convert_with_errors(InputPtr data, size_t len,
       code_point -= 0x10000;
       uint16_t high_surrogate = uint16_t(0xD800 + (code_point >> 10));
       uint16_t low_surrogate = uint16_t(0xDC00 + (code_point & 0x3FF));
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         high_surrogate = u16_swap_bytes(high_surrogate);
         low_surrogate = u16_swap_bytes(low_surrogate);
       }

--- a/include/simdutf/scalar/utf8_to_utf16/valid_utf8_to_utf16.h
+++ b/include/simdutf/scalar/utf8_to_utf16/valid_utf8_to_utf16.h
@@ -51,7 +51,7 @@ simdutf_constexpr23 size_t convert_valid(InputPtr data, size_t len,
       } // minimal bound checking
       uint16_t code_point = uint16_t(((leading_byte & 0b00011111) << 6) |
                                      (uint8_t(data[pos + 1]) & 0b00111111));
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         code_point = u16_swap_bytes(uint16_t(code_point));
       }
       *utf16_output++ = char16_t(code_point);
@@ -66,7 +66,7 @@ simdutf_constexpr23 size_t convert_valid(InputPtr data, size_t len,
           uint16_t(((leading_byte & 0b00001111) << 12) |
                    ((uint8_t(data[pos + 1]) & 0b00111111) << 6) |
                    (uint8_t(data[pos + 2]) & 0b00111111));
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         code_point = u16_swap_bytes(uint16_t(code_point));
       }
       *utf16_output++ = char16_t(code_point);
@@ -83,7 +83,7 @@ simdutf_constexpr23 size_t convert_valid(InputPtr data, size_t len,
       code_point -= 0x10000;
       uint16_t high_surrogate = uint16_t(0xD800 + (code_point >> 10));
       uint16_t low_surrogate = uint16_t(0xDC00 + (code_point & 0x3FF));
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         high_surrogate = u16_swap_bytes(high_surrogate);
         low_surrogate = u16_swap_bytes(low_surrogate);
       }

--- a/scripts/check_typos.sh
+++ b/scripts/check_typos.sh
@@ -8,6 +8,6 @@ set -eu
 # this exits with nonzero status if it finds something, which terminates the script
 codespell \
     --skip="./benchmarks/competition,./build,./fuzz/work"  \
-    -L vie,persan,fo,ans,larg,indx,shft,carryin
+    -L vie,persan,fo,ans,larg,indx,shft,carryin,statics
 
 echo "no typos detected!"

--- a/scripts/compile_many_variations.sh
+++ b/scripts/compile_many_variations.sh
@@ -24,7 +24,7 @@ echo ".PHONY: testall">>$makefile
 echo "testall:">>$makefile
 
 compilers="g++-12 g++-13 g++-14 clang++-19"
-standards="11 14 17 20 23"
+standards="17 20 23"
 buildtypes="Release Debug"
 
 for compiler in $compilers; do

--- a/singleheader/README.md
+++ b/singleheader/README.md
@@ -9,10 +9,19 @@ c++ -o amalgamation_demo amalgamation_demo.cpp -std=c++17 && ./amalgamation_demo
 
 ### C Demo
 
+You can compile both the simdutf library and the C program using a C++ compiler.
+
+```
+c++ -c simdutf.cpp -std=c++17
+cc -c amalgamation_demo.c
+c++  amalgamation_demo.o simdutf.o -o cdemo
+ ./cdemo
+```
+
 You may also build a C executable without a dependency on the C++ standard library.
 
 ```
-c++ -c simdutf.cpp  -nostdlib++ -fno-rtti -fno-exceptions
+c++ -c simdutf.cpp  -nostdlib++ -fno-rtti -fno-exceptions -DSIMDUTF_NO_LIBCXX=1 -std=c++17
 cc amalgamation_demo.c simdutf.o -o cdemo
 ./cdemo
 ```

--- a/singleheader/README.md
+++ b/singleheader/README.md
@@ -9,11 +9,10 @@ c++ -o amalgamation_demo amalgamation_demo.cpp -std=c++17 && ./amalgamation_demo
 
 ### C Demo
 
-You may also build a C executable.
+You may also build a C executable without a dependency on the C++ standard library.
 
 ```
-c++ -c simdutf.cpp 
-cc -c ./amalgamation_demo.c
-c++ amalgamation_demo.o simdutf.o -o cdemo
+c++ -c simdutf.cpp  -nostdlib++ -fno-rtti -fno-exceptions
+cc amalgamation_demo.c simdutf.o -o cdemo
 ./cdemo
 ```

--- a/singleheader/amalgamation_demo.cpp
+++ b/singleheader/amalgamation_demo.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <string>
 
 #include "simdutf.cpp"
 #include "simdutf.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,11 +94,19 @@ if(SIMDUTF_ALWAYS_INCLUDE_FALLBACK)
 endif()
 
 include(CheckCXXCompilerFlag)
-include(CheckCXXLinkerFlag)
+include(CheckCXXSourceCompiles)
 
 check_cxx_compiler_flag("-fno-exceptions" HAVE_CXX_FLAG_NO_EXCEPTIONS)
 check_cxx_compiler_flag("-fno-rtti" HAVE_CXX_FLAG_NO_RTTI)
-check_cxx_linker_flag("-nostdlib++" HAVE_CXX_LINKER_FLAG_NO_STDLIBXX)
+
+# CheckCXXLinkerFlag is only available in CMake 3.18+, so we probe the linker
+# flag directly via CheckCXXSourceCompiles + CMAKE_REQUIRED_LINK_OPTIONS.
+set(_simdutf_prev_link_options "${CMAKE_REQUIRED_LINK_OPTIONS}")
+set(CMAKE_REQUIRED_LINK_OPTIONS "-nostdlib++")
+check_cxx_source_compiles("int main() { return 0; }"
+  HAVE_CXX_LINKER_FLAG_NO_STDLIBXX)
+set(CMAKE_REQUIRED_LINK_OPTIONS "${_simdutf_prev_link_options}")
+unset(_simdutf_prev_link_options)
 
 ##
 ## simdutf-nostdlibcxx: a variant of the library that does not require the C++

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,13 +93,20 @@ if(SIMDUTF_ALWAYS_INCLUDE_FALLBACK)
   target_compile_definitions(simdutf PRIVATE SIMDUTF_IMPLEMENTATION_FALLBACK=1)
 endif()
 
+include(CheckCXXCompilerFlag)
+include(CheckCXXLinkerFlag)
+
+check_cxx_compiler_flag("-fno-exceptions" HAVE_CXX_FLAG_NO_EXCEPTIONS)
+check_cxx_compiler_flag("-fno-rtti" HAVE_CXX_FLAG_NO_RTTI)
+check_cxx_linker_flag("-nostdlib++" HAVE_CXX_LINKER_FLAG_NO_STDLIBXX)
+
 ##
 ## simdutf-nostdlibcxx: a variant of the library that does not require the C++
 ## standard library runtime (libc++ / libc++abi / libstdc++). It is intended to
 ## be consumed through the C interface (simdutf_c.h) and only supports GCC and
 ## Clang.
 ##
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+if(HAVE_CXX_FLAG_NO_EXCEPTIONS AND HAVE_CXX_FLAG_NO_RTTI AND HAVE_CXX_LINKER_FLAG_NO_STDLIBXX)
   add_library(simdutf-nostdlibcxx STATIC simdutf.cpp)
   target_include_directories(simdutf-nostdlibcxx PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,9 @@ endif()
 if(SIMDUTF_LOGGING)
   target_compile_definitions(simdutf PUBLIC SIMDUTF_LOGGING=1)
 endif()
+if(SIMDUTF_USE_STATIC_INITIALIZATION)
+  target_compile_definitions(simdutf PUBLIC SIMDUTF_USE_STATIC_INITIALIZATION=1)
+endif()
 if(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
   target_compile_definitions(simdutf PUBLIC FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1)
 endif()
@@ -94,19 +97,11 @@ if(SIMDUTF_ALWAYS_INCLUDE_FALLBACK)
 endif()
 
 include(CheckCXXCompilerFlag)
-include(CheckCXXSourceCompiles)
+include(CheckLinkerFlag)
 
 check_cxx_compiler_flag("-fno-exceptions" HAVE_CXX_FLAG_NO_EXCEPTIONS)
 check_cxx_compiler_flag("-fno-rtti" HAVE_CXX_FLAG_NO_RTTI)
-
-# CheckCXXLinkerFlag is only available in CMake 3.18+, so we probe the linker
-# flag directly via CheckCXXSourceCompiles + CMAKE_REQUIRED_LINK_OPTIONS.
-set(_simdutf_prev_link_options "${CMAKE_REQUIRED_LINK_OPTIONS}")
-set(CMAKE_REQUIRED_LINK_OPTIONS "-nostdlib++")
-check_cxx_source_compiles("int main() { return 0; }"
-  HAVE_CXX_LINKER_FLAG_NO_STDLIBXX)
-set(CMAKE_REQUIRED_LINK_OPTIONS "${_simdutf_prev_link_options}")
-unset(_simdutf_prev_link_options)
+check_linker_flag(CXX "-nostdlib++" HAVE_CXX_LINKER_FLAG_NO_STDLIBXX)
 
 ##
 ## simdutf-nostdlibcxx: a variant of the library that does not require the C++

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,7 +113,6 @@ unset(_simdutf_prev_link_options)
 ## standard library runtime (libc++ / libc++abi / libstdc++). It is intended to
 ## be consumed through the C interface (simdutf_c.h) and only supports GCC and
 ## Clang.
-##
 if(HAVE_CXX_FLAG_NO_EXCEPTIONS AND HAVE_CXX_FLAG_NO_RTTI AND HAVE_CXX_LINKER_FLAG_NO_STDLIBXX)
   add_library(simdutf-nostdlibcxx STATIC simdutf.cpp)
   target_include_directories(simdutf-nostdlibcxx PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,17 +105,10 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
   target_include_directories(simdutf-nostdlibcxx PUBLIC
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+  target_compile_definitions(simdutf-nostdlibcxx PRIVATE SIMDUTF_NO_LIBCXX=1)
   target_compile_options(simdutf-nostdlibcxx PRIVATE
     -fno-exceptions -fno-rtti)
   set_target_properties(simdutf-nostdlibcxx PROPERTIES POSITION_INDEPENDENT_CODE ON)
-
-  # Smoke test: compile a pure-C program against the C API and link it without
-  # the C++ standard library, proving libsimdutf-nostdlibcxx.a is self-contained.
-  add_executable(nostdlibcxx_c_api_test
-    ${CMAKE_SOURCE_DIR}/tests/nostdlibcxx_c_api_test.c)
-  target_link_libraries(nostdlibcxx_c_api_test PRIVATE simdutf-nostdlibcxx)
-  target_link_options(nostdlibcxx_c_api_test PRIVATE -nostdlib++)
-  add_test(NAME nostdlibcxx_c_api_test COMMAND nostdlibcxx_c_api_test)
 endif()
 
 if(SIMDUTF_SANITIZE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,6 +93,31 @@ if(SIMDUTF_ALWAYS_INCLUDE_FALLBACK)
   target_compile_definitions(simdutf PRIVATE SIMDUTF_IMPLEMENTATION_FALLBACK=1)
 endif()
 
+##
+## simdutf-nostdlibcxx: a variant of the library that does not require the C++
+## standard library runtime (libc++ / libc++abi / libstdc++). It is intended to
+## be consumed through the C interface (simdutf_c.h) and only supports GCC and
+## Clang.
+##
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  add_library(simdutf-nostdlibcxx STATIC simdutf.cpp)
+  target_include_directories(simdutf-nostdlibcxx PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+  target_include_directories(simdutf-nostdlibcxx PUBLIC
+    "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+  target_compile_options(simdutf-nostdlibcxx PRIVATE
+    -fno-exceptions -fno-rtti)
+  set_target_properties(simdutf-nostdlibcxx PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+  # Smoke test: compile a pure-C program against the C API and link it without
+  # the C++ standard library, proving libsimdutf-nostdlibcxx.a is self-contained.
+  add_executable(nostdlibcxx_c_api_test
+    ${CMAKE_SOURCE_DIR}/tests/nostdlibcxx_c_api_test.c)
+  target_link_libraries(nostdlibcxx_c_api_test PRIVATE simdutf-nostdlibcxx)
+  target_link_options(nostdlibcxx_c_api_test PRIVATE -nostdlib++)
+  add_test(NAME nostdlibcxx_c_api_test COMMAND nostdlibcxx_c_api_test)
+endif()
+
 if(SIMDUTF_SANITIZE)
   target_compile_options(simdutf PUBLIC -fsanitize=address  -fno-omit-frame-pointer -fno-sanitize-recover=all)
   target_compile_definitions(simdutf PUBLIC ASAN_OPTIONS=detect_leaks=1)

--- a/src/arm64/arm_convert_latin1_to_utf16.cpp
+++ b/src/arm64/arm_convert_latin1_to_utf16.cpp
@@ -7,12 +7,12 @@ arm_convert_latin1_to_utf16(const char *buf, size_t len,
   while (end - buf >= 16) {
     uint8x16_t in8 = vld1q_u8(reinterpret_cast<const uint8_t *>(buf));
     uint16x8_t inlow = vmovl_u8(vget_low_u8(in8));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       inlow = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(inlow)));
     }
     vst1q_u16(reinterpret_cast<uint16_t *>(utf16_output), inlow);
     uint16x8_t inhigh = vmovl_u8(vget_high_u8(in8));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       inhigh = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(inhigh)));
     }
     vst1q_u16(reinterpret_cast<uint16_t *>(utf16_output + 8), inhigh);

--- a/src/arm64/arm_convert_utf16_to_latin1.cpp
+++ b/src/arm64/arm_convert_utf16_to_latin1.cpp
@@ -6,7 +6,7 @@ arm_convert_utf16_to_latin1(const char16_t *buf, size_t len,
   const char16_t *end = buf + len;
   while (end - buf >= 8) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(in)));
     }
     if (vmaxvq_u16(in) <= 0xff) {
@@ -32,7 +32,7 @@ arm_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
   const char16_t *end = buf + len;
   while (end - buf >= 8) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(in)));
     }
     if (vmaxvq_u16(in) <= 0xff) {

--- a/src/arm64/arm_convert_utf16_to_utf32.cpp
+++ b/src/arm64/arm_convert_utf16_to_utf32.cpp
@@ -62,7 +62,7 @@ arm_convert_utf16_to_utf32(const char16_t *buf, size_t len,
 
   while (end - buf >= 8) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(in)));
     }
 
@@ -132,7 +132,7 @@ arm_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
 
   while ((end - buf) >= 8) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(in)));
     }
 

--- a/src/arm64/arm_convert_utf16_to_utf8.cpp
+++ b/src/arm64/arm_convert_utf16_to_utf8.cpp
@@ -64,7 +64,7 @@ arm_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
           // https://github.com/simdutf/simdutf/issues/92
   while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(in)));
     }
     if (vmaxvq_u16(in) <= 0x7F) { // ASCII fast path!!!!
@@ -72,7 +72,7 @@ arm_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
       // characters.
       uint16x8_t nextin =
           vld1q_u16(reinterpret_cast<const uint16_t *>(buf) + 8);
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         nextin = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(nextin)));
       }
       if (vmaxvq_u16(nextin) > 0x7F) {
@@ -333,7 +333,7 @@ arm_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
 
   while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
     uint16x8_t in = vld1q_u16(reinterpret_cast<const uint16_t *>(buf));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(in)));
     }
     if (vmaxvq_u16(in) <= 0x7F) { // ASCII fast path!!!!
@@ -341,7 +341,7 @@ arm_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
       // characters.
       uint16x8_t nextin =
           vld1q_u16(reinterpret_cast<const uint16_t *>(buf) + 8);
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         nextin = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(nextin)));
       }
       if (vmaxvq_u16(nextin) > 0x7F) {
@@ -605,7 +605,7 @@ arm64_utf8_length_from_utf16_bytemask(const char16_t *in, size_t size) {
     auto base_input = vld2q_u8(reinterpret_cast<const uint8_t *>(in + pos));
     //
     size_t idx = 1; // we use the second lane of the deinterleaved load
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       idx = 0;
     }
     size_t idx_lsb = idx ^ 1;
@@ -686,7 +686,7 @@ arm64_utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
   for (; size - pos >= N + 1; pos += N) {
     auto base_input = vld2q_u8(reinterpret_cast<const uint8_t *>(in + pos));
     size_t idx = 1; // we use the second lane of the deinterleaved load
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       idx = 0;
     }
     size_t idx_lsb = idx ^ 1;

--- a/src/arm64/arm_convert_utf32_to_utf16.cpp
+++ b/src/arm64/arm_convert_utf32_to_utf16.cpp
@@ -89,7 +89,7 @@ arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
           vorrq_u16(vceqq_u16(vandq_u16(utf16_packed, v_f800), v_d800),
                     forbidden_bytemask);
 
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         utf16_packed = vreinterpretq_u16_u8(
             vrev16q_u8(vreinterpretq_u8_u16(utf16_packed)));
       }
@@ -147,7 +147,7 @@ arm_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
                               reinterpret_cast<char16_t *>(utf16_output));
       }
 
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         utf16_packed = vreinterpretq_u16_u8(
             vrev16q_u8(vreinterpretq_u8_u16(utf16_packed)));
       }
@@ -171,7 +171,7 @@ arm_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
             word -= 0x10000;
             uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
             uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-            if simdutf_constexpr (!match_system(big_endian)) {
+            if constexpr (!match_system(big_endian)) {
               high_surrogate =
                   uint16_t(high_surrogate >> 8 | high_surrogate << 8);
               low_surrogate = uint16_t(low_surrogate << 8 | low_surrogate >> 8);

--- a/src/arm64/arm_convert_utf8_to_utf16.cpp
+++ b/src/arm64/arm_convert_utf8_to_utf16.cpp
@@ -37,7 +37,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // UTF-16 code units.
     uint16x4_t composed = convert_utf8_3_byte_to_utf16(in);
     // Byte swap if necessary
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       composed = vreinterpret_u16_u8(vrev16_u8(vreinterpret_u8_u16(composed)));
     }
     vst1_u16(reinterpret_cast<uint16_t *>(utf16_output), composed);
@@ -51,7 +51,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // UTF-16 code units.
     uint16x8_t composed = convert_utf8_2_byte_to_utf16(in);
     // Byte swap if necessary
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       composed =
           vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(composed)));
     }
@@ -74,7 +74,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // Convert to UTF-16
     uint16x8_t composed = convert_utf8_1_to_2_byte_to_utf16(in, idx);
     // Byte swap if necessary
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       composed =
           vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(composed)));
     }
@@ -121,7 +121,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // 3 byte: aaaabbbb bbcccccc
     uint16x4_t composed = vsli_n_u16(middlelow, highperm, 12);
     // Byte swap if necessary
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       composed = vreinterpret_u16_u8(vrev16_u8(vreinterpret_u8_u16(composed)));
     }
     vst1_u16(reinterpret_cast<uint16_t *>(utf16_output), composed);
@@ -176,7 +176,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
       // 110111CC CCDDDDDD|110110AA BBBBBBCC
       uint16x8_t composed = vaddq_u16(blend, magic_with_low_2);
       // Byte swap if necessary
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         composed =
             vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(composed)));
       }
@@ -281,7 +281,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // 4 byte: 110110AA BBBBBBCC|110111CC CCDDDDDD
     uint32x4_t selected = vbslq_u32(is_pair, surrogates, composed);
     // Byte swap if necessary
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       selected =
           vreinterpretq_u32_u8(vrev16q_u8(vreinterpretq_u8_u32(selected)));
     }

--- a/src/arm64/arm_utf16fix.cpp
+++ b/src/arm64/arm_utf16fix.cpp
@@ -54,7 +54,7 @@ void utf16fix_block(char16_t *out, const char16_t *in) {
     out[-1] = ill ? replacement : lbc;
 
     /* fix illegal sequencing in the main block */
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       block.val[1] = vbslq_u8(block_illseq, vdupq_n_u8(0xfd), block.val[1]);
       block.val[0] = vorrq_u8(block_illseq, block.val[0]);
     } else {

--- a/src/arm64/arm_validate_utf16.cpp
+++ b/src/arm64/arm_validate_utf16.cpp
@@ -12,7 +12,7 @@ const char16_t *arm_validate_utf16(const char16_t *input, size_t size) {
     auto in0 = simd16<uint16_t>(input);
     auto in1 =
         simd16<uint16_t>(input + simd16<uint16_t>::SIZE / sizeof(char16_t));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in0 = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(in0)));
       in1 = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(in1)));
     }
@@ -76,7 +76,7 @@ const char16_t *arm_validate_utf16_as_ascii(const char16_t *input,
     uint16x8_t in1 = vld1q_u16(reinterpret_cast<const uint16_t *>(input));
     uint16x8_t in2 = vld1q_u16(reinterpret_cast<const uint16_t *>(input + 8));
     uint16x8_t inor = vorrq_u16(in1, in2);
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       inor = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(inor)));
     }
     // next we compute inor > 0x7f
@@ -108,7 +108,7 @@ const result arm_validate_utf16_with_errors(const char16_t *input,
     auto in1 =
         simd16<uint16_t>(input + simd16<uint16_t>::SIZE / sizeof(char16_t));
 
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in0 = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(in0)));
       in1 = vreinterpretq_u16_u8(vrev16q_u8(vreinterpretq_u8_u16(in1)));
     }

--- a/src/encoding_types.cpp
+++ b/src/encoding_types.cpp
@@ -1,6 +1,6 @@
 
 namespace simdutf {
-const char *to_string(encoding_type bom) {
+std::string_view to_string(encoding_type bom) {
   switch (bom) {
   case UTF16_LE:
     return "UTF16 little-endian";

--- a/src/encoding_types.cpp
+++ b/src/encoding_types.cpp
@@ -1,6 +1,6 @@
 
 namespace simdutf {
-std::string to_string(encoding_type bom) {
+const char *to_string(encoding_type bom) {
   switch (bom) {
   case UTF16_LE:
     return "UTF16 little-endian";

--- a/src/generic/buf_block_reader.h
+++ b/src/generic/buf_block_reader.h
@@ -30,40 +30,6 @@ private:
   size_t idx;
 };
 
-// Routines to print masks and text for debugging bitmask operations
-simdutf_unused static char *format_input_text_64(const uint8_t *text) {
-  static char *buf =
-      reinterpret_cast<char *>(malloc(sizeof(simd8x64<uint8_t>) + 1));
-  for (size_t i = 0; i < sizeof(simd8x64<uint8_t>); i++) {
-    buf[i] = int8_t(text[i]) < ' ' ? '_' : int8_t(text[i]);
-  }
-  buf[sizeof(simd8x64<uint8_t>)] = '\0';
-  return buf;
-}
-
-// Routines to print masks and text for debugging bitmask operations
-simdutf_unused static char *format_input_text(const simd8x64<uint8_t> &in) {
-  static char *buf =
-      reinterpret_cast<char *>(malloc(sizeof(simd8x64<uint8_t>) + 1));
-  in.store(reinterpret_cast<uint8_t *>(buf));
-  for (size_t i = 0; i < sizeof(simd8x64<uint8_t>); i++) {
-    if (buf[i] < ' ') {
-      buf[i] = '_';
-    }
-  }
-  buf[sizeof(simd8x64<uint8_t>)] = '\0';
-  return buf;
-}
-
-simdutf_unused static char *format_mask(uint64_t mask) {
-  static char *buf = reinterpret_cast<char *>(malloc(64 + 1));
-  for (size_t i = 0; i < 64; i++) {
-    buf[i] = (mask & (size_t(1) << i)) ? 'X' : ' ';
-  }
-  buf[64] = '\0';
-  return buf;
-}
-
 template <size_t STEP_SIZE>
 simdutf_really_inline
 buf_block_reader<STEP_SIZE>::buf_block_reader(const uint8_t *_buf, size_t _len)

--- a/src/generic/utf16.h
+++ b/src/generic/utf16.h
@@ -10,7 +10,7 @@ simdutf_really_inline size_t count_code_points(const char16_t *in,
   size_t count = 0;
   for (; pos < size / 32 * 32; pos += 32) {
     simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       input.swap_bytes();
     }
     uint64_t not_pair = input.not_in_range(0xDC00, 0xDFFF);
@@ -28,7 +28,7 @@ simdutf_really_inline size_t utf8_length_from_utf16(const char16_t *in,
   // This algorithm could no doubt be improved!
   for (; pos < size / 32 * 32; pos += 32) {
     simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       input.swap_bytes();
     }
     uint64_t ascii_mask = input.lteq(0x7F);

--- a/src/generic/utf16/count_code_points_bytemask.h
+++ b/src/generic/utf16/count_code_points_bytemask.h
@@ -23,7 +23,7 @@ simdutf_really_inline size_t count_code_points(const char16_t *in,
   auto counters = zero;
   for (; pos < size / N * N; pos += N) {
     auto input = vector_u16::load(in + pos);
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       input = input.swap_bytes();
     }
 

--- a/src/generic/utf16/to_well_formed.h
+++ b/src/generic/utf16/to_well_formed.h
@@ -18,7 +18,7 @@ simdutf_really_inline void utf16fix_block(char16_t *out, const char16_t *in) {
   const char16_t replacement = scalar::utf16::replacement<big_endian>();
 
   using vector_u16 = simd16<uint16_t>;
-  auto swap_if_needed = [](uint16_t x) simdutf_constexpr -> uint16_t {
+  auto swap_if_needed = [](uint16_t x) constexpr -> uint16_t {
     return scalar::utf16::swap_if_needed<big_endian>(x);
   };
 

--- a/src/generic/utf16/utf8_length_from_utf16.h
+++ b/src/generic/utf16/utf8_length_from_utf16.h
@@ -11,7 +11,7 @@ simdutf_really_inline size_t utf8_length_from_utf16(const char16_t *in,
   // This algorithm could no doubt be improved!
   for (; pos < size / 32 * 32; pos += 32) {
     simd16x32<uint16_t> input(reinterpret_cast<const uint16_t *>(in + pos));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       input.swap_bytes();
     }
     uint64_t ascii_mask = input.lteq(0x7F);

--- a/src/generic/utf16/utf8_length_from_utf16_bytemask.h
+++ b/src/generic/utf16/utf8_length_from_utf16_bytemask.h
@@ -27,7 +27,7 @@ simdutf_really_inline size_t utf8_length_from_utf16_bytemask(const char16_t *in,
 
   for (; pos < size / N * N; pos += N) {
     auto input = vector_u16::load(reinterpret_cast<const uint16_t *>(in + pos));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       input = input.swap_bytes();
     }
     // 0xd800 .. 0xdbff - low surrogate
@@ -116,7 +116,7 @@ utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
 
   for (; pos < (size - 1) / N * N; pos += N) {
     auto input = vector_u16::load(reinterpret_cast<const uint16_t *>(in + pos));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       input = input.swap_bytes();
     }
     // 0xd800 .. 0xdbff - low surrogate
@@ -137,7 +137,7 @@ utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
       any_surrogates = true;
       auto input_next =
           vector_u16::load(reinterpret_cast<const uint16_t *>(in + pos + 1));
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         input_next = input_next.swap_bytes();
       }
 

--- a/src/generic/utf8_to_utf16/utf8_to_utf16.h
+++ b/src/generic/utf8_to_utf16/utf8_to_utf16.h
@@ -158,10 +158,10 @@ struct validating_transcoder {
                 (simd8x64<uint8_t>::NUM_CHUNKS == 4),
             "We support either two or four chunks per 64-byte block.");
         auto zero = simd8<uint8_t>{uint8_t(0)};
-        if simdutf_constexpr (simd8x64<uint8_t>::NUM_CHUNKS == 2) {
+        if constexpr (simd8x64<uint8_t>::NUM_CHUNKS == 2) {
           this->check_utf8_bytes(input.chunks[0], zero);
           this->check_utf8_bytes(input.chunks[1], input.chunks[0]);
-        } else if simdutf_constexpr (simd8x64<uint8_t>::NUM_CHUNKS == 4) {
+        } else if constexpr (simd8x64<uint8_t>::NUM_CHUNKS == 4) {
           this->check_utf8_bytes(input.chunks[0], zero);
           this->check_utf8_bytes(input.chunks[1], input.chunks[0]);
           this->check_utf8_bytes(input.chunks[2], input.chunks[1]);
@@ -246,10 +246,10 @@ struct validating_transcoder {
                 (simd8x64<uint8_t>::NUM_CHUNKS == 4),
             "We support either two or four chunks per 64-byte block.");
         auto zero = simd8<uint8_t>{uint8_t(0)};
-        if simdutf_constexpr (simd8x64<uint8_t>::NUM_CHUNKS == 2) {
+        if constexpr (simd8x64<uint8_t>::NUM_CHUNKS == 2) {
           this->check_utf8_bytes(input.chunks[0], zero);
           this->check_utf8_bytes(input.chunks[1], input.chunks[0]);
-        } else if simdutf_constexpr (simd8x64<uint8_t>::NUM_CHUNKS == 4) {
+        } else if constexpr (simd8x64<uint8_t>::NUM_CHUNKS == 4) {
           this->check_utf8_bytes(input.chunks[0], zero);
           this->check_utf8_bytes(input.chunks[1], input.chunks[0]);
           this->check_utf8_bytes(input.chunks[2], input.chunks[1]);

--- a/src/generic/validate_utf16.h
+++ b/src/generic/validate_utf16.h
@@ -135,7 +135,7 @@ const result validate_utf16_as_ascii_with_errors(const char16_t *input,
   for (; pos < size / 32 * 32; pos += 32) {
     simd16x32<uint16_t> input_vec(
         reinterpret_cast<const uint16_t *>(input + pos));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       input_vec.swap_bytes();
     }
     uint64_t matches = input_vec.lteq(uint16_t(0x7f));

--- a/src/generic/validate_utf32.h
+++ b/src/generic/validate_utf32.h
@@ -24,7 +24,7 @@ simdutf_really_inline bool validate(const char32_t *input, size_t size) {
 
   while (input + N < end) {
     auto in = vector_u32(input);
-    if simdutf_constexpr (!match_system(endianness::BIG)) {
+    if constexpr (!match_system(endianness::BIG)) {
       in.swap_bytes();
     }
 
@@ -67,7 +67,7 @@ simdutf_really_inline result validate_with_errors(const char32_t *input,
 
   while (input + N < end) {
     auto in = vector_u32(input);
-    if simdutf_constexpr (!match_system(endianness::BIG)) {
+    if constexpr (!match_system(endianness::BIG)) {
       in.swap_bytes();
     }
 

--- a/src/haswell/avx2_convert_utf16_to_latin1.cpp
+++ b/src/haswell/avx2_convert_utf16_to_latin1.cpp
@@ -9,7 +9,7 @@ avx2_convert_utf16_to_latin1(const char16_t *buf, size_t len,
     __m256i in1 =
         _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf + 16));
 
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       const __m256i swap = _mm256_setr_epi8(
           1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14, 17, 16, 19, 18,
           21, 20, 23, 22, 25, 24, 27, 26, 29, 28, 31, 30);
@@ -44,7 +44,7 @@ avx2_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
   while (end - buf >= 16) {
     __m256i in = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf));
 
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       const __m256i swap = _mm256_setr_epi8(
           1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14, 17, 16, 19, 18,
           21, 20, 23, 22, 25, 24, 27, 26, 29, 28, 31, 30);

--- a/src/haswell/avx2_utf16fix.cpp
+++ b/src/haswell/avx2_utf16fix.cpp
@@ -8,7 +8,7 @@
  */
 template <endianness big_endian, bool in_place>
 void utf16fix_block(char16_t *out, const char16_t *in) {
-  auto swap_if_needed = [](uint16_t x) simdutf_constexpr -> uint16_t {
+  auto swap_if_needed = [](uint16_t x) constexpr -> uint16_t {
     return scalar::utf16::swap_if_needed<big_endian>(x);
   };
   const char16_t replacement = scalar::utf16::replacement<big_endian>();
@@ -70,7 +70,7 @@ void utf16fix_block(char16_t *out, const char16_t *in) {
 
 template <endianness big_endian, bool in_place>
 void utf16fix_block_sse(char16_t *out, const char16_t *in) {
-  auto swap_if_needed = [](uint16_t x) simdutf_constexpr -> uint16_t {
+  auto swap_if_needed = [](uint16_t x) constexpr -> uint16_t {
     return scalar::utf16::swap_if_needed<big_endian>(x);
   };
   const char16_t replacement = scalar::utf16::replacement<big_endian>();

--- a/src/icelake/icelake_utf16fix.cpp
+++ b/src/icelake/icelake_utf16fix.cpp
@@ -13,7 +13,7 @@ simdutf_really_inline void utf16fix_block(char16_t *out, const char16_t *in) {
   const char16_t replacement = scalar::utf16::replacement<big_endian>();
   __m512i lookback, block, lb_masked, block_masked;
   __mmask32 lb_is_high, block_is_low, illseq;
-  auto swap_if_needed = [](uint16_t x) simdutf_constexpr -> uint16_t {
+  auto swap_if_needed = [](uint16_t x) constexpr -> uint16_t {
     return scalar::utf16::swap_if_needed<big_endian>(x);
   };
 
@@ -66,7 +66,7 @@ void utf16fix_short(const char16_t *in, size_t n, char16_t *out) {
   __m512i lookback, block, lb_masked, block_masked;
   __mmask32 lb_is_high, block_is_low, illseq;
   uint32_t mask = 0xFFFFFFFF >> (32 - n);
-  auto swap_if_needed = [](uint16_t x) simdutf_constexpr -> uint16_t {
+  auto swap_if_needed = [](uint16_t x) constexpr -> uint16_t {
     return scalar::utf16::swap_if_needed<big_endian>(x);
   };
   lookback = _mm512_maskz_loadu_epi16(_cvtmask32_u32(mask << 1),

--- a/src/icelake/icelake_utf8_length_from_utf16.inl.cpp
+++ b/src/icelake/icelake_utf8_length_from_utf16.inl.cpp
@@ -26,7 +26,7 @@ simdutf_really_inline size_t icelake_utf8_length_from_utf16(const char16_t *in,
     __m512i input2 =
         _mm512_loadu_si512(reinterpret_cast<const __m512i *>(in + pos + N));
 
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       input1 = _mm512_shuffle_epi8(input1, byteflip);
       input2 = _mm512_shuffle_epi8(input2, byteflip);
     }
@@ -59,7 +59,7 @@ simdutf_really_inline size_t icelake_utf8_length_from_utf16(const char16_t *in,
   if (pos + N <= size) {
     __m512i input =
         _mm512_loadu_si512(reinterpret_cast<const __m512i *>(in + pos));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       input = _mm512_shuffle_epi8(input, byteflip);
     }
     // 0xd800 .. 0xdbff - low surrogate
@@ -86,7 +86,7 @@ simdutf_really_inline size_t icelake_utf8_length_from_utf16(const char16_t *in,
       0xFFFFFFFFULL >>
       (32 - (size - pos)); // mask for the remaining char16 values
   __m512i input = _mm512_maskz_loadu_epi16(remaining_mask, in + pos);
-  if simdutf_constexpr (!match_system(big_endian)) {
+  if constexpr (!match_system(big_endian)) {
     input = _mm512_shuffle_epi8(input, byteflip);
   }
   // 0xd800 .. 0xdbff - low surrogate
@@ -147,12 +147,12 @@ simdutf_really_inline result icelake_utf8_length_from_utf16_with_replacement(
   for (; pos < (size - 1) / (2 * N) * (2 * N); pos += 2 * N) {
     __m512i current1 =
         _mm512_loadu_si512(reinterpret_cast<const __m512i *>(in + pos));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       current1 = _mm512_shuffle_epi8(current1, byteflip);
     }
     __m512i current2 =
         _mm512_loadu_si512(reinterpret_cast<const __m512i *>(in + pos + N));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       current2 = _mm512_shuffle_epi8(current2, byteflip);
     }
 
@@ -202,7 +202,7 @@ simdutf_really_inline result icelake_utf8_length_from_utf16_with_replacement(
   if (pos + N + 1 <= size) {
     __m512i input =
         _mm512_loadu_si512(reinterpret_cast<const __m512i *>(in + pos));
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       input = _mm512_shuffle_epi8(input, byteflip);
     }
 
@@ -236,7 +236,7 @@ simdutf_really_inline result icelake_utf8_length_from_utf16_with_replacement(
   __mmask32 remaining_mask(uint32_t(0xFFFFFFFFULL << overshoot));
   __m512i input =
       _mm512_maskz_loadu_epi16(remaining_mask, in + pos - overshoot);
-  if simdutf_constexpr (!match_system(big_endian)) {
+  if constexpr (!match_system(big_endian)) {
     input = _mm512_shuffle_epi8(input, byteflip);
   }
 

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -16,6 +16,12 @@
 extern "C" __attribute__((weak, noreturn)) void __cxa_pure_virtual() {
   __builtin_trap();
 }
+namespace std {
+    [[noreturn]] __attribute__((weak))
+    void __glibcxx_assert_fail(const char*, int, const char*, const char*) {
+        __builtin_trap();
+    }
+}
 #endif
 
 static_assert(sizeof(uint8_t) == sizeof(char),

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -26,6 +26,8 @@
 // cost on the first call to get_active_implementation(), and a smaller cost on
 // subsequent calls but it is then safe to use the simdutf library in static
 // initialization.
+//
+// Further reading: https://en.cppreference.com/cpp/language/siof
 #ifndef SIMDUTF_USE_STATIC_INITIALIZATION
   #if SIMDUTF_NO_LIBCXX
     #define SIMDUTF_USE_STATIC_INITIALIZATION 1

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -8,11 +8,12 @@
   #include "simdutf/scalar/atomic_util.h"
 #endif
 
-// GCC/Clang: provide a weak stub for __cxa_pure_virtual so that builds without
-// libc++abi (e.g. -nostdlib++) do not fail to link when the compiler emits a
-// reference to it from the abstract implementation vtable. If libc++abi is
-// linked in anyway, its strong definition takes precedence.
-#if (defined(__GNUC__) || defined(__clang__)) && !defined(_WIN32)
+// When building without libc++abi (SIMDUTF_NO_LIBCXX=1) on GCC/Clang, provide
+// a weak stub for __cxa_pure_virtual so the abstract implementation vtable
+// does not drag in libc++abi just for this unreachable hook. Kept weak so a
+// real libc++abi definition wins if one is linked in anyway.
+#if SIMDUTF_NO_LIBCXX &&                                                       \
+    (defined(__GNUC__) || defined(__clang__)) && !defined(_WIN32)
 extern "C" __attribute__((weak, noreturn)) void __cxa_pure_virtual() {
   __builtin_trap();
 }
@@ -117,59 +118,111 @@ namespace internal {
        SIMDUTF_IMPLEMENTATION_LASX + SIMDUTF_IMPLEMENTATION_FALLBACK ==        \
    1)
 
-// Static array of known implementations. We are hoping these get baked into the
-// executable without requiring a static initializer.
+// Static array of known implementations. We are hoping these get baked into
+// the executable without requiring a static initializer.
+//
+// Under SIMDUTF_NO_LIBCXX the singleton storage is promoted from a
+// function-local static to a translation-unit-scope variable so first-use
+// does not emit a thread-safe init guard (`__cxa_guard_*` from libc++abi).
+// The objects are trivial metadata wrappers so eager TU-scope initialization
+// is cheap. Otherwise we keep the classic function-local static.
 
-// Hoisted to translation-unit scope so that first-use does not emit a
-// thread-safe init guard (`__cxa_guard_*` from libc++abi). The objects are
-// trivial metadata wrappers, so eager static initialization is cheap.
 #if SIMDUTF_IMPLEMENTATION_ICELAKE
+  #if SIMDUTF_NO_LIBCXX
 static const icelake::implementation icelake_singleton{};
+  #endif
 static const icelake::implementation *get_icelake_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const icelake::implementation icelake_singleton{};
+  #endif
   return &icelake_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_HASWELL
+  #if SIMDUTF_NO_LIBCXX
 static const haswell::implementation haswell_singleton{};
+  #endif
 static const haswell::implementation *get_haswell_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const haswell::implementation haswell_singleton{};
+  #endif
   return &haswell_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_WESTMERE
+  #if SIMDUTF_NO_LIBCXX
 static const westmere::implementation westmere_singleton{};
+  #endif
 static const westmere::implementation *get_westmere_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const westmere::implementation westmere_singleton{};
+  #endif
   return &westmere_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_ARM64
+  #if SIMDUTF_NO_LIBCXX
 static const arm64::implementation arm64_singleton{};
+  #endif
 static const arm64::implementation *get_arm64_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const arm64::implementation arm64_singleton{};
+  #endif
   return &arm64_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_PPC64
+  #if SIMDUTF_NO_LIBCXX
 static const ppc64::implementation ppc64_singleton{};
+  #endif
 static const ppc64::implementation *get_ppc64_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const ppc64::implementation ppc64_singleton{};
+  #endif
   return &ppc64_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_RVV
+  #if SIMDUTF_NO_LIBCXX
 static const rvv::implementation rvv_singleton{};
-static const rvv::implementation *get_rvv_singleton() { return &rvv_singleton; }
+  #endif
+static const rvv::implementation *get_rvv_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const rvv::implementation rvv_singleton{};
+  #endif
+  return &rvv_singleton;
+}
 #endif
 #if SIMDUTF_IMPLEMENTATION_LASX
+  #if SIMDUTF_NO_LIBCXX
 static const lasx::implementation lasx_singleton{};
+  #endif
 static const lasx::implementation *get_lasx_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const lasx::implementation lasx_singleton{};
+  #endif
   return &lasx_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_LSX
+  #if SIMDUTF_NO_LIBCXX
 static const lsx::implementation lsx_singleton{};
-static const lsx::implementation *get_lsx_singleton() { return &lsx_singleton; }
+  #endif
+static const lsx::implementation *get_lsx_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const lsx::implementation lsx_singleton{};
+  #endif
+  return &lsx_singleton;
+}
 #endif
 #if SIMDUTF_IMPLEMENTATION_FALLBACK
+  #if SIMDUTF_NO_LIBCXX
 static const fallback::implementation fallback_singleton{};
+  #endif
 static const fallback::implementation *get_fallback_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const fallback::implementation fallback_singleton{};
+  #endif
   return &fallback_singleton;
 }
 #endif
@@ -821,38 +874,74 @@ static_assert(std::is_trivially_destructible<
               "detect_best_supported_implementation_on_first_use should be "
               "trivially destructible");
 
-// TU-scope storage for the pointer array — replaces a function-local static
-// std::initializer_list to avoid `__cxa_guard_*`. The array is used via a
-// pointer+size pair (see available_implementation_list methods).
-static const implementation *const available_implementation_pointers_array[] = {
-#if SIMDUTF_IMPLEMENTATION_ICELAKE
-    &icelake_singleton,
+#if SIMDUTF_NO_LIBCXX
+static const std::initializer_list<const implementation *>
+    available_implementation_pointers{
+  #if SIMDUTF_IMPLEMENTATION_ICELAKE
+        get_icelake_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_HASWELL
+        get_haswell_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_WESTMERE
+        get_westmere_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_ARM64
+        get_arm64_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_PPC64
+        get_ppc64_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_RVV
+        get_rvv_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_LASX
+        get_lasx_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_LSX
+        get_lsx_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_FALLBACK
+        get_fallback_singleton(),
+  #endif
+    };
 #endif
-#if SIMDUTF_IMPLEMENTATION_HASWELL
-    &haswell_singleton,
+static const std::initializer_list<const implementation *> &
+get_available_implementation_pointers() {
+#if !SIMDUTF_NO_LIBCXX
+  static const std::initializer_list<const implementation *>
+      available_implementation_pointers{
+  #if SIMDUTF_IMPLEMENTATION_ICELAKE
+          get_icelake_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_HASWELL
+          get_haswell_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_WESTMERE
+          get_westmere_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_ARM64
+          get_arm64_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_PPC64
+          get_ppc64_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_RVV
+          get_rvv_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_LASX
+          get_lasx_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_LSX
+          get_lsx_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_FALLBACK
+          get_fallback_singleton(),
+  #endif
+      };
 #endif
-#if SIMDUTF_IMPLEMENTATION_WESTMERE
-    &westmere_singleton,
-#endif
-#if SIMDUTF_IMPLEMENTATION_ARM64
-    &arm64_singleton,
-#endif
-#if SIMDUTF_IMPLEMENTATION_PPC64
-    &ppc64_singleton,
-#endif
-#if SIMDUTF_IMPLEMENTATION_RVV
-    &rvv_singleton,
-#endif
-#if SIMDUTF_IMPLEMENTATION_LASX
-    &lasx_singleton,
-#endif
-#if SIMDUTF_IMPLEMENTATION_LSX
-    &lsx_singleton,
-#endif
-#if SIMDUTF_IMPLEMENTATION_FALLBACK
-    &fallback_singleton,
-#endif
-};
+  return available_implementation_pointers;
+}
 
 // So we can return UNSUPPORTED_ARCHITECTURE from the parser when there is no
 // support
@@ -1372,24 +1461,28 @@ public:
                        "Unsupported CPU (no detected SIMD instructions)", 0) {}
 };
 
+#if SIMDUTF_NO_LIBCXX
 static const unsupported_implementation unsupported_singleton{};
+#endif
 const unsupported_implementation *get_unsupported_singleton() {
+#if !SIMDUTF_NO_LIBCXX
+  static const unsupported_implementation unsupported_singleton{};
+#endif
   return &unsupported_singleton;
 }
 static_assert(std::is_trivially_destructible<unsupported_implementation>::value,
               "unsupported_singleton should be trivially destructible");
 
 size_t available_implementation_list::size() const noexcept {
-  return sizeof(internal::available_implementation_pointers_array) /
-         sizeof(internal::available_implementation_pointers_array[0]);
+  return internal::get_available_implementation_pointers().size();
 }
 const implementation *const *
 available_implementation_list::begin() const noexcept {
-  return internal::available_implementation_pointers_array;
+  return internal::get_available_implementation_pointers().begin();
 }
 const implementation *const *
 available_implementation_list::end() const noexcept {
-  return internal::available_implementation_pointers_array + size();
+  return internal::get_available_implementation_pointers().end();
 }
 const implementation *
 available_implementation_list::detect_best_supported() const noexcept {
@@ -1397,7 +1490,7 @@ available_implementation_list::detect_best_supported() const noexcept {
   uint32_t supported_instruction_sets =
       internal::detect_supported_architectures();
   for (const implementation *impl :
-       internal::available_implementation_pointers_array) {
+       internal::get_available_implementation_pointers()) {
     uint32_t required_instruction_sets = impl->required_instruction_sets();
     if ((supported_instruction_sets & required_instruction_sets) ==
         required_instruction_sets) {
@@ -1434,35 +1527,52 @@ detect_best_supported_implementation_on_first_use::set_best() const noexcept {
 /**
  * The list of available implementations compiled into simdutf.
  */
-// TU-scope storage to avoid a function-local static with `__cxa_guard_*`.
-static const internal::available_implementation_list
-    available_implementations_instance{};
-
+#if SIMDUTF_NO_LIBCXX
+static const internal::available_implementation_list available_implementations{};
+#endif
 SIMDUTF_DLLIMPORTEXPORT const internal::available_implementation_list &
 get_available_implementations() {
-  return available_implementations_instance;
+#if !SIMDUTF_NO_LIBCXX
+  static const internal::available_implementation_list
+      available_implementations{};
+#endif
+  return available_implementations;
 }
-
-#if !SIMDUTF_SINGLE_IMPLEMENTATION
-static const internal::detect_best_supported_implementation_on_first_use
-    detect_best_supported_implementation_on_first_use_singleton;
-#endif
-
-static internal::atomic_ptr<const implementation>
-    active_implementation_instance{
-#if SIMDUTF_SINGLE_IMPLEMENTATION
-        internal::get_single_implementation()
-#else
-        &detect_best_supported_implementation_on_first_use_singleton
-#endif
-    };
 
 /**
  * The active implementation.
  */
+#if SIMDUTF_NO_LIBCXX && !SIMDUTF_SINGLE_IMPLEMENTATION
+static const internal::detect_best_supported_implementation_on_first_use
+    detect_best_supported_implementation_on_first_use_singleton;
+#endif
+#if SIMDUTF_NO_LIBCXX
+static internal::atomic_ptr<const implementation> active_implementation{
+  #if SIMDUTF_SINGLE_IMPLEMENTATION
+    internal::get_single_implementation()
+  #else
+    &detect_best_supported_implementation_on_first_use_singleton
+  #endif
+};
+#endif
 SIMDUTF_DLLIMPORTEXPORT internal::atomic_ptr<const implementation> &
 get_active_implementation() {
-  return active_implementation_instance;
+#if SIMDUTF_SINGLE_IMPLEMENTATION
+  #if !SIMDUTF_NO_LIBCXX
+  // skip runtime detection
+  static internal::atomic_ptr<const implementation> active_implementation{
+      internal::get_single_implementation()};
+  #endif
+  return active_implementation;
+#else
+  #if !SIMDUTF_NO_LIBCXX
+  static const internal::detect_best_supported_implementation_on_first_use
+      detect_best_supported_implementation_on_first_use_singleton;
+  static internal::atomic_ptr<const implementation> active_implementation{
+      &detect_best_supported_implementation_on_first_use_singleton};
+  #endif
+  return active_implementation;
+#endif
 }
 
 #if SIMDUTF_SINGLE_IMPLEMENTATION
@@ -2501,12 +2611,18 @@ simdutf_warn_unused int detect_encodings(const char *buf,
 }
 #endif // SIMDUTF_FEATURE_DETECT_ENCODING
 
-// TU-scope storage to avoid a function-local static with `__cxa_guard_*`.
-static const implementation *const builtin_impl_instance =
-    get_available_implementations()[SIMDUTF_STRINGIFY(
-        SIMDUTF_BUILTIN_IMPLEMENTATION)];
-
-const implementation *builtin_implementation() { return builtin_impl_instance; }
+#if SIMDUTF_NO_LIBCXX
+static const implementation *builtin_impl = get_available_implementations()[
+    SIMDUTF_STRINGIFY(SIMDUTF_BUILTIN_IMPLEMENTATION)];
+#endif
+const implementation *builtin_implementation() {
+#if !SIMDUTF_NO_LIBCXX
+  static const implementation *builtin_impl =
+      get_available_implementations()[SIMDUTF_STRINGIFY(
+          SIMDUTF_BUILTIN_IMPLEMENTATION)];
+#endif
+  return builtin_impl;
+}
 
 #if SIMDUTF_FEATURE_UTF8
 simdutf_warn_unused size_t trim_partial_utf8(const char *input, size_t length) {

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -12,8 +12,7 @@
 // a weak stub for __cxa_pure_virtual so the abstract implementation vtable
 // does not drag in libc++abi just for this unreachable hook. Kept weak so a
 // real libc++abi definition wins if one is linked in anyway.
-#if SIMDUTF_NO_LIBCXX &&                                                       \
-    (defined(__GNUC__) || defined(__clang__)) && !defined(_WIN32)
+#if SIMDUTF_NO_LIBCXX
 extern "C" __attribute__((weak, noreturn)) void __cxa_pure_virtual() {
   __builtin_trap();
 }
@@ -118,111 +117,59 @@ namespace internal {
        SIMDUTF_IMPLEMENTATION_LASX + SIMDUTF_IMPLEMENTATION_FALLBACK ==        \
    1)
 
-// Static array of known implementations. We are hoping these get baked into
-// the executable without requiring a static initializer.
-//
-// Under SIMDUTF_NO_LIBCXX the singleton storage is promoted from a
-// function-local static to a translation-unit-scope variable so first-use
-// does not emit a thread-safe init guard (`__cxa_guard_*` from libc++abi).
-// The objects are trivial metadata wrappers so eager TU-scope initialization
-// is cheap. Otherwise we keep the classic function-local static.
+// Static array of known implementations. We are hoping these get baked into the
+// executable without requiring a static initializer.
 
+// Hoisted to translation-unit scope so that first-use does not emit a
+// thread-safe init guard (`__cxa_guard_*` from libc++abi). The objects are
+// trivial metadata wrappers, so eager static initialization is cheap.
 #if SIMDUTF_IMPLEMENTATION_ICELAKE
-  #if SIMDUTF_NO_LIBCXX
 static const icelake::implementation icelake_singleton{};
-  #endif
 static const icelake::implementation *get_icelake_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
-  static const icelake::implementation icelake_singleton{};
-  #endif
   return &icelake_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_HASWELL
-  #if SIMDUTF_NO_LIBCXX
 static const haswell::implementation haswell_singleton{};
-  #endif
 static const haswell::implementation *get_haswell_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
-  static const haswell::implementation haswell_singleton{};
-  #endif
   return &haswell_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_WESTMERE
-  #if SIMDUTF_NO_LIBCXX
 static const westmere::implementation westmere_singleton{};
-  #endif
 static const westmere::implementation *get_westmere_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
-  static const westmere::implementation westmere_singleton{};
-  #endif
   return &westmere_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_ARM64
-  #if SIMDUTF_NO_LIBCXX
 static const arm64::implementation arm64_singleton{};
-  #endif
 static const arm64::implementation *get_arm64_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
-  static const arm64::implementation arm64_singleton{};
-  #endif
   return &arm64_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_PPC64
-  #if SIMDUTF_NO_LIBCXX
 static const ppc64::implementation ppc64_singleton{};
-  #endif
 static const ppc64::implementation *get_ppc64_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
-  static const ppc64::implementation ppc64_singleton{};
-  #endif
   return &ppc64_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_RVV
-  #if SIMDUTF_NO_LIBCXX
 static const rvv::implementation rvv_singleton{};
-  #endif
-static const rvv::implementation *get_rvv_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
-  static const rvv::implementation rvv_singleton{};
-  #endif
-  return &rvv_singleton;
-}
+static const rvv::implementation *get_rvv_singleton() { return &rvv_singleton; }
 #endif
 #if SIMDUTF_IMPLEMENTATION_LASX
-  #if SIMDUTF_NO_LIBCXX
 static const lasx::implementation lasx_singleton{};
-  #endif
 static const lasx::implementation *get_lasx_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
-  static const lasx::implementation lasx_singleton{};
-  #endif
   return &lasx_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_LSX
-  #if SIMDUTF_NO_LIBCXX
 static const lsx::implementation lsx_singleton{};
-  #endif
-static const lsx::implementation *get_lsx_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
-  static const lsx::implementation lsx_singleton{};
-  #endif
-  return &lsx_singleton;
-}
+static const lsx::implementation *get_lsx_singleton() { return &lsx_singleton; }
 #endif
 #if SIMDUTF_IMPLEMENTATION_FALLBACK
-  #if SIMDUTF_NO_LIBCXX
 static const fallback::implementation fallback_singleton{};
-  #endif
 static const fallback::implementation *get_fallback_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
-  static const fallback::implementation fallback_singleton{};
-  #endif
   return &fallback_singleton;
 }
 #endif
@@ -874,74 +821,38 @@ static_assert(std::is_trivially_destructible<
               "detect_best_supported_implementation_on_first_use should be "
               "trivially destructible");
 
-#if SIMDUTF_NO_LIBCXX
-static const std::initializer_list<const implementation *>
-    available_implementation_pointers{
-  #if SIMDUTF_IMPLEMENTATION_ICELAKE
-        get_icelake_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_HASWELL
-        get_haswell_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_WESTMERE
-        get_westmere_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_ARM64
-        get_arm64_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_PPC64
-        get_ppc64_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_RVV
-        get_rvv_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_LASX
-        get_lasx_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_LSX
-        get_lsx_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_FALLBACK
-        get_fallback_singleton(),
-  #endif
-    };
+// TU-scope storage for the pointer array — replaces a function-local static
+// std::initializer_list to avoid `__cxa_guard_*`. The array is used via a
+// pointer+size pair (see available_implementation_list methods).
+static const implementation *const available_implementation_pointers_array[] = {
+#if SIMDUTF_IMPLEMENTATION_ICELAKE
+    &icelake_singleton,
 #endif
-static const std::initializer_list<const implementation *> &
-get_available_implementation_pointers() {
-#if !SIMDUTF_NO_LIBCXX
-  static const std::initializer_list<const implementation *>
-      available_implementation_pointers{
-  #if SIMDUTF_IMPLEMENTATION_ICELAKE
-          get_icelake_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_HASWELL
-          get_haswell_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_WESTMERE
-          get_westmere_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_ARM64
-          get_arm64_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_PPC64
-          get_ppc64_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_RVV
-          get_rvv_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_LASX
-          get_lasx_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_LSX
-          get_lsx_singleton(),
-  #endif
-  #if SIMDUTF_IMPLEMENTATION_FALLBACK
-          get_fallback_singleton(),
-  #endif
-      };
+#if SIMDUTF_IMPLEMENTATION_HASWELL
+    &haswell_singleton,
 #endif
-  return available_implementation_pointers;
-}
+#if SIMDUTF_IMPLEMENTATION_WESTMERE
+    &westmere_singleton,
+#endif
+#if SIMDUTF_IMPLEMENTATION_ARM64
+    &arm64_singleton,
+#endif
+#if SIMDUTF_IMPLEMENTATION_PPC64
+    &ppc64_singleton,
+#endif
+#if SIMDUTF_IMPLEMENTATION_RVV
+    &rvv_singleton,
+#endif
+#if SIMDUTF_IMPLEMENTATION_LASX
+    &lasx_singleton,
+#endif
+#if SIMDUTF_IMPLEMENTATION_LSX
+    &lsx_singleton,
+#endif
+#if SIMDUTF_IMPLEMENTATION_FALLBACK
+    &fallback_singleton,
+#endif
+};
 
 // So we can return UNSUPPORTED_ARCHITECTURE from the parser when there is no
 // support
@@ -1461,28 +1372,24 @@ public:
                        "Unsupported CPU (no detected SIMD instructions)", 0) {}
 };
 
-#if SIMDUTF_NO_LIBCXX
 static const unsupported_implementation unsupported_singleton{};
-#endif
 const unsupported_implementation *get_unsupported_singleton() {
-#if !SIMDUTF_NO_LIBCXX
-  static const unsupported_implementation unsupported_singleton{};
-#endif
   return &unsupported_singleton;
 }
 static_assert(std::is_trivially_destructible<unsupported_implementation>::value,
               "unsupported_singleton should be trivially destructible");
 
 size_t available_implementation_list::size() const noexcept {
-  return internal::get_available_implementation_pointers().size();
+  return sizeof(internal::available_implementation_pointers_array) /
+         sizeof(internal::available_implementation_pointers_array[0]);
 }
 const implementation *const *
 available_implementation_list::begin() const noexcept {
-  return internal::get_available_implementation_pointers().begin();
+  return internal::available_implementation_pointers_array;
 }
 const implementation *const *
 available_implementation_list::end() const noexcept {
-  return internal::get_available_implementation_pointers().end();
+  return internal::available_implementation_pointers_array + size();
 }
 const implementation *
 available_implementation_list::detect_best_supported() const noexcept {
@@ -1490,7 +1397,7 @@ available_implementation_list::detect_best_supported() const noexcept {
   uint32_t supported_instruction_sets =
       internal::detect_supported_architectures();
   for (const implementation *impl :
-       internal::get_available_implementation_pointers()) {
+       internal::available_implementation_pointers_array) {
     uint32_t required_instruction_sets = impl->required_instruction_sets();
     if ((supported_instruction_sets & required_instruction_sets) ==
         required_instruction_sets) {
@@ -1527,52 +1434,35 @@ detect_best_supported_implementation_on_first_use::set_best() const noexcept {
 /**
  * The list of available implementations compiled into simdutf.
  */
-#if SIMDUTF_NO_LIBCXX
-static const internal::available_implementation_list available_implementations{};
-#endif
+// TU-scope storage to avoid a function-local static with `__cxa_guard_*`.
+static const internal::available_implementation_list
+    available_implementations_instance{};
+
 SIMDUTF_DLLIMPORTEXPORT const internal::available_implementation_list &
 get_available_implementations() {
-#if !SIMDUTF_NO_LIBCXX
-  static const internal::available_implementation_list
-      available_implementations{};
-#endif
-  return available_implementations;
+  return available_implementations_instance;
 }
+
+#if !SIMDUTF_SINGLE_IMPLEMENTATION
+static const internal::detect_best_supported_implementation_on_first_use
+    detect_best_supported_implementation_on_first_use_singleton;
+#endif
+
+static internal::atomic_ptr<const implementation>
+    active_implementation_instance{
+#if SIMDUTF_SINGLE_IMPLEMENTATION
+        internal::get_single_implementation()
+#else
+        &detect_best_supported_implementation_on_first_use_singleton
+#endif
+    };
 
 /**
  * The active implementation.
  */
-#if SIMDUTF_NO_LIBCXX && !SIMDUTF_SINGLE_IMPLEMENTATION
-static const internal::detect_best_supported_implementation_on_first_use
-    detect_best_supported_implementation_on_first_use_singleton;
-#endif
-#if SIMDUTF_NO_LIBCXX
-static internal::atomic_ptr<const implementation> active_implementation{
-  #if SIMDUTF_SINGLE_IMPLEMENTATION
-    internal::get_single_implementation()
-  #else
-    &detect_best_supported_implementation_on_first_use_singleton
-  #endif
-};
-#endif
 SIMDUTF_DLLIMPORTEXPORT internal::atomic_ptr<const implementation> &
 get_active_implementation() {
-#if SIMDUTF_SINGLE_IMPLEMENTATION
-  #if !SIMDUTF_NO_LIBCXX
-  // skip runtime detection
-  static internal::atomic_ptr<const implementation> active_implementation{
-      internal::get_single_implementation()};
-  #endif
-  return active_implementation;
-#else
-  #if !SIMDUTF_NO_LIBCXX
-  static const internal::detect_best_supported_implementation_on_first_use
-      detect_best_supported_implementation_on_first_use_singleton;
-  static internal::atomic_ptr<const implementation> active_implementation{
-      &detect_best_supported_implementation_on_first_use_singleton};
-  #endif
-  return active_implementation;
-#endif
+  return active_implementation_instance;
 }
 
 #if SIMDUTF_SINGLE_IMPLEMENTATION
@@ -2611,18 +2501,12 @@ simdutf_warn_unused int detect_encodings(const char *buf,
 }
 #endif // SIMDUTF_FEATURE_DETECT_ENCODING
 
-#if SIMDUTF_NO_LIBCXX
-static const implementation *builtin_impl = get_available_implementations()[
-    SIMDUTF_STRINGIFY(SIMDUTF_BUILTIN_IMPLEMENTATION)];
-#endif
-const implementation *builtin_implementation() {
-#if !SIMDUTF_NO_LIBCXX
-  static const implementation *builtin_impl =
-      get_available_implementations()[SIMDUTF_STRINGIFY(
-          SIMDUTF_BUILTIN_IMPLEMENTATION)];
-#endif
-  return builtin_impl;
-}
+// TU-scope storage to avoid a function-local static with `__cxa_guard_*`.
+static const implementation *const builtin_impl_instance =
+    get_available_implementations()[SIMDUTF_STRINGIFY(
+        SIMDUTF_BUILTIN_IMPLEMENTATION)];
+
+const implementation *builtin_implementation() { return builtin_impl_instance; }
 
 #if SIMDUTF_FEATURE_UTF8
 simdutf_warn_unused size_t trim_partial_utf8(const char *input, size_t length) {

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1570,13 +1570,14 @@ get_active_implementation() {
   static const internal::detect_best_supported_implementation_on_first_use
       detect_best_supported_implementation_on_first_use_singleton;
   #endif
-  static internal::atomic_ptr<const implementation> active_implementation_instance{
+  static internal::atomic_ptr<const implementation>
+      active_implementation_instance{
   #if SIMDUTF_SINGLE_IMPLEMENTATION
-      internal::get_single_implementation()
+          internal::get_single_implementation()
   #else
-      &detect_best_supported_implementation_on_first_use_singleton
+          &detect_best_supported_implementation_on_first_use_singleton
   #endif
-  };
+      };
 #endif
   return active_implementation_instance;
 }

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1,10 +1,19 @@
 #include "simdutf.h"
-#include <initializer_list>
 #include <climits>
 #include <type_traits>
 #if SIMDUTF_ATOMIC_REF
   #include <array>
   #include "simdutf/scalar/atomic_util.h"
+#endif
+
+// GCC/Clang: provide a weak stub for __cxa_pure_virtual so that builds without
+// libc++abi (e.g. -nostdlib++) do not fail to link when the compiler emits a
+// reference to it from the abstract implementation vtable. If libc++abi is
+// linked in anyway, its strong definition takes precedence.
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(_WIN32)
+extern "C" __attribute__((weak, noreturn)) void __cxa_pure_virtual() {
+  __builtin_trap();
+}
 #endif
 
 static_assert(sizeof(uint8_t) == sizeof(char),
@@ -15,22 +24,6 @@ static_assert(sizeof(uint32_t) == sizeof(char32_t),
               "simdutf requires that char32_t be 32 bits");
 // next line is redundant, but it is kept to catch defective systems.
 static_assert(CHAR_BIT == 8, "simdutf requires 8-bit bytes");
-
-// Useful for debugging purposes
-namespace simdutf {
-namespace {
-
-template <typename T> std::string toBinaryString(T b) {
-  std::string binary = "";
-  T mask = T(1) << (sizeof(T) * CHAR_BIT - 1);
-  while (mask > 0) {
-    binary += ((b & mask) == 0) ? '0' : '1';
-    mask >>= 1;
-  }
-  return binary;
-}
-} // namespace
-} // namespace simdutf
 
 namespace simdutf {
 bool implementation::supported_by_runtime_system() const {
@@ -125,57 +118,60 @@ namespace internal {
 // Static array of known implementations. We are hoping these get baked into the
 // executable without requiring a static initializer.
 
+// Hoisted to translation-unit scope so that first-use does not emit a
+// thread-safe init guard (`__cxa_guard_*` from libc++abi). The objects are
+// trivial metadata wrappers, so eager static initialization is cheap.
 #if SIMDUTF_IMPLEMENTATION_ICELAKE
+static const icelake::implementation icelake_singleton{};
 static const icelake::implementation *get_icelake_singleton() {
-  static const icelake::implementation icelake_singleton{};
   return &icelake_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_HASWELL
+static const haswell::implementation haswell_singleton{};
 static const haswell::implementation *get_haswell_singleton() {
-  static const haswell::implementation haswell_singleton{};
   return &haswell_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_WESTMERE
+static const westmere::implementation westmere_singleton{};
 static const westmere::implementation *get_westmere_singleton() {
-  static const westmere::implementation westmere_singleton{};
   return &westmere_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_ARM64
+static const arm64::implementation arm64_singleton{};
 static const arm64::implementation *get_arm64_singleton() {
-  static const arm64::implementation arm64_singleton{};
   return &arm64_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_PPC64
+static const ppc64::implementation ppc64_singleton{};
 static const ppc64::implementation *get_ppc64_singleton() {
-  static const ppc64::implementation ppc64_singleton{};
   return &ppc64_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_RVV
+static const rvv::implementation rvv_singleton{};
 static const rvv::implementation *get_rvv_singleton() {
-  static const rvv::implementation rvv_singleton{};
   return &rvv_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_LASX
+static const lasx::implementation lasx_singleton{};
 static const lasx::implementation *get_lasx_singleton() {
-  static const lasx::implementation lasx_singleton{};
   return &lasx_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_LSX
+static const lsx::implementation lsx_singleton{};
 static const lsx::implementation *get_lsx_singleton() {
-  static const lsx::implementation lsx_singleton{};
   return &lsx_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_FALLBACK
+static const fallback::implementation fallback_singleton{};
 static const fallback::implementation *get_fallback_singleton() {
-  static const fallback::implementation fallback_singleton{};
   return &fallback_singleton;
 }
 #endif
@@ -216,8 +212,8 @@ simdutf_really_inline static const implementation *get_single_implementation() {
 class detect_best_supported_implementation_on_first_use final
     : public implementation {
 public:
-  std::string name() const noexcept final { return set_best()->name(); }
-  std::string description() const noexcept final {
+  const char *name() const noexcept final { return set_best()->name(); }
+  const char *description() const noexcept final {
     return set_best()->description();
   }
   uint32_t required_instruction_sets() const noexcept final {
@@ -827,40 +823,38 @@ static_assert(std::is_trivially_destructible<
               "detect_best_supported_implementation_on_first_use should be "
               "trivially destructible");
 
-static const std::initializer_list<const implementation *> &
-get_available_implementation_pointers() {
-  static const std::initializer_list<const implementation *>
-      available_implementation_pointers{
+// TU-scope storage for the pointer array — replaces a function-local static
+// std::initializer_list to avoid `__cxa_guard_*`. The array is used via a
+// pointer+size pair (see available_implementation_list methods).
+static const implementation *const available_implementation_pointers_array[] = {
 #if SIMDUTF_IMPLEMENTATION_ICELAKE
-          get_icelake_singleton(),
+    &icelake_singleton,
 #endif
 #if SIMDUTF_IMPLEMENTATION_HASWELL
-          get_haswell_singleton(),
+    &haswell_singleton,
 #endif
 #if SIMDUTF_IMPLEMENTATION_WESTMERE
-          get_westmere_singleton(),
+    &westmere_singleton,
 #endif
 #if SIMDUTF_IMPLEMENTATION_ARM64
-          get_arm64_singleton(),
+    &arm64_singleton,
 #endif
 #if SIMDUTF_IMPLEMENTATION_PPC64
-          get_ppc64_singleton(),
+    &ppc64_singleton,
 #endif
 #if SIMDUTF_IMPLEMENTATION_RVV
-          get_rvv_singleton(),
+    &rvv_singleton,
 #endif
 #if SIMDUTF_IMPLEMENTATION_LASX
-          get_lasx_singleton(),
+    &lasx_singleton,
 #endif
 #if SIMDUTF_IMPLEMENTATION_LSX
-          get_lsx_singleton(),
+    &lsx_singleton,
 #endif
 #if SIMDUTF_IMPLEMENTATION_FALLBACK
-          get_fallback_singleton(),
+    &fallback_singleton,
 #endif
-      }; // available_implementation_pointers
-  return available_implementation_pointers;
-}
+};
 
 // So we can return UNSUPPORTED_ARCHITECTURE from the parser when there is no
 // support
@@ -1380,23 +1374,25 @@ public:
                        "Unsupported CPU (no detected SIMD instructions)", 0) {}
 };
 
+static const unsupported_implementation unsupported_singleton{};
 const unsupported_implementation *get_unsupported_singleton() {
-  static const unsupported_implementation unsupported_singleton{};
   return &unsupported_singleton;
 }
 static_assert(std::is_trivially_destructible<unsupported_implementation>::value,
               "unsupported_singleton should be trivially destructible");
 
 size_t available_implementation_list::size() const noexcept {
-  return internal::get_available_implementation_pointers().size();
+  return sizeof(internal::available_implementation_pointers_array) /
+         sizeof(internal::available_implementation_pointers_array[0]);
 }
 const implementation *const *
 available_implementation_list::begin() const noexcept {
-  return internal::get_available_implementation_pointers().begin();
+  return internal::available_implementation_pointers_array;
 }
 const implementation *const *
 available_implementation_list::end() const noexcept {
-  return internal::get_available_implementation_pointers().end();
+  return internal::available_implementation_pointers_array +
+         size();
 }
 const implementation *
 available_implementation_list::detect_best_supported() const noexcept {
@@ -1404,7 +1400,7 @@ available_implementation_list::detect_best_supported() const noexcept {
   uint32_t supported_instruction_sets =
       internal::detect_supported_architectures();
   for (const implementation *impl :
-       internal::get_available_implementation_pointers()) {
+       internal::available_implementation_pointers_array) {
     uint32_t required_instruction_sets = impl->required_instruction_sets();
     if ((supported_instruction_sets & required_instruction_sets) ==
         required_instruction_sets) {
@@ -1441,30 +1437,34 @@ detect_best_supported_implementation_on_first_use::set_best() const noexcept {
 /**
  * The list of available implementations compiled into simdutf.
  */
+// TU-scope storage to avoid a function-local static with `__cxa_guard_*`.
+static const internal::available_implementation_list
+    available_implementations_instance{};
+
 SIMDUTF_DLLIMPORTEXPORT const internal::available_implementation_list &
 get_available_implementations() {
-  static const internal::available_implementation_list
-      available_implementations{};
-  return available_implementations;
+  return available_implementations_instance;
 }
+
+#if !SIMDUTF_SINGLE_IMPLEMENTATION
+static const internal::detect_best_supported_implementation_on_first_use
+    detect_best_supported_implementation_on_first_use_singleton;
+#endif
+
+static internal::atomic_ptr<const implementation> active_implementation_instance{
+#if SIMDUTF_SINGLE_IMPLEMENTATION
+    internal::get_single_implementation()
+#else
+    &detect_best_supported_implementation_on_first_use_singleton
+#endif
+};
 
 /**
  * The active implementation.
  */
 SIMDUTF_DLLIMPORTEXPORT internal::atomic_ptr<const implementation> &
 get_active_implementation() {
-#if SIMDUTF_SINGLE_IMPLEMENTATION
-  // skip runtime detection
-  static internal::atomic_ptr<const implementation> active_implementation{
-      internal::get_single_implementation()};
-  return active_implementation;
-#else
-  static const internal::detect_best_supported_implementation_on_first_use
-      detect_best_supported_implementation_on_first_use_singleton;
-  static internal::atomic_ptr<const implementation> active_implementation{
-      &detect_best_supported_implementation_on_first_use_singleton};
-  return active_implementation;
-#endif
+  return active_implementation_instance;
 }
 
 #if SIMDUTF_SINGLE_IMPLEMENTATION
@@ -2503,12 +2503,12 @@ simdutf_warn_unused int detect_encodings(const char *buf,
 }
 #endif // SIMDUTF_FEATURE_DETECT_ENCODING
 
-const implementation *builtin_implementation() {
-  static const implementation *builtin_impl =
-      get_available_implementations()[SIMDUTF_STRINGIFY(
-          SIMDUTF_BUILTIN_IMPLEMENTATION)];
-  return builtin_impl;
-}
+// TU-scope storage to avoid a function-local static with `__cxa_guard_*`.
+static const implementation *const builtin_impl_instance =
+    get_available_implementations()[SIMDUTF_STRINGIFY(
+        SIMDUTF_BUILTIN_IMPLEMENTATION)];
+
+const implementation *builtin_implementation() { return builtin_impl_instance; }
 
 #if SIMDUTF_FEATURE_UTF8
 simdutf_warn_unused size_t trim_partial_utf8(const char *input, size_t length) {

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -8,6 +8,32 @@
   #include "simdutf/scalar/atomic_util.h"
 #endif
 
+// The macro SIMDUTF_USE_STATIC_INITIALIZATION, when set to 1, means that we
+// will use translation-unit-scope variables to hold our implementations.
+//
+// The downside of a translation-unit-scope variable is that the initialization
+// order is not well defined, thus if someone uses simdutf before main() starts,
+// they might get a crash. Thus setting SIMDUTF_USE_STATIC_INITIALIZATION to 1
+// is not recommended if you are using simdutf in a library that might be used
+// by other code before main() starts. However, the upside is that there is no
+// synchronization overhead on every call to get_active_implementation(). When
+// compiling without the c++ standard library, we use static initialization,
+// because C++ relies on the standard library for thread-safe initialization of
+// function-scope static variables.
+//
+// By default, we avoid translation-unit-scope static initialization, so we set
+// SIMDUTF_USE_STATIC_INITIALIZATION to 0. It comes with a small performance
+// cost on the first call to get_active_implementation(), and a smaller cost on
+// subsequent calls but it is then safe to use the simdutf library in static
+// initialization.
+#ifndef SIMDUTF_USE_STATIC_INITIALIZATION
+  #if SIMDUTF_NO_LIBCXX
+    #define SIMDUTF_USE_STATIC_INITIALIZATION 1
+  #else // SIMDUTF_NO_LIBCXX
+    #define SIMDUTF_USE_STATIC_INITIALIZATION 0
+  #endif // SIMDUTF_NO_LIBCXX
+#endif   // SIMDUTF_USE_STATIC_INITIALIZATION
+
 // When building without libc++abi (SIMDUTF_NO_LIBCXX=1) on GCC/Clang, provide
 // a weak stub for __cxa_pure_virtual so the abstract implementation vtable
 // does not drag in libc++abi just for this unreachable hook. Kept weak so a
@@ -123,108 +149,100 @@ namespace internal {
        SIMDUTF_IMPLEMENTATION_LASX + SIMDUTF_IMPLEMENTATION_FALLBACK ==        \
    1)
 
-// Static array of known implementations. We are hoping these get baked into
-// the executable without requiring a static initializer.
-//
-// Under SIMDUTF_NO_LIBCXX the singleton storage is promoted from a
-// function-local static to a translation-unit-scope variable so first-use
-// does not emit a thread-safe init guard (`__cxa_guard_*` from libc++abi).
-// The objects are trivial metadata wrappers so eager TU-scope initialization
-// is cheap. Otherwise we keep the classic function-local static.
 #if SIMDUTF_IMPLEMENTATION_ICELAKE
-  #if SIMDUTF_NO_LIBCXX
+  #if SIMDUTF_USE_STATIC_INITIALIZATION
 static const icelake::implementation icelake_singleton{};
   #endif
 static const icelake::implementation *get_icelake_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
+  #if !SIMDUTF_USE_STATIC_INITIALIZATION
   static const icelake::implementation icelake_singleton{};
   #endif
   return &icelake_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_HASWELL
-  #if SIMDUTF_NO_LIBCXX
+  #if SIMDUTF_USE_STATIC_INITIALIZATION
 static const haswell::implementation haswell_singleton{};
   #endif
 static const haswell::implementation *get_haswell_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
+  #if !SIMDUTF_USE_STATIC_INITIALIZATION
   static const haswell::implementation haswell_singleton{};
   #endif
   return &haswell_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_WESTMERE
-  #if SIMDUTF_NO_LIBCXX
+  #if SIMDUTF_USE_STATIC_INITIALIZATION
 static const westmere::implementation westmere_singleton{};
   #endif
 static const westmere::implementation *get_westmere_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
+  #if !SIMDUTF_USE_STATIC_INITIALIZATION
   static const westmere::implementation westmere_singleton{};
   #endif
   return &westmere_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_ARM64
-  #if SIMDUTF_NO_LIBCXX
+  #if SIMDUTF_USE_STATIC_INITIALIZATION
 static const arm64::implementation arm64_singleton{};
   #endif
 static const arm64::implementation *get_arm64_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
+  #if !SIMDUTF_USE_STATIC_INITIALIZATION
   static const arm64::implementation arm64_singleton{};
   #endif
   return &arm64_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_PPC64
-  #if SIMDUTF_NO_LIBCXX
+  #if SIMDUTF_USE_STATIC_INITIALIZATION
 static const ppc64::implementation ppc64_singleton{};
   #endif
 static const ppc64::implementation *get_ppc64_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
+  #if !SIMDUTF_USE_STATIC_INITIALIZATION
   static const ppc64::implementation ppc64_singleton{};
   #endif
   return &ppc64_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_RVV
-  #if SIMDUTF_NO_LIBCXX
+  #if SIMDUTF_USE_STATIC_INITIALIZATION
 static const rvv::implementation rvv_singleton{};
   #endif
 static const rvv::implementation *get_rvv_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
+  #if !SIMDUTF_USE_STATIC_INITIALIZATION
   static const rvv::implementation rvv_singleton{};
   #endif
   return &rvv_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_LASX
-  #if SIMDUTF_NO_LIBCXX
+  #if SIMDUTF_USE_STATIC_INITIALIZATION
 static const lasx::implementation lasx_singleton{};
   #endif
 static const lasx::implementation *get_lasx_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
+  #if !SIMDUTF_USE_STATIC_INITIALIZATION
   static const lasx::implementation lasx_singleton{};
   #endif
   return &lasx_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_LSX
-  #if SIMDUTF_NO_LIBCXX
+  #if SIMDUTF_USE_STATIC_INITIALIZATION
 static const lsx::implementation lsx_singleton{};
   #endif
 static const lsx::implementation *get_lsx_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
+  #if !SIMDUTF_USE_STATIC_INITIALIZATION
   static const lsx::implementation lsx_singleton{};
   #endif
   return &lsx_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_FALLBACK
-  #if SIMDUTF_NO_LIBCXX
+  #if SIMDUTF_USE_STATIC_INITIALIZATION
 static const fallback::implementation fallback_singleton{};
   #endif
 static const fallback::implementation *get_fallback_singleton() {
-  #if !SIMDUTF_NO_LIBCXX
+  #if !SIMDUTF_USE_STATIC_INITIALIZATION
   static const fallback::implementation fallback_singleton{};
   #endif
   return &fallback_singleton;
@@ -878,7 +896,7 @@ static_assert(std::is_trivially_destructible<
               "detect_best_supported_implementation_on_first_use should be "
               "trivially destructible");
 
-#if SIMDUTF_NO_LIBCXX
+#if SIMDUTF_USE_STATIC_INITIALIZATION
 static const std::initializer_list<const implementation *>
     available_implementation_pointers{
   #if SIMDUTF_IMPLEMENTATION_ICELAKE
@@ -912,7 +930,7 @@ static const std::initializer_list<const implementation *>
 #endif
 static const std::initializer_list<const implementation *> &
 get_available_implementation_pointers() {
-#if !SIMDUTF_NO_LIBCXX
+#if !SIMDUTF_USE_STATIC_INITIALIZATION
   static const std::initializer_list<const implementation *>
       available_implementation_pointers{
   #if SIMDUTF_IMPLEMENTATION_ICELAKE
@@ -1465,11 +1483,11 @@ public:
                        "Unsupported CPU (no detected SIMD instructions)", 0) {}
 };
 
-#if SIMDUTF_NO_LIBCXX
+#if SIMDUTF_USE_STATIC_INITIALIZATION
 static const unsupported_implementation unsupported_singleton{};
 #endif
 const unsupported_implementation *get_unsupported_singleton() {
-#if !SIMDUTF_NO_LIBCXX
+#if !SIMDUTF_USE_STATIC_INITIALIZATION
   static const unsupported_implementation unsupported_singleton{};
 #endif
   return &unsupported_singleton;
@@ -1531,25 +1549,25 @@ detect_best_supported_implementation_on_first_use::set_best() const noexcept {
 /**
  * The list of available implementations compiled into simdutf.
  */
-#if SIMDUTF_NO_LIBCXX
+#if SIMDUTF_USE_STATIC_INITIALIZATION
 static const internal::available_implementation_list
     available_implementations_instance{};
 #endif
 SIMDUTF_DLLIMPORTEXPORT const internal::available_implementation_list &
 get_available_implementations() {
-#if !SIMDUTF_NO_LIBCXX
+#if !SIMDUTF_USE_STATIC_INITIALIZATION
   static const internal::available_implementation_list
       available_implementations_instance{};
 #endif
   return available_implementations_instance;
 }
 
-#if SIMDUTF_NO_LIBCXX && !SIMDUTF_SINGLE_IMPLEMENTATION
+#if SIMDUTF_USE_STATIC_INITIALIZATION && !SIMDUTF_SINGLE_IMPLEMENTATION
 static const internal::detect_best_supported_implementation_on_first_use
     detect_best_supported_implementation_on_first_use_singleton;
 #endif
 
-#if SIMDUTF_NO_LIBCXX
+#if SIMDUTF_USE_STATIC_INITIALIZATION
 static internal::atomic_ptr<const implementation>
     active_implementation_instance{
   #if SIMDUTF_SINGLE_IMPLEMENTATION
@@ -1565,7 +1583,7 @@ static internal::atomic_ptr<const implementation>
  */
 SIMDUTF_DLLIMPORTEXPORT internal::atomic_ptr<const implementation> &
 get_active_implementation() {
-#if !SIMDUTF_NO_LIBCXX
+#if !SIMDUTF_USE_STATIC_INITIALIZATION
   #if !SIMDUTF_SINGLE_IMPLEMENTATION
   static const internal::detect_best_supported_implementation_on_first_use
       detect_best_supported_implementation_on_first_use_singleton;
@@ -2618,13 +2636,13 @@ simdutf_warn_unused int detect_encodings(const char *buf,
 }
 #endif // SIMDUTF_FEATURE_DETECT_ENCODING
 
-#if SIMDUTF_NO_LIBCXX
+#if SIMDUTF_USE_STATIC_INITIALIZATION
 static const implementation *const builtin_impl_instance =
     get_available_implementations()[SIMDUTF_STRINGIFY(
         SIMDUTF_BUILTIN_IMPLEMENTATION)];
 #endif
 const implementation *builtin_implementation() {
-#if !SIMDUTF_NO_LIBCXX
+#if !SIMDUTF_USE_STATIC_INITIALIZATION
   static const implementation *const builtin_impl_instance =
       get_available_implementations()[SIMDUTF_STRINGIFY(
           SIMDUTF_BUILTIN_IMPLEMENTATION)];

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -210,8 +210,8 @@ simdutf_really_inline static const implementation *get_single_implementation() {
 class detect_best_supported_implementation_on_first_use final
     : public implementation {
 public:
-  const char *name() const noexcept final { return set_best()->name(); }
-  const char *description() const noexcept final {
+  std::string_view name() const noexcept final { return set_best()->name(); }
+  std::string_view description() const noexcept final {
     return set_best()->description();
   }
   uint32_t required_instruction_sets() const noexcept final {

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -117,59 +117,110 @@ namespace internal {
        SIMDUTF_IMPLEMENTATION_LASX + SIMDUTF_IMPLEMENTATION_FALLBACK ==        \
    1)
 
-// Static array of known implementations. We are hoping these get baked into the
-// executable without requiring a static initializer.
-
-// Hoisted to translation-unit scope so that first-use does not emit a
-// thread-safe init guard (`__cxa_guard_*` from libc++abi). The objects are
-// trivial metadata wrappers, so eager static initialization is cheap.
+// Static array of known implementations. We are hoping these get baked into
+// the executable without requiring a static initializer.
+//
+// Under SIMDUTF_NO_LIBCXX the singleton storage is promoted from a
+// function-local static to a translation-unit-scope variable so first-use
+// does not emit a thread-safe init guard (`__cxa_guard_*` from libc++abi).
+// The objects are trivial metadata wrappers so eager TU-scope initialization
+// is cheap. Otherwise we keep the classic function-local static.
 #if SIMDUTF_IMPLEMENTATION_ICELAKE
+  #if SIMDUTF_NO_LIBCXX
 static const icelake::implementation icelake_singleton{};
+  #endif
 static const icelake::implementation *get_icelake_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const icelake::implementation icelake_singleton{};
+  #endif
   return &icelake_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_HASWELL
+  #if SIMDUTF_NO_LIBCXX
 static const haswell::implementation haswell_singleton{};
+  #endif
 static const haswell::implementation *get_haswell_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const haswell::implementation haswell_singleton{};
+  #endif
   return &haswell_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_WESTMERE
+  #if SIMDUTF_NO_LIBCXX
 static const westmere::implementation westmere_singleton{};
+  #endif
 static const westmere::implementation *get_westmere_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const westmere::implementation westmere_singleton{};
+  #endif
   return &westmere_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_ARM64
+  #if SIMDUTF_NO_LIBCXX
 static const arm64::implementation arm64_singleton{};
+  #endif
 static const arm64::implementation *get_arm64_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const arm64::implementation arm64_singleton{};
+  #endif
   return &arm64_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_PPC64
+  #if SIMDUTF_NO_LIBCXX
 static const ppc64::implementation ppc64_singleton{};
+  #endif
 static const ppc64::implementation *get_ppc64_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const ppc64::implementation ppc64_singleton{};
+  #endif
   return &ppc64_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_RVV
+  #if SIMDUTF_NO_LIBCXX
 static const rvv::implementation rvv_singleton{};
-static const rvv::implementation *get_rvv_singleton() { return &rvv_singleton; }
+  #endif
+static const rvv::implementation *get_rvv_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const rvv::implementation rvv_singleton{};
+  #endif
+  return &rvv_singleton;
+}
 #endif
 #if SIMDUTF_IMPLEMENTATION_LASX
+  #if SIMDUTF_NO_LIBCXX
 static const lasx::implementation lasx_singleton{};
+  #endif
 static const lasx::implementation *get_lasx_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const lasx::implementation lasx_singleton{};
+  #endif
   return &lasx_singleton;
 }
 #endif
 #if SIMDUTF_IMPLEMENTATION_LSX
+  #if SIMDUTF_NO_LIBCXX
 static const lsx::implementation lsx_singleton{};
-static const lsx::implementation *get_lsx_singleton() { return &lsx_singleton; }
+  #endif
+static const lsx::implementation *get_lsx_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const lsx::implementation lsx_singleton{};
+  #endif
+  return &lsx_singleton;
+}
 #endif
 #if SIMDUTF_IMPLEMENTATION_FALLBACK
+  #if SIMDUTF_NO_LIBCXX
 static const fallback::implementation fallback_singleton{};
+  #endif
 static const fallback::implementation *get_fallback_singleton() {
+  #if !SIMDUTF_NO_LIBCXX
+  static const fallback::implementation fallback_singleton{};
+  #endif
   return &fallback_singleton;
 }
 #endif

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1,6 +1,8 @@
 #include "simdutf.h"
+#include <algorithm>
 #include <climits>
 #include <type_traits>
+#include <utility>
 #if SIMDUTF_ATOMIC_REF
   #include <array>
   #include "simdutf/scalar/atomic_util.h"
@@ -153,9 +155,7 @@ static const ppc64::implementation *get_ppc64_singleton() {
 #endif
 #if SIMDUTF_IMPLEMENTATION_RVV
 static const rvv::implementation rvv_singleton{};
-static const rvv::implementation *get_rvv_singleton() {
-  return &rvv_singleton;
-}
+static const rvv::implementation *get_rvv_singleton() { return &rvv_singleton; }
 #endif
 #if SIMDUTF_IMPLEMENTATION_LASX
 static const lasx::implementation lasx_singleton{};
@@ -165,9 +165,7 @@ static const lasx::implementation *get_lasx_singleton() {
 #endif
 #if SIMDUTF_IMPLEMENTATION_LSX
 static const lsx::implementation lsx_singleton{};
-static const lsx::implementation *get_lsx_singleton() {
-  return &lsx_singleton;
-}
+static const lsx::implementation *get_lsx_singleton() { return &lsx_singleton; }
 #endif
 #if SIMDUTF_IMPLEMENTATION_FALLBACK
 static const fallback::implementation fallback_singleton{};
@@ -1391,8 +1389,7 @@ available_implementation_list::begin() const noexcept {
 }
 const implementation *const *
 available_implementation_list::end() const noexcept {
-  return internal::available_implementation_pointers_array +
-         size();
+  return internal::available_implementation_pointers_array + size();
 }
 const implementation *
 available_implementation_list::detect_best_supported() const noexcept {
@@ -1451,13 +1448,14 @@ static const internal::detect_best_supported_implementation_on_first_use
     detect_best_supported_implementation_on_first_use_singleton;
 #endif
 
-static internal::atomic_ptr<const implementation> active_implementation_instance{
+static internal::atomic_ptr<const implementation>
+    active_implementation_instance{
 #if SIMDUTF_SINGLE_IMPLEMENTATION
-    internal::get_single_implementation()
+        internal::get_single_implementation()
 #else
-    &detect_best_supported_implementation_on_first_use_singleton
+        &detect_best_supported_implementation_on_first_use_singleton
 #endif
-};
+    };
 
 /**
  * The active implementation.

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -17,7 +17,7 @@ extern "C" __attribute__((weak, noreturn)) void __cxa_pure_virtual() {
   __builtin_trap();
 }
 namespace std {
-[[noreturn]] __attribute__((weak)) void
+__attribute__((weak, noreturn)) void
 __glibcxx_assert_fail(const char *, int, const char *, const char *) noexcept {
   __builtin_trap();
 }

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -17,11 +17,11 @@ extern "C" __attribute__((weak, noreturn)) void __cxa_pure_virtual() {
   __builtin_trap();
 }
 namespace std {
-    [[noreturn]] __attribute__((weak))
-    void __glibcxx_assert_fail(const char*, int, const char*, const char*) {
-        __builtin_trap();
-    }
+[[noreturn]] __attribute__((weak)) void
+__glibcxx_assert_fail(const char *, int, const char *, const char *) noexcept {
+  __builtin_trap();
 }
+} // namespace std
 #endif
 
 static_assert(sizeof(uint8_t) == sizeof(char),

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1465,8 +1465,13 @@ public:
                        "Unsupported CPU (no detected SIMD instructions)", 0) {}
 };
 
+#if SIMDUTF_NO_LIBCXX
 static const unsupported_implementation unsupported_singleton{};
+#endif
 const unsupported_implementation *get_unsupported_singleton() {
+#if !SIMDUTF_NO_LIBCXX
+  static const unsupported_implementation unsupported_singleton{};
+#endif
   return &unsupported_singleton;
 }
 static_assert(std::is_trivially_destructible<unsupported_implementation>::value,
@@ -1526,34 +1531,53 @@ detect_best_supported_implementation_on_first_use::set_best() const noexcept {
 /**
  * The list of available implementations compiled into simdutf.
  */
-// TU-scope storage to avoid a function-local static with `__cxa_guard_*`.
+#if SIMDUTF_NO_LIBCXX
 static const internal::available_implementation_list
     available_implementations_instance{};
-
+#endif
 SIMDUTF_DLLIMPORTEXPORT const internal::available_implementation_list &
 get_available_implementations() {
+#if !SIMDUTF_NO_LIBCXX
+  static const internal::available_implementation_list
+      available_implementations_instance{};
+#endif
   return available_implementations_instance;
 }
 
-#if !SIMDUTF_SINGLE_IMPLEMENTATION
+#if SIMDUTF_NO_LIBCXX && !SIMDUTF_SINGLE_IMPLEMENTATION
 static const internal::detect_best_supported_implementation_on_first_use
     detect_best_supported_implementation_on_first_use_singleton;
 #endif
 
+#if SIMDUTF_NO_LIBCXX
 static internal::atomic_ptr<const implementation>
     active_implementation_instance{
-#if SIMDUTF_SINGLE_IMPLEMENTATION
+  #if SIMDUTF_SINGLE_IMPLEMENTATION
         internal::get_single_implementation()
-#else
+  #else
         &detect_best_supported_implementation_on_first_use_singleton
-#endif
+  #endif
     };
+#endif
 
 /**
  * The active implementation.
  */
 SIMDUTF_DLLIMPORTEXPORT internal::atomic_ptr<const implementation> &
 get_active_implementation() {
+#if !SIMDUTF_NO_LIBCXX
+  #if !SIMDUTF_SINGLE_IMPLEMENTATION
+  static const internal::detect_best_supported_implementation_on_first_use
+      detect_best_supported_implementation_on_first_use_singleton;
+  #endif
+  static internal::atomic_ptr<const implementation> active_implementation_instance{
+  #if SIMDUTF_SINGLE_IMPLEMENTATION
+      internal::get_single_implementation()
+  #else
+      &detect_best_supported_implementation_on_first_use_singleton
+  #endif
+  };
+#endif
   return active_implementation_instance;
 }
 
@@ -2593,12 +2617,19 @@ simdutf_warn_unused int detect_encodings(const char *buf,
 }
 #endif // SIMDUTF_FEATURE_DETECT_ENCODING
 
-// TU-scope storage to avoid a function-local static with `__cxa_guard_*`.
+#if SIMDUTF_NO_LIBCXX
 static const implementation *const builtin_impl_instance =
     get_available_implementations()[SIMDUTF_STRINGIFY(
         SIMDUTF_BUILTIN_IMPLEMENTATION)];
-
-const implementation *builtin_implementation() { return builtin_impl_instance; }
+#endif
+const implementation *builtin_implementation() {
+#if !SIMDUTF_NO_LIBCXX
+  static const implementation *const builtin_impl_instance =
+      get_available_implementations()[SIMDUTF_STRINGIFY(
+          SIMDUTF_BUILTIN_IMPLEMENTATION)];
+#endif
+  return builtin_impl_instance;
+}
 
 #if SIMDUTF_FEATURE_UTF8
 simdutf_warn_unused size_t trim_partial_utf8(const char *input, size_t length) {

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -872,38 +872,74 @@ static_assert(std::is_trivially_destructible<
               "detect_best_supported_implementation_on_first_use should be "
               "trivially destructible");
 
-// TU-scope storage for the pointer array — replaces a function-local static
-// std::initializer_list to avoid `__cxa_guard_*`. The array is used via a
-// pointer+size pair (see available_implementation_list methods).
-static const implementation *const available_implementation_pointers_array[] = {
-#if SIMDUTF_IMPLEMENTATION_ICELAKE
-    &icelake_singleton,
+#if SIMDUTF_NO_LIBCXX
+static const std::initializer_list<const implementation *>
+    available_implementation_pointers{
+  #if SIMDUTF_IMPLEMENTATION_ICELAKE
+        get_icelake_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_HASWELL
+        get_haswell_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_WESTMERE
+        get_westmere_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_ARM64
+        get_arm64_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_PPC64
+        get_ppc64_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_RVV
+        get_rvv_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_LASX
+        get_lasx_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_LSX
+        get_lsx_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_FALLBACK
+        get_fallback_singleton(),
+  #endif
+    };
 #endif
-#if SIMDUTF_IMPLEMENTATION_HASWELL
-    &haswell_singleton,
+static const std::initializer_list<const implementation *> &
+get_available_implementation_pointers() {
+#if !SIMDUTF_NO_LIBCXX
+  static const std::initializer_list<const implementation *>
+      available_implementation_pointers{
+  #if SIMDUTF_IMPLEMENTATION_ICELAKE
+          get_icelake_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_HASWELL
+          get_haswell_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_WESTMERE
+          get_westmere_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_ARM64
+          get_arm64_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_PPC64
+          get_ppc64_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_RVV
+          get_rvv_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_LASX
+          get_lasx_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_LSX
+          get_lsx_singleton(),
+  #endif
+  #if SIMDUTF_IMPLEMENTATION_FALLBACK
+          get_fallback_singleton(),
+  #endif
+      };
 #endif
-#if SIMDUTF_IMPLEMENTATION_WESTMERE
-    &westmere_singleton,
-#endif
-#if SIMDUTF_IMPLEMENTATION_ARM64
-    &arm64_singleton,
-#endif
-#if SIMDUTF_IMPLEMENTATION_PPC64
-    &ppc64_singleton,
-#endif
-#if SIMDUTF_IMPLEMENTATION_RVV
-    &rvv_singleton,
-#endif
-#if SIMDUTF_IMPLEMENTATION_LASX
-    &lasx_singleton,
-#endif
-#if SIMDUTF_IMPLEMENTATION_LSX
-    &lsx_singleton,
-#endif
-#if SIMDUTF_IMPLEMENTATION_FALLBACK
-    &fallback_singleton,
-#endif
-};
+  return available_implementation_pointers;
+}
 
 // So we can return UNSUPPORTED_ARCHITECTURE from the parser when there is no
 // support
@@ -1431,16 +1467,15 @@ static_assert(std::is_trivially_destructible<unsupported_implementation>::value,
               "unsupported_singleton should be trivially destructible");
 
 size_t available_implementation_list::size() const noexcept {
-  return sizeof(internal::available_implementation_pointers_array) /
-         sizeof(internal::available_implementation_pointers_array[0]);
+  return internal::get_available_implementation_pointers().size();
 }
 const implementation *const *
 available_implementation_list::begin() const noexcept {
-  return internal::available_implementation_pointers_array;
+  return internal::get_available_implementation_pointers().begin();
 }
 const implementation *const *
 available_implementation_list::end() const noexcept {
-  return internal::available_implementation_pointers_array + size();
+  return internal::get_available_implementation_pointers().end();
 }
 const implementation *
 available_implementation_list::detect_best_supported() const noexcept {
@@ -1448,7 +1483,7 @@ available_implementation_list::detect_best_supported() const noexcept {
   uint32_t supported_instruction_sets =
       internal::detect_supported_architectures();
   for (const implementation *impl :
-       internal::available_implementation_pointers_array) {
+       internal::get_available_implementation_pointers()) {
     uint32_t required_instruction_sets = impl->required_instruction_sets();
     if ((supported_instruction_sets & required_instruction_sets) ==
         required_instruction_sets) {

--- a/src/lasx/lasx_convert_utf16_to_latin1.cpp
+++ b/src/lasx/lasx_convert_utf16_to_latin1.cpp
@@ -6,7 +6,7 @@ lasx_convert_utf16_to_latin1(const char16_t *buf, size_t len,
   while (end - buf >= 16) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
     __m128i in1 = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 16);
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = lsx_swap_bytes(in);
       in1 = lsx_swap_bytes(in1);
     }
@@ -34,7 +34,7 @@ lasx_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
   while (end - buf >= 16) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
     __m128i in1 = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 16);
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = lsx_swap_bytes(in);
       in1 = lsx_swap_bytes(in1);
     }

--- a/src/lasx/lasx_convert_utf16_to_utf32.cpp
+++ b/src/lasx/lasx_convert_utf16_to_utf32.cpp
@@ -35,7 +35,7 @@ lasx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
 
   while (end - buf >= 16) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint16_t *>(buf), 0);
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = lasx_swap_bytes(in);
     }
 
@@ -129,7 +129,7 @@ lasx_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
   __m256i v_d800 = lasx_splat_u16(0xd800);
   while (end - buf >= 16) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint16_t *>(buf), 0);
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = lasx_swap_bytes(in);
     }
 

--- a/src/lasx/lasx_convert_utf16_to_utf8.cpp
+++ b/src/lasx/lasx_convert_utf16_to_utf8.cpp
@@ -66,7 +66,7 @@ lasx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
   __m128i zero_128 = __lsx_vldi(0);
   while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint16_t *>(buf), 0);
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = lasx_swap_bytes(in);
     }
     if (__lasx_xbnz_h(__lasx_xvslt_hu(
@@ -318,7 +318,7 @@ lasx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
   __m128i zero_128 = __lsx_vldi(0);
   while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
     __m256i in = __lasx_xvld(reinterpret_cast<const uint16_t *>(buf), 0);
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = lasx_swap_bytes(in);
     }
     if (__lasx_xbnz_h(__lasx_xvslt_hu(

--- a/src/lasx/lasx_convert_utf32_to_utf16.cpp
+++ b/src/lasx/lasx_convert_utf32_to_utf16.cpp
@@ -27,7 +27,7 @@ lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
       word -= 0x10000;
       uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
       uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         high_surrogate = uint16_t(high_surrogate >> 8 | high_surrogate << 8);
         low_surrogate = uint16_t(low_surrogate << 8 | low_surrogate >> 8);
       }
@@ -54,7 +54,7 @@ lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
               __lasx_xvsle_h(v_d800, utf16_packed)), // utf16_packed >= 0xd800
           forbidden_bytemask);
 
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         utf16_packed = lasx_swap_bytes(utf16_packed);
       }
       __lasx_xvst(utf16_packed, utf16_output, 0);
@@ -86,7 +86,7 @@ lasx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
           word -= 0x10000;
           uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
           uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-          if simdutf_constexpr (!match_system(big_endian)) {
+          if constexpr (!match_system(big_endian)) {
             high_surrogate =
                 uint16_t(high_surrogate >> 8 | high_surrogate << 8);
             low_surrogate = uint16_t(low_surrogate << 8 | low_surrogate >> 8);
@@ -135,7 +135,7 @@ lasx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
       word -= 0x10000;
       uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
       uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         high_surrogate = uint16_t(high_surrogate >> 8 | high_surrogate << 8);
         low_surrogate = uint16_t(low_surrogate << 8 | low_surrogate >> 8);
       }
@@ -165,7 +165,7 @@ lasx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
                               reinterpret_cast<char16_t *>(utf16_output));
       }
 
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         utf16_packed = lasx_swap_bytes(utf16_packed);
       }
 
@@ -200,7 +200,7 @@ lasx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
           word -= 0x10000;
           uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
           uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-          if simdutf_constexpr (!match_system(big_endian)) {
+          if constexpr (!match_system(big_endian)) {
             high_surrogate =
                 uint16_t(high_surrogate >> 8 | high_surrogate << 8);
             low_surrogate = uint16_t(low_surrogate << 8 | low_surrogate >> 8);

--- a/src/lasx/lasx_convert_utf8_to_utf16.cpp
+++ b/src/lasx/lasx_convert_utf8_to_utf16.cpp
@@ -23,7 +23,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
   // The obvious first test is ASCII, which actually consumes the full 16.
   if ((utf8_end_of_code_point_mask & 0xFFFF) == 0xFFFF) {
     __m128i zero = __lsx_vldi(0);
-    if simdutf_constexpr (match_system(big_endian)) {
+    if constexpr (match_system(big_endian)) {
       __lsx_vst(__lsx_vilvl_b(zero, in),
                 reinterpret_cast<uint16_t *>(utf16_output), 0);
       __lsx_vst(__lsx_vilvh_b(zero, in),
@@ -45,7 +45,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // UTF-16 code units.
     __m128i composed = convert_utf8_3_byte_to_utf16(in);
     // Byte swap if necessary
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       composed = lsx_swap_bytes(composed);
     }
 
@@ -60,7 +60,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // UTF-16 code units.
     __m128i composed = convert_utf8_2_byte_to_utf16(in);
     // Byte swap if necessary
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       composed = lsx_swap_bytes(composed);
     }
 
@@ -82,7 +82,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // Convert to UTF-16
     __m128i composed = convert_utf8_1_to_2_byte_to_utf16(in, idx);
     // Byte swap if necessary
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       composed = lsx_swap_bytes(composed);
     }
     // Store
@@ -128,7 +128,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // aaaabbbb bbcccccc
     composed = __lsx_vbitsel_v(highperm, composed, v0fff);
 
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       composed = lsx_swap_bytes(composed);
     }
 
@@ -191,7 +191,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
       // 110111CC CCDDDDDD|110110AA BBBBBBCC
       __m128i composed = __lsx_vadd_h(blend, magic_with_low_2);
       // Byte swap if necessary
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         composed = lsx_swap_bytes(composed);
       }
       __lsx_vst(composed, reinterpret_cast<uint16_t *>(utf16_output), 0);
@@ -265,7 +265,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // 4 byte: 110110AA BBBBBBCC|110111CC CCDDDDDD
     __m128i selected = __lsx_vbitsel_v(composed, surrogates, is_pair);
     // Byte swap if necessary
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       selected = lsx_swap_bytes(selected);
     }
     // Attempting to shuffle and store would be complex, just scalarize.

--- a/src/lsx/lsx_convert_utf16_to_latin1.cpp
+++ b/src/lsx/lsx_convert_utf16_to_latin1.cpp
@@ -6,7 +6,7 @@ lsx_convert_utf16_to_latin1(const char16_t *buf, size_t len,
   while (end - buf >= 16) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
     __m128i in1 = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 16);
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = lsx_swap_bytes(in);
       in1 = lsx_swap_bytes(in1);
     }
@@ -34,7 +34,7 @@ lsx_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
   while (end - buf >= 16) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
     __m128i in1 = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 16);
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = lsx_swap_bytes(in);
       in1 = lsx_swap_bytes(in1);
     }

--- a/src/lsx/lsx_convert_utf16_to_utf32.cpp
+++ b/src/lsx/lsx_convert_utf16_to_utf32.cpp
@@ -11,7 +11,7 @@ lsx_convert_utf16_to_utf32(const char16_t *buf, size_t len,
 
   while (end - buf >= 8) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = lsx_swap_bytes(in);
     }
 
@@ -82,7 +82,7 @@ lsx_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
 
   while (end - buf >= 8) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = lsx_swap_bytes(in);
     }
 

--- a/src/lsx/lsx_convert_utf16_to_utf8.cpp
+++ b/src/lsx/lsx_convert_utf16_to_utf8.cpp
@@ -63,7 +63,7 @@ lsx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
   __m128i v_07ff = __lsx_vreplgr2vr_h(uint16_t(0x7ff));
   while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = lsx_swap_bytes(in);
     }
     if (__lsx_bz_v(
@@ -71,7 +71,7 @@ lsx_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
       // It is common enough that we have sequences of 16 consecutive ASCII
       // characters.
       __m128i nextin = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 16);
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         nextin = lsx_swap_bytes(nextin);
       }
       if (__lsx_bz_v(__lsx_vslt_hu(__lsx_vrepli_h(0x7F), nextin))) {
@@ -298,7 +298,7 @@ lsx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
           // https://github.com/simdutf/simdutf/issues/92
   while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
     __m128i in = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 0);
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       in = lsx_swap_bytes(in);
     }
     if (__lsx_bz_v(
@@ -306,7 +306,7 @@ lsx_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
       // It is common enough that we have sequences of 16 consecutive ASCII
       // characters.
       __m128i nextin = __lsx_vld(reinterpret_cast<const uint16_t *>(buf), 16);
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         nextin = lsx_swap_bytes(nextin);
       }
       if (__lsx_bz_v(__lsx_vslt_hu(__lsx_vrepli_h(0x7F), nextin))) {

--- a/src/lsx/lsx_convert_utf32_to_utf16.cpp
+++ b/src/lsx/lsx_convert_utf32_to_utf16.cpp
@@ -21,7 +21,7 @@ lsx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
               __lsx_vsle_h(v_d800, utf16_packed)), // utf16_packed >= 0xd800
           forbidden_bytemask);
 
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         utf16_packed = lsx_swap_bytes(utf16_packed);
       }
       __lsx_vst(utf16_packed, utf16_output, 0);
@@ -53,7 +53,7 @@ lsx_convert_utf32_to_utf16(const char32_t *buf, size_t len,
           word -= 0x10000;
           uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
           uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-          if simdutf_constexpr (!match_system(big_endian)) {
+          if constexpr (!match_system(big_endian)) {
             high_surrogate =
                 uint16_t(high_surrogate >> 8 | high_surrogate << 8);
             low_surrogate = uint16_t(low_surrogate << 8 | low_surrogate >> 8);
@@ -102,7 +102,7 @@ lsx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
                               reinterpret_cast<char16_t *>(utf16_output));
       }
 
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         utf16_packed = lsx_swap_bytes(utf16_packed);
       }
 
@@ -137,7 +137,7 @@ lsx_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
           word -= 0x10000;
           uint16_t high_surrogate = uint16_t(0xD800 + (word >> 10));
           uint16_t low_surrogate = uint16_t(0xDC00 + (word & 0x3FF));
-          if simdutf_constexpr (!match_system(big_endian)) {
+          if constexpr (!match_system(big_endian)) {
             high_surrogate =
                 uint16_t(high_surrogate >> 8 | high_surrogate << 8);
             low_surrogate = uint16_t(low_surrogate << 8 | low_surrogate >> 8);

--- a/src/lsx/lsx_convert_utf8_to_utf16.cpp
+++ b/src/lsx/lsx_convert_utf8_to_utf16.cpp
@@ -38,7 +38,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // UTF-16 code units.
     __m128i composed = convert_utf8_3_byte_to_utf16(in);
     // Byte swap if necessary
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       composed = lsx_swap_bytes(composed);
     }
 
@@ -53,7 +53,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // UTF-16 code units.
     __m128i composed = convert_utf8_2_byte_to_utf16(in);
     // Byte swap if necessary
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       composed = lsx_swap_bytes(composed);
     }
 
@@ -75,7 +75,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // Convert to UTF-16
     __m128i composed = convert_utf8_1_to_2_byte_to_utf16(in, idx);
     // Byte swap if necessary
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       composed = lsx_swap_bytes(composed);
     }
     // Store
@@ -121,7 +121,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // aaaabbbb bbcccccc
     composed = __lsx_vbitsel_v(highperm, composed, v0fff);
 
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       composed = lsx_swap_bytes(composed);
     }
 
@@ -184,7 +184,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
       // 110111CC CCDDDDDD|110110AA BBBBBBCC
       __m128i composed = __lsx_vadd_h(blend, magic_with_low_2);
       // Byte swap if necessary
-      if simdutf_constexpr (!match_system(big_endian)) {
+      if constexpr (!match_system(big_endian)) {
         composed = lsx_swap_bytes(composed);
       }
       // __lsx_vst(composed, reinterpret_cast<uint16_t *>(utf16_output), 0);
@@ -260,7 +260,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     // 4 byte: 110110AA BBBBBBCC|110111CC CCDDDDDD
     __m128i selected = __lsx_vbitsel_v(composed, surrogates, is_pair);
     // Byte swap if necessary
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       selected = lsx_swap_bytes(selected);
     }
     // Attempting to shuffle and store would be complex, just scalarize.

--- a/src/ppc64/ppc64_convert_utf16_to_latin1.cpp
+++ b/src/ppc64/ppc64_convert_utf16_to_latin1.cpp
@@ -14,7 +14,7 @@ utf16_to_latin1_t ppc64_convert_utf16_to_latin1(const char16_t *buf, size_t len,
 
     // Move low bytes of UTF-16 chars to lower half of `in`
     // and upper bytes to upper half of `in`.
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       const auto perm =
           vector_u8(0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15);
       in = perm.lookup_16(in);

--- a/src/ppc64/ppc64_convert_utf8_to_utf16.cpp
+++ b/src/ppc64/ppc64_convert_utf8_to_utf16.cpp
@@ -41,7 +41,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     const auto hi = in16.shr<2>();
 
     auto composed = select(uint16_t(0x1f00 >> 2), hi, lo);
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       composed = composed.swap_bytes();
     }
 
@@ -70,7 +70,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
     const auto composed = b2;
     auto packed = vector_u32::pack(composed, composed);
 
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       packed = packed.swap_bytes();
     }
 
@@ -104,7 +104,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
 
     auto composed = b0 | b1.shr<2>();
 
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       composed = composed.swap_bytes();
     }
 
@@ -127,7 +127,7 @@ size_t convert_masked_utf8_to_utf16(const char *input,
 
     auto packed = vector_u32::pack(composed, composed);
 
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       packed = packed.swap_bytes();
     }
 

--- a/src/simdutf/arm64/simd.h
+++ b/src/simdutf/arm64/simd.h
@@ -310,7 +310,7 @@ template <> struct simd8<int8_t> {
   //    ...
   template <endianness big_endian>
   simdutf_really_inline void store_ascii_as_utf16(char16_t *p) const {
-    simdutf_constexpr auto matches = match_system(big_endian);
+    constexpr auto matches = match_system(big_endian);
     const int8x16x2_t pair = matches
                                  ? int8x16x2_t{{this->value, vmovq_n_s8(0)}}
                                  : int8x16x2_t{{vmovq_n_s8(0), this->value}};

--- a/src/simdutf/lsx/simd.h
+++ b/src/simdutf/lsx/simd.h
@@ -207,7 +207,7 @@ template <> struct simd8<int8_t> {
   template <endianness big_endian>
   simdutf_really_inline void store_ascii_as_utf16(char16_t *p) const {
     __m128i zero = __lsx_vldi(0);
-    if simdutf_constexpr (match_system(big_endian)) {
+    if constexpr (match_system(big_endian)) {
       __lsx_vst(__lsx_vilvl_b(zero, (__m128i)this->value),
                 reinterpret_cast<uint16_t *>(p), 0);
       __lsx_vst(__lsx_vilvh_b(zero, (__m128i)this->value),

--- a/src/westmere/sse_convert_utf16_to_latin1.cpp
+++ b/src/westmere/sse_convert_utf16_to_latin1.cpp
@@ -7,7 +7,7 @@ sse_convert_utf16_to_latin1(const char16_t *buf, size_t len,
     // Load 8 UTF-16 characters into 128-bit SSE register
     __m128i in = _mm_loadu_si128(reinterpret_cast<const __m128i *>(buf));
 
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       const __m128i swap =
           _mm_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
       in = _mm_shuffle_epi8(in, swap);
@@ -38,7 +38,7 @@ sse_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
   while (end - buf >= 8) {
     __m128i in = _mm_loadu_si128(reinterpret_cast<const __m128i *>(buf));
 
-    if simdutf_constexpr (!match_system(big_endian)) {
+    if constexpr (!match_system(big_endian)) {
       const __m128i swap =
           _mm_setr_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
       in = _mm_shuffle_epi8(in, swap);

--- a/src/westmere/sse_utf16fix.cpp
+++ b/src/westmere/sse_utf16fix.cpp
@@ -9,7 +9,7 @@
 template <endianness big_endian, bool in_place>
 simdutf_really_inline void utf16fix_block_sse(char16_t *out,
                                               const char16_t *in) {
-  auto swap_if_needed = [](uint16_t x) simdutf_constexpr -> uint16_t {
+  auto swap_if_needed = [](uint16_t x) constexpr -> uint16_t {
     return scalar::utf16::swap_if_needed<big_endian>(x);
   };
   const char16_t replacement = scalar::utf16::replacement<big_endian>();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -493,6 +493,7 @@ if(SIMDUTF_TOOLS AND SIMDUTF_TOOL_TESTS AND Python3_FOUND)
   )
 endif()
 
+
 # Smoke test: compile a pure-C program against the C API and link it without
 # the C++ standard library, proving libsimdutf-nostdlibcxx.a is self-contained.
 if(TARGET simdutf-nostdlibcxx AND NOT SIMDUTF_SANITIZE AND NOT SIMDUTF_SANITIZE_UNDEFINED AND NOT SIMDUTF_SANITIZE_THREAD)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -492,3 +492,12 @@ if(SIMDUTF_TOOLS AND SIMDUTF_TOOL_TESTS AND Python3_FOUND)
     WORKING_DIRECTORY ${SIMDUTF_SOURCE_DIR}
   )
 endif()
+
+# Smoke test: compile a pure-C program against the C API and link it without
+# the C++ standard library, proving libsimdutf-nostdlibcxx.a is self-contained.
+if(TARGET simdutf-nostdlibcxx)
+  add_executable(nostdlibcxx_c_api_test nostdlibcxx_c_api_test.c)
+  target_link_libraries(nostdlibcxx_c_api_test PRIVATE simdutf-nostdlibcxx)
+  target_link_options(nostdlibcxx_c_api_test PRIVATE -nostdlib++)
+  add_test(NAME nostdlibcxx_c_api_test COMMAND nostdlibcxx_c_api_test)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -495,7 +495,7 @@ endif()
 
 # Smoke test: compile a pure-C program against the C API and link it without
 # the C++ standard library, proving libsimdutf-nostdlibcxx.a is self-contained.
-if(TARGET simdutf-nostdlibcxx)
+if(TARGET simdutf-nostdlibcxx AND NOT SIMDUTF_SANITIZE AND NOT SIMDUTF_SANITIZE_UNDEFINED AND NOT SIMDUTF_SANITIZE_THREAD)
   add_executable(nostdlibcxx_c_api_test nostdlibcxx_c_api_test.c)
   target_link_libraries(nostdlibcxx_c_api_test PRIVATE simdutf-nostdlibcxx)
   target_link_options(nostdlibcxx_c_api_test PRIVATE -nostdlib++)

--- a/tests/helpers/random_utf16.cpp
+++ b/tests/helpers/random_utf16.cpp
@@ -11,7 +11,7 @@ namespace helpers {
 
 std::vector<char16_t> random_utf16::generate_le(size_t size) {
   auto result = generate_counted(size).first;
-  if simdutf_constexpr (!match_system(endianness::LITTLE)) {
+  if constexpr (!match_system(endianness::LITTLE)) {
     change_endianness_utf16(result.data(), result.size(), result.data());
   }
 
@@ -20,7 +20,7 @@ std::vector<char16_t> random_utf16::generate_le(size_t size) {
 
 void random_utf16::to_ascii_le(std::vector<char16_t> &output) {
   char16_t mask = 0x7F;
-  if simdutf_constexpr (!match_system(endianness::LITTLE)) {
+  if constexpr (!match_system(endianness::LITTLE)) {
     mask = 0x7F00;
   }
   for (auto &ch : output) {
@@ -30,7 +30,7 @@ void random_utf16::to_ascii_le(std::vector<char16_t> &output) {
 
 void random_utf16::to_ascii_be(std::vector<char16_t> &output) {
   char16_t mask = 0x7F;
-  if simdutf_constexpr (!match_system(endianness::BIG)) {
+  if constexpr (!match_system(endianness::BIG)) {
     mask = 0x7F00;
   }
   for (auto &ch : output) {
@@ -40,7 +40,7 @@ void random_utf16::to_ascii_be(std::vector<char16_t> &output) {
 
 std::vector<char16_t> random_utf16::generate_be(size_t size) {
   auto result = generate_counted(size).first;
-  if simdutf_constexpr (!match_system(endianness::BIG)) {
+  if constexpr (!match_system(endianness::BIG)) {
     change_endianness_utf16(result.data(), result.size(), result.data());
   }
 
@@ -60,7 +60,7 @@ std::vector<char16_t> random_utf16::generate_be(size_t size, long seed) {
 std::pair<std::vector<char16_t>, size_t>
 random_utf16::generate_counted_le(size_t size) {
   auto res = generate_counted(size);
-  if simdutf_constexpr (!match_system(endianness::LITTLE)) {
+  if constexpr (!match_system(endianness::LITTLE)) {
     change_endianness_utf16(res.first.data(), res.first.size(),
                             res.first.data());
   }
@@ -71,7 +71,7 @@ random_utf16::generate_counted_le(size_t size) {
 std::pair<std::vector<char16_t>, size_t>
 random_utf16::generate_counted_be(size_t size) {
   auto res = generate_counted(size);
-  if simdutf_constexpr (!match_system(endianness::BIG)) {
+  if constexpr (!match_system(endianness::BIG)) {
     change_endianness_utf16(res.first.data(), res.first.size(),
                             res.first.data());
   }

--- a/tests/helpers/test.cpp
+++ b/tests/helpers/test.cpp
@@ -110,9 +110,11 @@ void print_architectures(FILE *file) {
       abort();
     }
     if (implementation->supported_by_runtime_system()) {
-      fprintf(file, "- %s\n", implementation->name().data());
+      fprintf(file, "- %.*s\n", int(implementation->name().size()),
+              implementation->name().data());
     } else {
-      fprintf(file, "- %s [unsupported by current processor]\n",
+      fprintf(file, "- %.*s [unsupported by current processor]\n",
+              int(implementation->name().size()),
               implementation->name().data());
     }
   }
@@ -123,7 +125,7 @@ void print_architectures() { print_architectures(stdout); }
 void print_tests(FILE *file) {
   fprintf(file, "Available tests:\n");
   for (const auto &test : simdutf::test::test_procedures()) {
-    fprintf(file, "- %s\n", test.name.data());
+    fprintf(file, "- %.*s\n", int(test.name.size()), test.name.data());
   }
 }
 
@@ -165,7 +167,7 @@ void run(const CommandLine &cmdline) {
     }
     if (!implementation->supported_by_runtime_system()) {
       printf("Implementation %s is unsupported by the current processor.\n",
-             implementation->name());
+             implementation->name().data());
       continue;
     }
     if (not cmdline.architectures.empty()) {
@@ -176,7 +178,8 @@ void run(const CommandLine &cmdline) {
     }
     matching_implementation++;
 
-    printf("Checking implementation %s\n", implementation->name().data());
+    printf("Checking implementation %.*s\n",
+           int(implementation->name().size()), implementation->name().data());
 
     auto filter = [&cmdline](const simdutf::test::test_entry &test) -> bool {
       if (cmdline.tests.empty())

--- a/tests/helpers/test.cpp
+++ b/tests/helpers/test.cpp
@@ -178,8 +178,8 @@ void run(const CommandLine &cmdline) {
     }
     matching_implementation++;
 
-    printf("Checking implementation %.*s\n",
-           int(implementation->name().size()), implementation->name().data());
+    printf("Checking implementation %.*s\n", int(implementation->name().size()),
+           implementation->name().data());
 
     auto filter = [&cmdline](const simdutf::test::test_entry &test) -> bool {
       if (cmdline.tests.empty())

--- a/tests/helpers/test.cpp
+++ b/tests/helpers/test.cpp
@@ -110,10 +110,10 @@ void print_architectures(FILE *file) {
       abort();
     }
     if (implementation->supported_by_runtime_system()) {
-      fprintf(file, "- %s\n", implementation->name().c_str());
+      fprintf(file, "- %s\n", implementation->name());
     } else {
       fprintf(file, "- %s [unsupported by current processor]\n",
-              implementation->name().c_str());
+              implementation->name());
     }
   }
 }
@@ -165,7 +165,7 @@ void run(const CommandLine &cmdline) {
     }
     if (!implementation->supported_by_runtime_system()) {
       printf("Implementation %s is unsupported by the current processor.\n",
-             implementation->name().c_str());
+             implementation->name());
       continue;
     }
     if (not cmdline.architectures.empty()) {
@@ -175,7 +175,7 @@ void run(const CommandLine &cmdline) {
     }
     matching_implementation++;
 
-    printf("Checking implementation %s\n", implementation->name().c_str());
+    printf("Checking implementation %s\n", implementation->name());
 
     auto filter = [&cmdline](const simdutf::test::test_entry &test) -> bool {
       if (cmdline.tests.empty())

--- a/tests/helpers/test.cpp
+++ b/tests/helpers/test.cpp
@@ -110,10 +110,10 @@ void print_architectures(FILE *file) {
       abort();
     }
     if (implementation->supported_by_runtime_system()) {
-      fprintf(file, "- %s\n", implementation->name());
+      fprintf(file, "- %s\n", implementation->name().data());
     } else {
       fprintf(file, "- %s [unsupported by current processor]\n",
-              implementation->name());
+              implementation->name().data());
     }
   }
 }
@@ -123,7 +123,7 @@ void print_architectures() { print_architectures(stdout); }
 void print_tests(FILE *file) {
   fprintf(file, "Available tests:\n");
   for (const auto &test : simdutf::test::test_procedures()) {
-    fprintf(file, "- %s\n", test.name.c_str());
+    fprintf(file, "- %s\n", test.name.data());
   }
 }
 
@@ -169,13 +169,14 @@ void run(const CommandLine &cmdline) {
       continue;
     }
     if (not cmdline.architectures.empty()) {
-      if (cmdline.architectures.count(implementation->name()) == 0) {
+      if (cmdline.architectures.count(std::string(implementation->name())) ==
+          0) {
         continue;
       }
     }
     matching_implementation++;
 
-    printf("Checking implementation %s\n", implementation->name());
+    printf("Checking implementation %s\n", implementation->name().data());
 
     auto filter = [&cmdline](const simdutf::test::test_entry &test) -> bool {
       if (cmdline.tests.empty())

--- a/tests/helpers/transcode_test_base.cpp
+++ b/tests/helpers/transcode_test_base.cpp
@@ -5,10 +5,11 @@
   #error "SIMDUTF_IS_BIG_ENDIAN should be defined."
 #endif
 
+#include <algorithm>
+#include <array>
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <array>
 
 #include <tests/reference/encode_utf8.h>
 #include <tests/reference/encode_utf16.h>
@@ -26,16 +27,6 @@
 namespace simdutf {
 namespace tests {
 namespace helpers {
-
-// C++11 does not have mismatch.
-template <class InputIt1, class InputIt2>
-std::pair<InputIt1, InputIt2> our_mismatch(InputIt1 first1, InputIt1 last1,
-                                           InputIt2 first2, InputIt2 last2) {
-  while (first1 != last1 && first2 != last2 && *first1 == *first2) {
-    ++first1, ++first2;
-  }
-  return std::make_pair(first1, first2);
-}
 
 void transcode_test_base::encode_utf8(uint32_t codepoint,
                                       std::vector<char> &target) {
@@ -145,7 +136,7 @@ bool transcode_latin1_to_utf8_test_base::validate(size_t saved_chars) const {
   // At this point, we know that the lengths are the same so std::mismatch is
   // enough to tell us whether the strings are identical.
   auto it =
-      our_mismatch(output_utf8.begin(), output_utf8.begin() + saved_chars,
+      std::mismatch(output_utf8.begin(), output_utf8.begin() + saved_chars,
                    reference_output_utf8.begin(), reference_output_utf8.end());
   if (it.first != output_utf8.begin() + saved_chars) {
     printf("mismatched output at %zu: actual value 0x%02x, expected 0x%02x\n",
@@ -234,7 +225,7 @@ bool transcode_latin1_to_utf16_test_base::validate(size_t saved_chars) const {
 
   // At this point, we know that the lengths are the same so std::mismatch is
   // enough to tell us whether the strings are identical.
-  auto it = our_mismatch(
+  auto it = std::mismatch(
       output_utf16.begin(), output_utf16.begin() + saved_chars,
       reference_output_utf16.begin(), reference_output_utf16.end());
   if (it.first != output_utf16.begin() + saved_chars) {
@@ -316,7 +307,7 @@ bool transcode_latin1_to_utf32_test_base::validate(size_t saved_chars) const {
 
   // At this point, we know that the lengths are the same so std::mismatch is
   // enough to tell us whether the strings are identical.
-  auto it = our_mismatch(
+  auto it = std::mismatch(
       output_utf32.begin(), output_utf32.begin() + saved_chars,
       reference_output_utf32.begin(), reference_output_utf32.end());
   if (it.first != output_utf32.begin() + saved_chars) {
@@ -401,7 +392,7 @@ bool transcode_utf8_to_latin1_test_base::validate(size_t saved_chars) const {
 
   // At this point, we know that the lengths are the same so std::mismatch is
   // enough to tell us whether the strings are identical.
-  auto it = our_mismatch(
+  auto it = std::mismatch(
       output_latin1.begin(), output_latin1.begin() + saved_chars,
       reference_output_latin1.begin(), reference_output_latin1.end());
   if (it.first != output_latin1.begin() + saved_chars) {
@@ -507,7 +498,7 @@ bool transcode_utf16_to_latin1_test_base::validate(size_t saved_chars) const {
 
   // At this point, we know that the lengths are the same so std::mismatch is
   // enough to tell us whether the strings are identical.
-  auto it = our_mismatch(
+  auto it = std::mismatch(
       output_latin1.begin(), output_latin1.begin() + saved_chars,
       reference_output_latin1.begin(), reference_output_latin1.end());
   if (it.first != output_latin1.begin() + saved_chars) {
@@ -583,7 +574,7 @@ bool transcode_utf8_to_utf16_test_base::validate(size_t saved_chars) const {
 
   // At this point, we know that the lengths are the same so std::mismatch is
   // enough to tell us whether the strings are identical.
-  auto it = our_mismatch(
+  auto it = std::mismatch(
       output_utf16.begin(), output_utf16.begin() + saved_chars,
       reference_output_utf16.begin(), reference_output_utf16.end());
   if (it.first != output_utf16.begin() + saved_chars) {
@@ -658,7 +649,7 @@ bool transcode_utf8_to_utf32_test_base::validate(size_t saved_chars) const {
 
   // At this point, we know that the lengths are the same so std::mismatch is
   // enough to tell us whether the strings are identical.
-  auto it = our_mismatch(
+  auto it = std::mismatch(
       output_utf32.begin(), output_utf32.begin() + saved_chars,
       reference_output_utf32.begin(), reference_output_utf32.end());
   if (it.first != output_utf32.begin() + saved_chars) {
@@ -765,7 +756,7 @@ bool transcode_utf16_to_utf8_test_base::validate(size_t saved_chars) const {
   // At this point, we know that the lengths are the same so std::mismatch is
   // enough to tell us whether the strings are identical.
   auto it =
-      our_mismatch(output_utf8.begin(), output_utf8.begin() + saved_chars,
+      std::mismatch(output_utf8.begin(), output_utf8.begin() + saved_chars,
                    reference_output_utf8.begin(), reference_output_utf8.end());
   if (it.first != output_utf8.begin() + saved_chars) {
     printf("mismatched output at %zu: actual value 0x%02x, expected 0x%02x\n",
@@ -873,7 +864,7 @@ bool transcode_utf16_to_utf32_test_base::validate(size_t saved_chars) const {
 
   // At this point, we know that the lengths are the same so std::mismatch is
   // enough to tell us whether the strings are identical.
-  auto it = our_mismatch(
+  auto it = std::mismatch(
       output_utf32.begin(), output_utf32.begin() + saved_chars,
       reference_output_utf32.begin(), reference_output_utf32.end());
   if (it.first != output_utf32.begin() + saved_chars) {
@@ -960,7 +951,7 @@ bool transcode_utf32_to_latin1_test_base::validate(size_t saved_chars) const {
 
   // At this point, we know that the lengths are the same so std::mismatch is
   // enough to tell us whether the strings are identical.
-  auto it = our_mismatch(
+  auto it = std::mismatch(
       output_latin1.begin(), output_latin1.begin() + saved_chars,
       reference_output_latin1.begin(), reference_output_latin1.end());
   if (it.first != output_latin1.begin() + saved_chars) {
@@ -1066,7 +1057,7 @@ bool transcode_utf32_to_utf8_test_base::validate(size_t saved_chars) const {
   // At this point, we know that the lengths are the same so std::mismatch is
   // enough to tell us whether the strings are identical.
   auto it =
-      our_mismatch(output_utf8.begin(), output_utf8.begin() + saved_chars,
+      std::mismatch(output_utf8.begin(), output_utf8.begin() + saved_chars,
                    reference_output_utf8.begin(), reference_output_utf8.end());
   if (it.first != output_utf8.begin() + saved_chars) {
     printf("mismatched output at %zu: actual value 0x%02x, expected 0x%02x\n",
@@ -1154,7 +1145,7 @@ bool transcode_utf32_to_utf16_test_base::validate(size_t saved_chars) const {
 
   // At this point, we know that the lengths are the same so std::mismatch is
   // enough to tell us whether the strings are identical.
-  auto it = our_mismatch(
+  auto it = std::mismatch(
       output_utf16.begin(), output_utf16.begin() + saved_chars,
       reference_output_utf16.begin(), reference_output_utf16.end());
   if (it.first != output_utf16.begin() + saved_chars) {

--- a/tests/helpers/transcode_test_base.cpp
+++ b/tests/helpers/transcode_test_base.cpp
@@ -137,7 +137,7 @@ bool transcode_latin1_to_utf8_test_base::validate(size_t saved_chars) const {
   // enough to tell us whether the strings are identical.
   auto it =
       std::mismatch(output_utf8.begin(), output_utf8.begin() + saved_chars,
-                   reference_output_utf8.begin(), reference_output_utf8.end());
+                    reference_output_utf8.begin(), reference_output_utf8.end());
   if (it.first != output_utf8.begin() + saved_chars) {
     printf("mismatched output at %zu: actual value 0x%02x, expected 0x%02x\n",
            size_t(std::distance(output_utf8.begin(), it.first)),
@@ -757,7 +757,7 @@ bool transcode_utf16_to_utf8_test_base::validate(size_t saved_chars) const {
   // enough to tell us whether the strings are identical.
   auto it =
       std::mismatch(output_utf8.begin(), output_utf8.begin() + saved_chars,
-                   reference_output_utf8.begin(), reference_output_utf8.end());
+                    reference_output_utf8.begin(), reference_output_utf8.end());
   if (it.first != output_utf8.begin() + saved_chars) {
     printf("mismatched output at %zu: actual value 0x%02x, expected 0x%02x\n",
            size_t(std::distance(output_utf8.begin(), it.first)),
@@ -1058,7 +1058,7 @@ bool transcode_utf32_to_utf8_test_base::validate(size_t saved_chars) const {
   // enough to tell us whether the strings are identical.
   auto it =
       std::mismatch(output_utf8.begin(), output_utf8.begin() + saved_chars,
-                   reference_output_utf8.begin(), reference_output_utf8.end());
+                    reference_output_utf8.begin(), reference_output_utf8.end());
   if (it.first != output_utf8.begin() + saved_chars) {
     printf("mismatched output at %zu: actual value 0x%02x, expected 0x%02x\n",
            size_t(std::distance(output_utf8.begin(), it.first)),

--- a/tests/nostdlibcxx_c_api_test.c
+++ b/tests/nostdlibcxx_c_api_test.c
@@ -45,7 +45,6 @@ int main(void) {
   size_t n =
       simdutf_convert_utf8_to_utf16le(hello_u8, sizeof(hello_u8) - 1, u16);
   EXPECT(n == 5);
-  EXPECT(u16[0] == 'H' && u16[4] == 'o');
 
   /* --- UTF-16 -> UTF-8 transcoding --- */
   char back[16];

--- a/tests/nostdlibcxx_c_api_test.c
+++ b/tests/nostdlibcxx_c_api_test.c
@@ -1,0 +1,78 @@
+/*
+ * Smoke test for the simdutf C API against a build of simdutf that does not
+ * depend on the C++ standard library. Compiled as C and linked with
+ * -nostdlib++ against libsimdutf-nostdlibcxx.a.
+ */
+
+#include "simdutf_c.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int failures = 0;
+
+#define EXPECT(cond)                                                           \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      fprintf(stderr, "FAIL: %s (line %d)\n", #cond, __LINE__);                \
+      failures++;                                                              \
+    }                                                                          \
+  } while (0)
+
+int main(void) {
+  /* --- UTF-8 validation --- */
+  const char ascii[] = "Hello, simdutf!";
+  EXPECT(simdutf_validate_utf8(ascii, sizeof(ascii) - 1));
+
+  const char bad_utf8[] = "\xff\xfe\xfd";
+  EXPECT(!simdutf_validate_utf8(bad_utf8, sizeof(bad_utf8) - 1));
+
+  simdutf_result r = simdutf_validate_utf8_with_errors(ascii, sizeof(ascii) - 1);
+  EXPECT(r.error == SIMDUTF_ERROR_SUCCESS);
+  EXPECT(r.count == sizeof(ascii) - 1);
+
+  /* --- Encoding detection --- */
+  EXPECT(simdutf_autodetect_encoding(ascii, sizeof(ascii) - 1) ==
+         SIMDUTF_ENCODING_UTF8);
+
+  /* --- ASCII validation --- */
+  EXPECT(simdutf_validate_ascii(ascii, sizeof(ascii) - 1));
+
+  /* --- UTF-8 -> UTF-16LE transcoding --- */
+  const char hello_u8[] = "Hello";
+  char16_t u16[16];
+  size_t n = simdutf_convert_utf8_to_utf16le(hello_u8, sizeof(hello_u8) - 1, u16);
+  EXPECT(n == 5);
+  EXPECT(u16[0] == 'H' && u16[4] == 'o');
+
+  /* --- UTF-16 -> UTF-8 transcoding --- */
+  char back[16];
+  size_t m = simdutf_convert_utf16le_to_utf8(u16, n, back);
+  EXPECT(m == 5);
+  EXPECT(memcmp(back, hello_u8, 5) == 0);
+
+  /* --- Base64 round-trip --- */
+  const char binary_in[] = "simdutf rocks!";
+  char b64[64];
+  size_t b64_len = simdutf_binary_to_base64(binary_in, sizeof(binary_in) - 1,
+                                            b64, SIMDUTF_BASE64_DEFAULT);
+  EXPECT(b64_len > 0);
+
+  char decoded[64];
+  simdutf_result dr = simdutf_base64_to_binary(
+      b64, b64_len, decoded, SIMDUTF_BASE64_DEFAULT, SIMDUTF_LAST_CHUNK_LOOSE);
+  EXPECT(dr.error == SIMDUTF_ERROR_SUCCESS);
+  EXPECT(dr.count == sizeof(binary_in) - 1);
+  EXPECT(memcmp(decoded, binary_in, sizeof(binary_in) - 1) == 0);
+
+  /* --- Length estimators --- */
+  EXPECT(simdutf_utf16_length_from_utf8(hello_u8, sizeof(hello_u8) - 1) == 5);
+  EXPECT(simdutf_count_utf8(hello_u8, sizeof(hello_u8) - 1) == 5);
+
+  if (failures == 0) {
+    printf("nostdlibcxx_c_api_test: all checks passed\n");
+    return 0;
+  }
+  fprintf(stderr, "nostdlibcxx_c_api_test: %d failure(s)\n", failures);
+  return 1;
+}

--- a/tests/nostdlibcxx_c_api_test.c
+++ b/tests/nostdlibcxx_c_api_test.c
@@ -27,7 +27,8 @@ int main(void) {
   const char bad_utf8[] = "\xff\xfe\xfd";
   EXPECT(!simdutf_validate_utf8(bad_utf8, sizeof(bad_utf8) - 1));
 
-  simdutf_result r = simdutf_validate_utf8_with_errors(ascii, sizeof(ascii) - 1);
+  simdutf_result r =
+      simdutf_validate_utf8_with_errors(ascii, sizeof(ascii) - 1);
   EXPECT(r.error == SIMDUTF_ERROR_SUCCESS);
   EXPECT(r.count == sizeof(ascii) - 1);
 
@@ -41,7 +42,8 @@ int main(void) {
   /* --- UTF-8 -> UTF-16LE transcoding --- */
   const char hello_u8[] = "Hello";
   char16_t u16[16];
-  size_t n = simdutf_convert_utf8_to_utf16le(hello_u8, sizeof(hello_u8) - 1, u16);
+  size_t n =
+      simdutf_convert_utf8_to_utf16le(hello_u8, sizeof(hello_u8) - 1, u16);
   EXPECT(n == 5);
   EXPECT(u16[0] == 'H' && u16[4] == 'o');
 

--- a/tests/random_fuzzer.cpp
+++ b/tests/random_fuzzer.cpp
@@ -20,7 +20,8 @@ static void print_input(const std::string &s,
   }
   printf("\n");
   printf("string length: %zu\n", s.size());
-  printf("implementation->name() = %s", e->name().data());
+  printf("implementation->name() = %.*s", int(e->name().size()),
+         e->name().data());
 }
 
 extern "C" {
@@ -751,7 +752,7 @@ int main(int argc, char *argv[]) {
     if (!e->supported_by_runtime_system()) {
       continue;
     }
-    printf("testing: %s\n", e->name().data());
+    printf("testing: %.*s\n", int(e->name().size()), e->name().data());
   }
 #ifndef SIMDUTF_TEST_FUZZER_TRIALS
   #error "SIMDUTF_TEST_FUZZER_TRIALS not set."

--- a/tests/random_fuzzer.cpp
+++ b/tests/random_fuzzer.cpp
@@ -20,7 +20,7 @@ static void print_input(const std::string &s,
   }
   printf("\n");
   printf("string length: %zu\n", s.size());
-  printf("implementation->name() = %s", e->name());
+  printf("implementation->name() = %s", e->name().data());
 }
 
 extern "C" {
@@ -751,7 +751,7 @@ int main(int argc, char *argv[]) {
     if (!e->supported_by_runtime_system()) {
       continue;
     }
-    printf("testing: %s\n", e->name());
+    printf("testing: %s\n", e->name().data());
   }
 #ifndef SIMDUTF_TEST_FUZZER_TRIALS
   #error "SIMDUTF_TEST_FUZZER_TRIALS not set."

--- a/tests/random_fuzzer.cpp
+++ b/tests/random_fuzzer.cpp
@@ -20,7 +20,7 @@ static void print_input(const std::string &s,
   }
   printf("\n");
   printf("string length: %zu\n", s.size());
-  printf("implementation->name() = %s", e->name().c_str());
+  printf("implementation->name() = %s", e->name());
 }
 
 extern "C" {
@@ -751,7 +751,7 @@ int main(int argc, char *argv[]) {
     if (!e->supported_by_runtime_system()) {
       continue;
     }
-    printf("testing: %s\n", e->name().c_str());
+    printf("testing: %s\n", e->name());
   }
 #ifndef SIMDUTF_TEST_FUZZER_TRIALS
   #error "SIMDUTF_TEST_FUZZER_TRIALS not set."

--- a/tests/select_implementation.cpp
+++ b/tests/select_implementation.cpp
@@ -17,7 +17,10 @@ int main() {
     if (!validutf8) {
       return EXIT_FAILURE;
     }
-    printf("%s: %s\n", implementation->name().data(), implementation->description().data());
+    printf("%.*s: %.*s\n", int(implementation->name().size()),
+           implementation->name().data(),
+           int(implementation->description().size()),
+           implementation->description().data());
     chosen_implementation = std::string(implementation->name());
   }
   auto my_implementation =
@@ -36,7 +39,8 @@ int main() {
   if (simdutf::get_active_implementation()->name() != chosen_implementation) {
     return EXIT_FAILURE;
   }
-  printf("Manually selected: %s\n",
+  printf("Manually selected: %.*s\n",
+         int(simdutf::get_active_implementation()->name().size()),
          simdutf::get_active_implementation()->name().data());
   return EXIT_SUCCESS;
 }

--- a/tests/select_implementation.cpp
+++ b/tests/select_implementation.cpp
@@ -17,11 +17,11 @@ int main() {
     if (!validutf8) {
       return EXIT_FAILURE;
     }
-    printf("%s: %s\n", implementation->name(), implementation->description());
-    chosen_implementation = implementation->name();
+    printf("%s: %s\n", implementation->name().data(), implementation->description().data());
+    chosen_implementation = std::string(implementation->name());
   }
   auto my_implementation =
-      simdutf::get_available_implementations()[chosen_implementation.c_str()];
+      simdutf::get_available_implementations()[chosen_implementation];
   if (!my_implementation) {
     return EXIT_FAILURE;
   }
@@ -37,6 +37,6 @@ int main() {
     return EXIT_FAILURE;
   }
   printf("Manually selected: %s\n",
-         simdutf::get_active_implementation()->name());
+         simdutf::get_active_implementation()->name().data());
   return EXIT_SUCCESS;
 }

--- a/tests/select_implementation.cpp
+++ b/tests/select_implementation.cpp
@@ -17,12 +17,11 @@ int main() {
     if (!validutf8) {
       return EXIT_FAILURE;
     }
-    printf("%s: %s\n", implementation->name().c_str(),
-           implementation->description().c_str());
+    printf("%s: %s\n", implementation->name(), implementation->description());
     chosen_implementation = implementation->name();
   }
   auto my_implementation =
-      simdutf::get_available_implementations()[chosen_implementation];
+      simdutf::get_available_implementations()[chosen_implementation.c_str()];
   if (!my_implementation) {
     return EXIT_FAILURE;
   }
@@ -38,6 +37,6 @@ int main() {
     return EXIT_FAILURE;
   }
   printf("Manually selected: %s\n",
-         simdutf::get_active_implementation()->name().c_str());
+         simdutf::get_active_implementation()->name());
   return EXIT_SUCCESS;
 }

--- a/tests/validate_utf8_basic_tests.cpp
+++ b/tests/validate_utf8_basic_tests.cpp
@@ -1,8 +1,6 @@
 #include "simdutf.h"
 
-#if SIMDUTF_CPLUSPLUS17
-  #include <string_view>
-#endif
+#include <string_view>
 
 #include <tests/helpers/fixed_string.h>
 #include <tests/helpers/test.h>

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -64,11 +64,6 @@ if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR (CMAKE_CXX_COMPILER_ID STREQUAL "Cl
     target_link_options(fastbase64 PRIVATE "-Wl,--gc-sections")
   endif()
 endif()
-message(STATUS "The tools require C++17. If your system does not support C++17, please set SIMDUTF_TOOLS to OFF.")
-set_property(TARGET sutf PROPERTY CXX_STANDARD 17)
-set_property(TARGET sutf PROPERTY CXX_STANDARD_REQUIRED ON)
-set_property(TARGET fastbase64 PROPERTY CXX_STANDARD 17)
-set_property(TARGET fastbase64 PROPERTY CXX_STANDARD_REQUIRED ON)
 
 target_link_libraries(sutf PUBLIC simdutf-nobase64)
 target_compile_definitions(sutf PRIVATE


### PR DESCRIPTION
This is an alternative to https://github.com/simdutf/simdutf/pull/959 proposed by @mitchellh 

~~It is AI generated with my guidance. Don't worry about the CI tests, this is a proof of concept.~~



- It removes std::string from the main library. We simply return `std::string_view`. This is a breaking change. It means requiring C++17 and up from now.
- We add a shim for `__cxa_pure_virtual`. Made optional with a macro.
- We initialize statically our implementations, instead of having them as static instances inside a function when the no c++ lib macro is set.
- We remove `toBinaryString` and some other legacy functions.


And that's it!!!

I get...

```
> nm -u  build_nolibcxx/src/libsimdutf-nostdlibcxx.a     

simdutf.cpp.o:
___stack_chk_fail
___stack_chk_guard
_getenv
_memcpy
_memmove
```


Let us try it out by hand. Run the amalgamation script, then do...

```
> c++ -c simdutf.cpp  -nostdlib++ -fno-rtti -fno-exceptions
> cc amalgamation_demo.c simdutf.o 
> otool -L a.out
a.out:
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1356.0.0)
```


Compare with old way:


```
> c++ -c simdutf.cpp
> cc -c  ./amalgamation_demo.c
> c++ amalgamation_demo.o simdutf.o
>  otool -L a.out
a.out:
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 2000.67.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1356.0.0)
```


So @pauldreik, here is my proposal...

1. In a major release, we switch from `std::string` to `std::string_view`. This will break some code but very little. Few of our users ever grab our strings. It requires switching to C++17, but that ought to be fine.
2. Using a macro, we guard the shim and the static initialization. The shim is tiny and not something that will get in our way. The static initialization is how I used to do things but people complained about possible data races and stuff. So I'd prefer not change it for everything, but it is a tiny localized change. We never touch this code... only when adding a new kernel and that's not a common event. So now there will be a macro, but it is not a big deal.


I think that my version has only a localized effect and it does not make the code much more difficult to maintain. It will only be an issue when adding new kernels, but it is already a bit tricky to do and not something we will do often. (New CPU families are not common.)


Update: I added `__glibcxx_assert_fail` as a weak symbol.
