### PR TITLE
build with fil-c

### DIFF
--- a/include/simdutf/internal/isadetection.h
+++ b/include/simdutf/internal/isadetection.h
@@ -50,8 +50,12 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <cstdlib>
 #if defined(_MSC_VER)
   #include <intrin.h>
-#elif defined(HAVE_GCC_GET_CPUID) && defined(USE_GCC_GET_CPUID)
+#elif (defined(HAVE_GCC_GET_CPUID) && defined(USE_GCC_GET_CPUID)) || defined(__FILC__)
   #include <cpuid.h>
+#endif
+
+#ifdef __FILC__
+#include <stdfil.h>
 #endif
 
 #include "simdutf/portability.h"
@@ -202,7 +206,7 @@ static inline void cpuid(uint32_t *eax, uint32_t *ebx, uint32_t *ecx,
   *ebx = cpu_info[1];
   *ecx = cpu_info[2];
   *edx = cpu_info[3];
-  #elif defined(HAVE_GCC_GET_CPUID) && defined(USE_GCC_GET_CPUID)
+  #elif (defined(HAVE_GCC_GET_CPUID) && defined(USE_GCC_GET_CPUID)) || defined(__FILC__)
   uint32_t level = *eax;
   __get_cpuid(level, eax, ebx, ecx, edx);
   #else
@@ -218,6 +222,8 @@ static inline void cpuid(uint32_t *eax, uint32_t *ebx, uint32_t *ecx,
 static inline uint64_t xgetbv() {
   #if defined(_MSC_VER)
   return _xgetbv(0);
+  #elif defined(__FILC__)
+  return zxgetbv();
   #else
   uint32_t xcr0_lo, xcr0_hi;
   asm volatile("xgetbv\n\t" : "=a"(xcr0_lo), "=d"(xcr0_hi) : "c"(0));

--- a/include/simdutf/internal/isadetection.h
+++ b/include/simdutf/internal/isadetection.h
@@ -50,12 +50,13 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <cstdlib>
 #if defined(_MSC_VER)
   #include <intrin.h>
-#elif (defined(HAVE_GCC_GET_CPUID) && defined(USE_GCC_GET_CPUID)) || defined(__FILC__)
+#elif (defined(HAVE_GCC_GET_CPUID) && defined(USE_GCC_GET_CPUID)) ||           \
+    defined(__FILC__)
   #include <cpuid.h>
 #endif
 
 #ifdef __FILC__
-#include <stdfil.h>
+  #include <stdfil.h>
 #endif
 
 #include "simdutf/portability.h"
@@ -206,7 +207,8 @@ static inline void cpuid(uint32_t *eax, uint32_t *ebx, uint32_t *ecx,
   *ebx = cpu_info[1];
   *ecx = cpu_info[2];
   *edx = cpu_info[3];
-  #elif (defined(HAVE_GCC_GET_CPUID) && defined(USE_GCC_GET_CPUID)) || defined(__FILC__)
+  #elif (defined(HAVE_GCC_GET_CPUID) && defined(USE_GCC_GET_CPUID)) ||         \
+      defined(__FILC__)
   uint32_t level = *eax;
   __get_cpuid(level, eax, ebx, ecx, edx);
   #else

--- a/src/icelake/icelake_base64.inl.cpp
+++ b/src/icelake/icelake_base64.inl.cpp
@@ -456,8 +456,10 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
           last_chunk_options == last_chunk_handling_options::strict &&
           (idx >= 2) && ((idx + padding_characters) & 3) != 0) {
         // The partial chunk was at src - idx
-        _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
-        dst += output_len;
+        if (output_len > 0) {
+          _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+          dst += output_len;
+        }
         return {BASE64_INPUT_REMAINDER, equallocation, size_t(dst - dstinit),
                 true};
       } else
@@ -471,8 +473,10 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
             (last_chunk_options ==
                  last_chunk_handling_options::only_full_chunks &&
              (idx >= 2 || padding_characters == 0))) {
-          _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
-          dst += output_len;
+          if (output_len > 0) {
+            _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+            dst += output_len;
+          }
           // we need to rewind src to before the partial chunk
           size_t characters_to_skip = idx;
           while (characters_to_skip > 0) {
@@ -501,8 +505,11 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
               uint32_t triple = (uint32_t(bufferptr[-2]) << 3 * 6) +
                                 (uint32_t(bufferptr[-1]) << 2 * 6);
               if (triple & 0xffff) {
-                _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
-                dst += output_len;
+                if (output_len > 0) {
+                  _mm512_mask_storeu_epi8((__m512i *)dst, output_mask,
+                                          shuffled);
+                  dst += output_len;
+                }
                 return {BASE64_EXTRA_BITS, size_t(src - srcinit),
                         size_t(dst - dstinit)};
               }
@@ -518,8 +525,11 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                                 (uint32_t(bufferptr[-2]) << 2 * 6) +
                                 (uint32_t(bufferptr[-1]) << 1 * 6);
               if (triple & 0xff) {
-                _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
-                dst += output_len;
+                if (output_len > 0) {
+                  _mm512_mask_storeu_epi8((__m512i *)dst, output_mask,
+                                          shuffled);
+                  dst += output_len;
+                }
                 return {BASE64_EXTRA_BITS, size_t(src - srcinit),
                         size_t(dst - dstinit)};
               }
@@ -532,18 +542,24 @@ compress_decode_base64(char *dst, const chartype *src, size_t srclen,
                      (!is_partial(last_chunk_options) ||
                       (is_partial(last_chunk_options) &&
                        padding_characters > 0))) {
-            _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
-            dst += output_len;
+            if (output_len > 0) {
+              _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+              dst += output_len;
+            }
             return {BASE64_INPUT_REMAINDER, size_t(src - srcinit),
                     size_t(dst - dstinit)};
           } else if (!ignore_garbage && idx == 0 && padding_characters > 0) {
-            _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
-            dst += output_len;
+            if (output_len > 0) {
+              _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+              dst += output_len;
+            }
             return {INVALID_BASE64_CHARACTER, equallocation,
                     size_t(dst - dstinit), true};
           } else {
-            _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
-            dst += output_len;
+            if (output_len > 0) {
+              _mm512_mask_storeu_epi8((__m512i *)dst, output_mask, shuffled);
+              dst += output_len;
+            }
           }
         }
     if (!ignore_garbage && !is_partial(last_chunk_options) &&


### PR DESCRIPTION
This PR adds support for building simdutf with [Fil-C, the memory-safe C/C++ compiler](https://fil-c.org).

For the most part, we just have to adjust our cpu detection.

There is a tricky issue with masked AVX-512 writes. I think that receiving a null pointer in such cases ought to be safe the mask is empty but Fil-C disagrees. I think that Fil-C is wrong.

cc @pizlonator

