### PR TITLE
test: strengthen conversion result coverage

### DIFF
--- a/tests/convert_utf16_to_utf8_with_replacement_tests.cpp
+++ b/tests/convert_utf16_to_utf8_with_replacement_tests.cpp
@@ -141,6 +141,134 @@ TEST(pure_ascii_le) {
   ASSERT_TRUE(std::memcmp(output.data(), "Hello", 5) == 0);
 }
 
+TEST(valid_utf16be_roundtrip) {
+  std::vector<char16_t> input = {to_utf16be(u'H'), to_utf16be(u'e'),
+                                 to_utf16be(u'l'), to_utf16be(u'l'),
+                                 to_utf16be(u'o'), to_utf16be(u' '),
+                                 to_utf16be(u'\u00e9'),
+                                 to_utf16be(u'\u4e16'),
+                                 to_utf16be(u'\u754c')};
+  size_t expected_len =
+      simdutf::utf8_length_from_utf16be(input.data(), input.size());
+  std::vector<char> expected(expected_len);
+  size_t written_expected = implementation.convert_utf16be_to_utf8(
+      input.data(), input.size(), expected.data());
+
+  std::vector<char> actual(expected_len + 10);
+  size_t written_actual =
+      implementation.convert_utf16be_to_utf8_with_replacement(
+          input.data(), input.size(), actual.data());
+
+  ASSERT_EQUAL(written_expected, written_actual);
+  ASSERT_TRUE(std::memcmp(expected.data(), actual.data(), written_actual) == 0);
+}
+
+TEST(valid_surrogate_pair_be) {
+  std::vector<char16_t> input = {to_utf16be(char16_t(0xD83D)),
+                                 to_utf16be(char16_t(0xDE00))};
+  std::vector<char> output(8);
+  size_t written = implementation.convert_utf16be_to_utf8_with_replacement(
+      input.data(), input.size(), output.data());
+  ASSERT_EQUAL(written, size_t(4));
+  ASSERT_EQUAL(uint8_t(output[0]), uint8_t(0xF0));
+  ASSERT_EQUAL(uint8_t(output[1]), uint8_t(0x9F));
+  ASSERT_EQUAL(uint8_t(output[2]), uint8_t(0x98));
+  ASSERT_EQUAL(uint8_t(output[3]), uint8_t(0x80));
+}
+
+TEST(unpaired_high_surrogate_be) {
+  std::vector<char16_t> input = {to_utf16be(char16_t(0xD800)),
+                                 to_utf16be(u'A')};
+  std::vector<char> output(8);
+  size_t written = implementation.convert_utf16be_to_utf8_with_replacement(
+      input.data(), input.size(), output.data());
+  ASSERT_EQUAL(written, size_t(4));
+  ASSERT_TRUE(std::memcmp(output.data(), fffd_utf8, 3) == 0);
+  ASSERT_EQUAL(output[3], 'A');
+}
+
+TEST(unpaired_low_surrogate_be) {
+  std::vector<char16_t> input = {to_utf16be(u'B'),
+                                 to_utf16be(char16_t(0xDC00)),
+                                 to_utf16be(u'C')};
+  std::vector<char> output(16);
+  size_t written = implementation.convert_utf16be_to_utf8_with_replacement(
+      input.data(), input.size(), output.data());
+  ASSERT_EQUAL(written, size_t(5));
+  ASSERT_EQUAL(output[0], 'B');
+  ASSERT_TRUE(std::memcmp(output.data() + 1, fffd_utf8, 3) == 0);
+  ASSERT_EQUAL(output[4], 'C');
+}
+
+TEST(reversed_surrogate_pair_be) {
+  std::vector<char16_t> input = {to_utf16be(char16_t(0xDC00)),
+                                 to_utf16be(char16_t(0xD800))};
+  std::vector<char> output(16);
+  size_t written = implementation.convert_utf16be_to_utf8_with_replacement(
+      input.data(), input.size(), output.data());
+  ASSERT_EQUAL(written, size_t(6));
+  ASSERT_TRUE(std::memcmp(output.data(), fffd_utf8, 3) == 0);
+  ASSERT_TRUE(std::memcmp(output.data() + 3, fffd_utf8, 3) == 0);
+}
+
+TEST(length_consistency_be) {
+  std::vector<char16_t> input = {
+      to_utf16be(u'A'),                 to_utf16be(char16_t(0xD83D)),
+      to_utf16be(char16_t(0xDE00)),     to_utf16be(char16_t(0xD800)),
+      to_utf16be(u'B'),                 to_utf16be(char16_t(0xDC00)),
+      to_utf16be(char16_t(0xDC00)),     to_utf16be(char16_t(0xD800)),
+      to_utf16be(u'\u4e16')};
+
+  simdutf::result len_result =
+      simdutf::utf8_length_from_utf16be_with_replacement(input.data(),
+                                                         input.size());
+
+  std::vector<char> output(input.size() * 3 + 4);
+  size_t written = implementation.convert_utf16be_to_utf8_with_replacement(
+      input.data(), input.size(), output.data());
+
+  ASSERT_EQUAL(len_result.count, written);
+}
+
+TEST(matches_well_formed_approach_be) {
+  std::vector<char16_t> input = {
+      to_utf16be(u'A'),                 to_utf16be(char16_t(0xD800)),
+      to_utf16be(u'B'),                 to_utf16be(char16_t(0xDC00)),
+      to_utf16be(char16_t(0xDC00)),     to_utf16be(char16_t(0xD800)),
+      to_utf16be(char16_t(0xD83D)),     to_utf16be(char16_t(0xDE00))};
+
+  std::vector<char16_t> well_formed(input.size());
+  simdutf::to_well_formed_utf16be(input.data(), input.size(),
+                                  well_formed.data());
+  size_t utf8_len =
+      simdutf::utf8_length_from_utf16be(well_formed.data(), well_formed.size());
+  std::vector<char> expected(utf8_len + 1);
+  size_t written_expected = simdutf::convert_utf16be_to_utf8(
+      well_formed.data(), well_formed.size(), expected.data());
+
+  std::vector<char> actual(utf8_len + 1);
+  size_t written_actual =
+      implementation.convert_utf16be_to_utf8_with_replacement(
+          input.data(), input.size(), actual.data());
+
+  ASSERT_EQUAL(written_expected, written_actual);
+  ASSERT_TRUE(std::memcmp(expected.data(), actual.data(), written_actual) == 0);
+}
+
+TEST(output_is_valid_utf8_be) {
+  std::vector<char16_t> input = {
+      to_utf16be(u'A'),                 to_utf16be(char16_t(0xD83D)),
+      to_utf16be(char16_t(0xDE00)),     to_utf16be(char16_t(0xD800)),
+      to_utf16be(u'B'),                 to_utf16be(char16_t(0xDC00)),
+      to_utf16be(u'\u4e16')};
+
+  std::vector<char> output(input.size() * 3 + 4);
+  size_t written = implementation.convert_utf16be_to_utf8_with_replacement(
+      input.data(), input.size(), output.data());
+
+  ASSERT_TRUE(simdutf::validate_utf8(output.data(), written));
+}
+
 // Test: consistency with utf8_length_from_utf16_with_replacement
 TEST_LOOP(length_consistency_le) {
   const size_t length = 64 + (seed % 128);

--- a/tests/simdutf_c_tests.cpp
+++ b/tests/simdutf_c_tests.cpp
@@ -184,6 +184,40 @@ TEST(invalid_utf8_c) {
   ASSERT_EQUAL(r.error, SIMDUTF_ERROR_HEADER_BITS);
 }
 
+TEST(invalid_utf8_conversion_results_c) {
+  const char *invalid = "\xff";
+
+  char16_t out16[4] = {0};
+  simdutf_result r16 =
+      simdutf_convert_utf8_to_utf16_with_errors(invalid, 1, out16);
+  ASSERT_EQUAL(r16.error, SIMDUTF_ERROR_HEADER_BITS);
+  ASSERT_EQUAL(r16.count, size_t(0));
+
+  char32_t out32[4] = {0};
+  simdutf_result r32 =
+      simdutf_convert_utf8_to_utf32_with_errors(invalid, 1, out32);
+  ASSERT_EQUAL(r32.error, SIMDUTF_ERROR_HEADER_BITS);
+  ASSERT_EQUAL(r32.count, size_t(0));
+}
+
+TEST(invalid_utf16_conversion_result_c) {
+  const char16_t invalid[] = {u'A', char16_t(0xD800), u'B'};
+  char out[16] = {0};
+  simdutf_result r =
+      simdutf_convert_utf16_to_utf8_with_errors(invalid, 3, out);
+  ASSERT_EQUAL(r.error, SIMDUTF_ERROR_SURROGATE);
+  ASSERT_EQUAL(r.count, size_t(1));
+}
+
+TEST(invalid_utf32_conversion_result_c) {
+  const char32_t invalid[] = {U'A', char32_t(0x110000), U'B'};
+  char out[16] = {0};
+  simdutf_result r =
+      simdutf_convert_utf32_to_utf8_with_errors(invalid, 3, out);
+  ASSERT_EQUAL(r.error, SIMDUTF_ERROR_TOO_LARGE);
+  ASSERT_EQUAL(r.count, size_t(1));
+}
+
 TEST(base64_utf16_c) {
   const char16_t *b64_u16 = u"aGVsbG8="; // "hello" in base64, as UTF-16
   char binout[16] = {0};


### PR DESCRIPTION
## Summary

- Add runtime UTF-16BE with-replacement conversion tests covering valid input, surrogate replacement cases, length consistency, well-formed equivalence, and UTF-8 validity.
- Add C API invalid conversion result tests that assert both `simdutf_result.error` and `simdutf_result.count`.

## Why

The existing runtime with-replacement tests were LE-heavy; the BE public API had no dedicated runtime coverage for the `_with_replacement` path. The C API tests covered many happy paths but did not assert error/count propagation for invalid-input result-returning wrappers.

## Test coverage delta

- **TGL-TC-001**: new BE oracles verify byte output for valid input, valid surrogate pair output (`0xD83D 0xDE00` → `0xF0 0x9F 0x98 0x80`), U+FFFD replacement for unpaired/reversed surrogate patterns, length consistency with `utf8_length_from_utf16be_with_replacement`, equivalence to `to_well_formed_utf16be` + normal conversion, and output UTF-8 validity.
- **TGL-TC-002**: new C API oracles verify `SIMDUTF_ERROR_HEADER_BITS` at count 0 (invalid UTF-8 `\xff`), `SIMDUTF_ERROR_SURROGATE` at count 1, and `SIMDUTF_ERROR_TOO_LARGE` at count 1.
- Targeted after-only coverage: 374 covered LOC, 4 uncovered LOC, 378 total LOC, 98.94%.

## Files changed

- `tests/convert_utf16_to_utf8_with_replacement_tests.cpp`
- `tests/simdutf_c_tests.cpp`

## Risk

Pure test addition — no production code changed.

> Note: tests were developed with AI assistance and reviewed by a human before filing.