### PR TITLE
fix doubled length in binary_length_from_base64 for char16 input

### DIFF
--- a/src/generic/base64lengths.h
+++ b/src/generic/base64lengths.h
@@ -39,6 +39,9 @@ simdutf_warn_unused size_t binary_length_from_base64(const char16_t *input,
     uint64_t maybe_base64 = block.gteq(33); // >= 33 which is '!' in ASCII
     count += count_ones(maybe_base64);
   }
+  // simd16x32::to_bitmask sets two bits per matching 16-bit lane, so the
+  // vectorized loop counted each unit twice.
+  count /= 2;
   while (pos < length) {
     count += (input[pos] > 0x20) ? 1 : 0;
     pos++;

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -3569,6 +3569,15 @@ TEST(binary_length_from_base64_char16) {
   ASSERT_EQUAL(simdutf::binary_length_from_base64(input16_spaces.data(),
                                                   input16_spaces.size()),
                1);
+
+  // Long input that exercises the vectorized path; "YWJj" decodes to "abc".
+  std::u16string input16_long;
+  for (int i = 0; i < 16; i++) {
+    input16_long += u"YWJj";
+  }
+  ASSERT_EQUAL(implementation.binary_length_from_base64(input16_long.data(),
+                                                        input16_long.size()),
+               48);
 }
 
 TEST(binary_length_from_base64_url_variant) {


### PR DESCRIPTION
The char16 `binary_length_from_base64` in src/generic/base64lengths.h counts a bitmask that sets two bits per 16-bit lane, so the vectorized loop double-counts and 64 base64 units report 96 bytes instead of 48. Halve the vectorized count before the scalar tail, as the avx2 and icelake kernels already do.
