### PR TITLE
icelake: use unsigned shift base in latin1_to_utf16 tail mask

### DIFF
--- a/src/icelake/icelake_convert_latin1_to_utf16.inl.cpp
+++ b/src/icelake/icelake_convert_latin1_to_utf16.inl.cpp
@@ -20,7 +20,7 @@ size_t icelake_convert_latin1_to_utf16(const char *latin1_input, size_t len,
     _mm512_storeu_si512((__m512i *)&utf16_output[i], out);
   }
   if (rounded_len != len) {
-    uint32_t mask = uint32_t(1 << (len - rounded_len)) - 1;
+    uint32_t mask = (1U << (len - rounded_len)) - 1;
     __m256i in = _mm256_maskz_loadu_epi8(mask, latin1_input + rounded_len);
 
     // Zero extend each set of 8 Latin1 characters to 32 16-bit integers


### PR DESCRIPTION
The tail mask at `src/icelake/icelake_convert_latin1_to_utf16.inl.cpp:23` builds from a signed `1`, so the shift reaches `1 << 31` whenever `len % 32 == 31` (simplest case `len == 31`), placing a 1 in the sign bit of an `int`. Switch to a `1U` base so it matches the unsigned masking idiom already used by the other icelake tail blocks (e.g. utf16_to_latin1 after #976); the produced value is unchanged.