### PR TITLE
icelake: use unsigned shift base in utf16_to_latin1 tail mask

### DIFF
--- a/src/icelake/icelake_convert_utf16_to_latin1.inl.cpp
+++ b/src/icelake/icelake_convert_utf16_to_latin1.inl.cpp
@@ -27,7 +27,7 @@ size_t icelake_convert_utf16_to_latin1(const char16_t *buf, size_t len,
     buf += 32;
   }
   if (buf < end) {
-    uint32_t mask(uint32_t(1 << (end - buf)) - 1);
+    uint32_t mask((1U << (end - buf)) - 1);
     __m512i in = _mm512_maskz_loadu_epi16(mask, buf);
     if (big_endian) {
       in = _mm512_shuffle_epi8(in, byteflip);
@@ -79,7 +79,7 @@ icelake_convert_utf16_to_latin1_with_errors(const char16_t *buf, size_t len,
     buf += 32;
   }
   if (buf < end) {
-    uint32_t mask(uint32_t(1 << (end - buf)) - 1);
+    uint32_t mask((1U << (end - buf)) - 1);
     __m512i in = _mm512_maskz_loadu_epi16(mask, buf);
     if (big_endian) {
       in = _mm512_shuffle_epi8(in, byteflip);


### PR DESCRIPTION
The masked tail block of `icelake_convert_utf16_to_latin1` and
`icelake_convert_utf16_to_latin1_with_errors` builds the AVX-512
load/store mask from a signed `1`:

- `src/icelake/icelake_convert_utf16_to_latin1.inl.cpp:30`
- `src/icelake/icelake_convert_utf16_to_latin1.inl.cpp:82`

```c
uint32_t mask(uint32_t(1 << (end - buf)) - 1);
```

After the 32-element main loop, `end - buf` is in `[1, 31]`. Any caller
that passes an input length such that the final block has 31 remaining
char16 values (the simplest case is `len == 31`) reaches the path with
shift count 31. `int 1 << 31` places a 1 in the sign bit of a 32-bit
`int`, which is implementation-defined behaviour in C++17 and was
undefined behaviour before.

The rest of the icelake source already builds these masks from an
unsigned base to avoid exactly this idiom:

- `src/icelake/icelake_ascii_validation.inl.cpp:14`: `uint64_t(1) << (end - buf)`
- `src/icelake/icelake_convert_utf16_to_utf8.inl.cpp:195`: `(1U << inlen) - 1`
- `src/icelake/implementation.cpp:294`/`323`/`418`/...: `(1U << (end - buf)) - 1`
- `include/simdutf/internal/isadetection.h:180`: `uint32_t(1) << 31`

The two tail-mask computations in `icelake_convert_utf16_to_latin1.inl.cpp`
were the remaining outliers.

### Fix

Switch both sites to `1U <<` and drop the now-redundant outer
`uint32_t(...)` cast around the shift. The value built by the expression
is unchanged on every supported compiler, but the construct no longer
depends on signed-to-unsigned conversion of an int with the sign bit
set.

### Reproducer / observation

To exercise the path on icelake-capable hardware:

```c
char16_t buf[31] = {};
char out[31];
simdutf::convert_utf16le_to_latin1(buf, 31, out);
```

This bypasses the 32-element main loop and enters the `if (buf < end)`
branch with `end - buf == 31`, evaluating the shift on `1`.