### PR TITLE
perf: short-input scalar fallback in convert_utf8_to_utf16{le,be} span overloads

### DIFF
--- a/benchmarks/shortbench.cpp
+++ b/benchmarks/shortbench.cpp
@@ -167,6 +167,18 @@ std::vector<BenchmarkFunc> available_functions = {
          return len;
        };
      }},
+    // Span-overload variant: calls the simdutf_really_inline span path in
+    // implementation.h which, for short inputs (<=16 bytes), calls the scalar
+    // implementation directly without going through the SIMD dispatcher.
+    // Compare against convert_utf8_to_utf16le to see the short-input benefit.
+    {"convert_utf8_to_utf16le_span",
+     [](std::span<const char> input, std::span<char> output) {
+       return [input, output]() -> size_t {
+         std::span<char16_t> out16{reinterpret_cast<char16_t *>(output.data()),
+                                   output.size() / sizeof(char16_t)};
+         return simdutf::convert_utf8_to_utf16le(input, out16);
+       };
+     }},
     {"convert_utf8_to_utf16be",
      [](std::span<const char> input, std::span<char> output) {
        return [input, output]() -> size_t {
@@ -174,6 +186,34 @@ std::vector<BenchmarkFunc> available_functions = {
              input.data(), input.size(),
              reinterpret_cast<char16_t *>(output.data()));
          return len;
+       };
+     }},
+    // Span-overload variant: same short-input optimisation as
+    // convert_utf8_to_utf16le_span but for big-endian output.
+    {"convert_utf8_to_utf16be_span",
+     [](std::span<const char> input, std::span<char> output) {
+       return [input, output]() -> size_t {
+         std::span<char16_t> out16{reinterpret_cast<char16_t *>(output.data()),
+                                   output.size() / sizeof(char16_t)};
+         return simdutf::convert_utf8_to_utf16be(input, out16);
+       };
+     }},
+    // Span-overload variant with error position for LE output.
+    {"convert_utf8_to_utf16le_with_errors_span",
+     [](std::span<const char> input, std::span<char> output) {
+       return [input, output]() -> size_t {
+         std::span<char16_t> out16{reinterpret_cast<char16_t *>(output.data()),
+                                   output.size() / sizeof(char16_t)};
+         return simdutf::convert_utf8_to_utf16le_with_errors(input, out16).count;
+       };
+     }},
+    // Span-overload variant with error position for BE output.
+    {"convert_utf8_to_utf16be_with_errors_span",
+     [](std::span<const char> input, std::span<char> output) {
+       return [input, output]() -> size_t {
+         std::span<char16_t> out16{reinterpret_cast<char16_t *>(output.data()),
+                                   output.size() / sizeof(char16_t)};
+         return simdutf::convert_utf8_to_utf16be_with_errors(input, out16).count;
        };
      }},
     {"convert_utf8_to_utf32",

--- a/benchmarks/shortbench.cpp
+++ b/benchmarks/shortbench.cpp
@@ -167,16 +167,14 @@ std::vector<BenchmarkFunc> available_functions = {
          return len;
        };
      }},
-    // Span-overload variant: calls the simdutf_really_inline span path in
-    // implementation.h which, for short inputs (<=16 bytes), calls the scalar
-    // implementation directly without going through the SIMD dispatcher.
-    // Compare against convert_utf8_to_utf16le to see the short-input benefit.
     {"convert_utf8_to_utf16le_span",
      [](std::span<const char> input, std::span<char> output) {
        return [input, output]() -> size_t {
-         std::span<char16_t> out16{reinterpret_cast<char16_t *>(output.data()),
-                                   output.size() / sizeof(char16_t)};
-         return simdutf::convert_utf8_to_utf16le(input, out16);
+         size_t len = simdutf::convert_utf8_to_utf16le(
+             input,
+             std::span<char16_t>(reinterpret_cast<char16_t *>(output.data()),
+                                 output.size() / sizeof(char16_t)));
+         return len;
        };
      }},
     {"convert_utf8_to_utf16be",
@@ -188,32 +186,52 @@ std::vector<BenchmarkFunc> available_functions = {
          return len;
        };
      }},
-    // Span-overload variant: same short-input optimisation as
-    // convert_utf8_to_utf16le_span but for big-endian output.
     {"convert_utf8_to_utf16be_span",
      [](std::span<const char> input, std::span<char> output) {
        return [input, output]() -> size_t {
-         std::span<char16_t> out16{reinterpret_cast<char16_t *>(output.data()),
-                                   output.size() / sizeof(char16_t)};
-         return simdutf::convert_utf8_to_utf16be(input, out16);
+         size_t len = simdutf::convert_utf8_to_utf16be(
+             input,
+             std::span<char16_t>(reinterpret_cast<char16_t *>(output.data()),
+                                 output.size() / sizeof(char16_t)));
+         return len;
        };
      }},
-    // Span-overload variant with error position for LE output.
+    {"convert_utf8_to_utf16le_with_errors",
+     [](std::span<const char> input, std::span<char> output) {
+       return [input, output]() -> size_t {
+         simdutf::result result = simdutf::convert_utf8_to_utf16le_with_errors(
+             input.data(), input.size(),
+             reinterpret_cast<char16_t *>(output.data()));
+         return result.count;
+       };
+     }},
     {"convert_utf8_to_utf16le_with_errors_span",
      [](std::span<const char> input, std::span<char> output) {
        return [input, output]() -> size_t {
-         std::span<char16_t> out16{reinterpret_cast<char16_t *>(output.data()),
-                                   output.size() / sizeof(char16_t)};
-         return simdutf::convert_utf8_to_utf16le_with_errors(input, out16).count;
+         simdutf::result result = simdutf::convert_utf8_to_utf16le_with_errors(
+             input,
+             std::span<char16_t>(reinterpret_cast<char16_t *>(output.data()),
+                                 output.size() / sizeof(char16_t)));
+         return result.count;
        };
      }},
-    // Span-overload variant with error position for BE output.
+    {"convert_utf8_to_utf16be_with_errors",
+     [](std::span<const char> input, std::span<char> output) {
+       return [input, output]() -> size_t {
+         simdutf::result result = simdutf::convert_utf8_to_utf16be_with_errors(
+             input.data(), input.size(),
+             reinterpret_cast<char16_t *>(output.data()));
+         return result.count;
+       };
+     }},
     {"convert_utf8_to_utf16be_with_errors_span",
      [](std::span<const char> input, std::span<char> output) {
        return [input, output]() -> size_t {
-         std::span<char16_t> out16{reinterpret_cast<char16_t *>(output.data()),
-                                   output.size() / sizeof(char16_t)};
-         return simdutf::convert_utf8_to_utf16be_with_errors(input, out16).count;
+         simdutf::result result = simdutf::convert_utf8_to_utf16be_with_errors(
+             input,
+             std::span<char16_t>(reinterpret_cast<char16_t *>(output.data()),
+                                 output.size() / sizeof(char16_t)));
+         return result.count;
        };
      }},
     {"convert_utf8_to_utf32",

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -1198,6 +1198,14 @@ convert_utf8_to_utf16le(const detail::input_span_of_byte_like auto &utf8_input,
   } else
     #endif
   {
+    // For short inputs the scalar path (which this function can inline) is
+    // faster than paying the non-inlineable dispatch overhead.  The threshold
+    // of 16 matches the scalar fast-path block size.
+    if (utf8_input.size() <= 16) {
+      return scalar::utf8_to_utf16::convert<endianness::LITTLE>(
+          reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
+          utf16_output.data());
+    }
     return convert_utf8_to_utf16le(
         reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
         utf16_output.data());
@@ -1231,6 +1239,11 @@ convert_utf8_to_utf16be(const detail::input_span_of_byte_like auto &utf8_input,
   } else
     #endif
   {
+    if (utf8_input.size() <= 16) {
+      return scalar::utf8_to_utf16::convert<endianness::BIG>(
+          reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
+          utf16_output.data());
+    }
     return convert_utf8_to_utf16be(
         reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
         utf16_output.data());
@@ -1343,6 +1356,11 @@ convert_utf8_to_utf16le_with_errors(
   } else
     #endif
   {
+    if (utf8_input.size() <= 16) {
+      return scalar::utf8_to_utf16::convert_with_errors<endianness::LITTLE>(
+          reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
+          utf16_output.data());
+    }
     return convert_utf8_to_utf16le_with_errors(
         reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
         utf16_output.data());
@@ -1378,6 +1396,11 @@ convert_utf8_to_utf16be_with_errors(
   } else
     #endif
   {
+    if (utf8_input.size() <= 16) {
+      return scalar::utf8_to_utf16::convert_with_errors<endianness::BIG>(
+          reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
+          utf16_output.data());
+    }
     return convert_utf8_to_utf16be_with_errors(
         reinterpret_cast<const char *>(utf8_input.data()), utf8_input.size(),
         utf16_output.data());

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -397,5 +397,141 @@ TEST(convert_valid_utf32_to_latin1) {
   auto r1b =
       simdutf::convert_valid_utf32_to_latin1(std::as_const(input), output);
 }
+
+// ---------------------------------------------------------------------------
+// Tests for the short-input scalar fast path in the convert_utf8_to_utf16le/be
+// span overloads (PR #986).  The overloads are simdutf_really_inline in
+// implementation.h; for inputs <= 16 bytes they call the scalar path directly
+// instead of going through the SIMD dispatcher.
+// ---------------------------------------------------------------------------
+
+// Helpers: compare span result against the C-style reference.
+namespace {
+std::vector<char16_t> ref_le(const char *u8, size_t n) {
+  std::vector<char16_t> out(n + 1);
+  out.resize(simdutf::convert_utf8_to_utf16le(u8, n, out.data()));
+  return out;
+}
+std::vector<char16_t> span_le(const char *u8, size_t n) {
+  std::vector<char16_t> out(n + 1);
+  std::span<char16_t> sp{out.data(), out.size()};
+  out.resize(simdutf::convert_utf8_to_utf16le(
+      std::span<const char>{u8, n}, sp));
+  return out;
+}
+std::vector<char16_t> ref_be(const char *u8, size_t n) {
+  std::vector<char16_t> out(n + 1);
+  out.resize(simdutf::convert_utf8_to_utf16be(u8, n, out.data()));
+  return out;
+}
+std::vector<char16_t> span_be(const char *u8, size_t n) {
+  std::vector<char16_t> out(n + 1);
+  std::span<char16_t> sp{out.data(), out.size()};
+  out.resize(simdutf::convert_utf8_to_utf16be(
+      std::span<const char>{u8, n}, sp));
+  return out;
+}
+} // namespace
+
+// All ASCII sizes 0..32 — exercises the scalar branch (<=16) and the
+// dispatch fallback (>16) to verify both paths produce identical output.
+TEST(span_convert_utf8_to_utf16le_ascii_matches_cstyle) {
+  const std::string s(32, 'a');
+  for (size_t n = 0; n <= 32; ++n) {
+    ASSERT_EQUAL(ref_le(s.data(), n), span_le(s.data(), n));
+  }
+}
+
+TEST(span_convert_utf8_to_utf16be_ascii_matches_cstyle) {
+  const std::string s(32, 'z');
+  for (size_t n = 0; n <= 32; ++n) {
+    ASSERT_EQUAL(ref_be(s.data(), n), span_be(s.data(), n));
+  }
+}
+
+// 2-byte UTF-8 sequences (é U+00E9 = 0xC3 0xA9).
+TEST(span_convert_utf8_to_utf16le_two_byte_matches_cstyle) {
+  std::string s;
+  for (int i = 0; i < 10; ++i) s += "\xc3\xa9"; // 20 bytes
+  for (size_t n = 0; n <= s.size(); n += 2) {
+    ASSERT_EQUAL(ref_le(s.data(), n), span_le(s.data(), n));
+  }
+}
+
+// 3-byte UTF-8 sequences (漢 U+6F22 = 0xE6 0xBC 0xA2).
+TEST(span_convert_utf8_to_utf16le_three_byte_matches_cstyle) {
+  std::string s;
+  for (int i = 0; i < 7; ++i) s += "\xe6\xbc\xa2"; // 21 bytes, straddles threshold
+  for (size_t n = 0; n <= s.size(); n += 3) {
+    ASSERT_EQUAL(ref_le(s.data(), n), span_le(s.data(), n));
+  }
+}
+
+// 4-byte UTF-8 sequences (😀 U+1F600 = 0xF0 0x9F 0x98 0x80).
+TEST(span_convert_utf8_to_utf16le_four_byte_matches_cstyle) {
+  std::string s;
+  for (int i = 0; i < 5; ++i) s += "\xf0\x9f\x98\x80"; // 20 bytes
+  for (size_t n = 0; n <= s.size(); n += 4) {
+    ASSERT_EQUAL(ref_le(s.data(), n), span_le(s.data(), n));
+  }
+}
+
+// Threshold boundary: 14, 15, 16 → scalar branch; 17, 18 → dispatch.
+TEST(span_convert_utf8_to_utf16le_threshold_boundary) {
+  const std::string s(32, 'B');
+  for (size_t n = 14; n <= 18; ++n) {
+    ASSERT_EQUAL(ref_le(s.data(), n), span_le(s.data(), n));
+  }
+}
+
+// Exactly 16 bytes of 2-byte sequences (8 × é): must be in scalar branch.
+TEST(span_convert_utf8_to_utf16le_exactly_16_bytes_two_byte_seq) {
+  std::string s;
+  for (int i = 0; i < 8; ++i) s += "\xc3\xa9";
+  ASSERT_EQUAL(size_t{16}, s.size());
+  ASSERT_EQUAL(ref_le(s.data(), 16), span_le(s.data(), 16));
+}
+
+// 17 bytes must fall through to the SIMD dispatcher and still be correct.
+TEST(span_convert_utf8_to_utf16le_17_bytes_falls_through_to_dispatch) {
+  const std::string s(17, 'C');
+  ASSERT_EQUAL(ref_le(s.data(), 17), span_le(s.data(), 17));
+}
+
+// _with_errors variants: invalid UTF-8 must return the same error code
+// and position via span as via C-style.
+TEST(span_convert_utf8_to_utf16le_with_errors_bad_continuation) {
+  const char bad[] = "hi\x80ok";
+  size_t len = sizeof(bad) - 1;
+  std::vector<char16_t> out_c(len + 1), out_s(len + 1);
+  auto rc = simdutf::convert_utf8_to_utf16le_with_errors(bad, len, out_c.data());
+  auto rs = simdutf::convert_utf8_to_utf16le_with_errors(
+      std::span<const char>{bad, len},
+      std::span<char16_t>{out_s.data(), out_s.size()});
+  ASSERT_EQUAL(rc.error, rs.error);
+  ASSERT_EQUAL(rc.count, rs.count);
+}
+
+TEST(span_convert_utf8_to_utf16be_with_errors_bad_continuation) {
+  const char bad[] = "AB\x80" "CD"; // split to stop hex escape at \x80
+  size_t len = sizeof(bad) - 1;
+  std::vector<char16_t> out_c(len + 1), out_s(len + 1);
+  auto rc = simdutf::convert_utf8_to_utf16be_with_errors(bad, len, out_c.data());
+  auto rs = simdutf::convert_utf8_to_utf16be_with_errors(
+      std::span<const char>{bad, len},
+      std::span<char16_t>{out_s.data(), out_s.size()});
+  ASSERT_EQUAL(rc.error, rs.error);
+  ASSERT_EQUAL(rc.count, rs.count);
+}
+
+// LE and BE must differ in byte order for non-ASCII output.
+TEST(span_convert_utf8_to_utf16le_and_be_byte_order_distinct) {
+  // é U+00E9: LE stores 0xE9 0x00, BE stores 0x00 0xE9.
+  auto le = span_le("\xc3\xa9", 2);
+  auto be = span_be("\xc3\xa9", 2);
+  ASSERT_EQUAL(size_t{1}, le.size());
+  ASSERT_EQUAL(size_t{1}, be.size());
+  ASSERT_TRUE(le[0] != be[0]);
+}
 #endif
 TEST_MAIN

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -239,11 +239,14 @@ TEST(convert_utf8_to_utf16) {
   auto r1b = simdutf::convert_utf8_to_utf16(std::as_const(input), output);
 }
 
-static void assert_equal_utf16_output(const std::array<char16_t, 64> &lhs,
-                                      const std::array<char16_t, 64> &rhs,
+static void assert_equal_utf16_output(const std::array<char16_t, 64> &expected,
+                                      const std::array<char16_t, 64> &actual,
                                       size_t length) {
+  // Parameters must not be named lhs/rhs: the ASSERT_EQUAL macro declares
+  // internal `lhs`/`rhs` variables, so `ASSERT_EQUAL(lhs[i], rhs[i])` would
+  // expand to `const auto lhs = (lhs[i])`, which MSVC rejects (C3536).
   for (size_t i = 0; i < length; i++) {
-    ASSERT_EQUAL(lhs[i], rhs[i]);
+    ASSERT_EQUAL(expected[i], actual[i]);
   }
 }
 

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -250,8 +250,8 @@ static void assert_equal_utf16_output(const std::array<char16_t, 64> &expected,
   }
 }
 
-static void assert_convert_utf8_to_utf16le_span_matches_pointer(
-    const std::string &input) {
+static void
+assert_convert_utf8_to_utf16le_span_matches_pointer(const std::string &input) {
   std::array<char16_t, 64> pointer_output{};
   std::array<char16_t, 64> span_output{};
 
@@ -265,8 +265,8 @@ static void assert_convert_utf8_to_utf16le_span_matches_pointer(
   assert_equal_utf16_output(pointer_output, span_output, pointer_count);
 }
 
-static void assert_convert_utf8_to_utf16be_span_matches_pointer(
-    const std::string &input) {
+static void
+assert_convert_utf8_to_utf16be_span_matches_pointer(const std::string &input) {
   std::array<char16_t, 64> pointer_output{};
   std::array<char16_t, 64> span_output{};
 
@@ -280,15 +280,14 @@ static void assert_convert_utf8_to_utf16be_span_matches_pointer(
   assert_equal_utf16_output(pointer_output, span_output, pointer_count);
 }
 
-static void
-assert_convert_utf8_to_utf16le_with_errors_span_matches_pointer(
+static void assert_convert_utf8_to_utf16le_with_errors_span_matches_pointer(
     const std::string &input) {
   std::array<char16_t, 64> pointer_output{};
   std::array<char16_t, 64> span_output{};
 
   const simdutf::result pointer_result =
-      simdutf::convert_utf8_to_utf16le_with_errors(
-          input.data(), input.size(), pointer_output.data());
+      simdutf::convert_utf8_to_utf16le_with_errors(input.data(), input.size(),
+                                                   pointer_output.data());
   const simdutf::result span_result =
       simdutf::convert_utf8_to_utf16le_with_errors(
           std::span<const char>(input.data(), input.size()),
@@ -301,15 +300,14 @@ assert_convert_utf8_to_utf16le_with_errors_span_matches_pointer(
   }
 }
 
-static void
-assert_convert_utf8_to_utf16be_with_errors_span_matches_pointer(
+static void assert_convert_utf8_to_utf16be_with_errors_span_matches_pointer(
     const std::string &input) {
   std::array<char16_t, 64> pointer_output{};
   std::array<char16_t, 64> span_output{};
 
   const simdutf::result pointer_result =
-      simdutf::convert_utf8_to_utf16be_with_errors(
-          input.data(), input.size(), pointer_output.data());
+      simdutf::convert_utf8_to_utf16be_with_errors(input.data(), input.size(),
+                                                   pointer_output.data());
   const simdutf::result span_result =
       simdutf::convert_utf8_to_utf16be_with_errors(
           std::span<const char>(input.data(), input.size()),
@@ -354,10 +352,8 @@ TEST(convert_utf8_to_utf16_span_threshold_boundary_matches_pointer_api) {
 
 TEST(convert_utf8_to_utf16_span_rejects_invalid_utf8_like_pointer_api) {
   const std::array<std::string, 5> inputs = {
-      std::string("\xFF\xFF", 2),
-      std::string("\xC3", 1),
-      std::string("\xC0\xAF", 2),
-      std::string("\xED\xA0\x80", 3),
+      std::string("\xFF\xFF", 2), std::string("\xC3", 1),
+      std::string("\xC0\xAF", 2), std::string("\xED\xA0\x80", 3),
       std::string("\xF4\x90\x80\x80", 4)};
 
   for (const std::string &input : inputs) {

--- a/tests/span_tests.cpp
+++ b/tests/span_tests.cpp
@@ -1,6 +1,7 @@
 #include "simdutf.h"
 
 #include <array>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -238,6 +239,132 @@ TEST(convert_utf8_to_utf16) {
   auto r1b = simdutf::convert_utf8_to_utf16(std::as_const(input), output);
 }
 
+static void assert_equal_utf16_output(const std::array<char16_t, 64> &lhs,
+                                      const std::array<char16_t, 64> &rhs,
+                                      size_t length) {
+  for (size_t i = 0; i < length; i++) {
+    ASSERT_EQUAL(lhs[i], rhs[i]);
+  }
+}
+
+static void assert_convert_utf8_to_utf16le_span_matches_pointer(
+    const std::string &input) {
+  std::array<char16_t, 64> pointer_output{};
+  std::array<char16_t, 64> span_output{};
+
+  const size_t pointer_count = simdutf::convert_utf8_to_utf16le(
+      input.data(), input.size(), pointer_output.data());
+  const size_t span_count = simdutf::convert_utf8_to_utf16le(
+      std::span<const char>(input.data(), input.size()),
+      std::span<char16_t>(span_output.data(), span_output.size()));
+
+  ASSERT_EQUAL(pointer_count, span_count);
+  assert_equal_utf16_output(pointer_output, span_output, pointer_count);
+}
+
+static void assert_convert_utf8_to_utf16be_span_matches_pointer(
+    const std::string &input) {
+  std::array<char16_t, 64> pointer_output{};
+  std::array<char16_t, 64> span_output{};
+
+  const size_t pointer_count = simdutf::convert_utf8_to_utf16be(
+      input.data(), input.size(), pointer_output.data());
+  const size_t span_count = simdutf::convert_utf8_to_utf16be(
+      std::span<const char>(input.data(), input.size()),
+      std::span<char16_t>(span_output.data(), span_output.size()));
+
+  ASSERT_EQUAL(pointer_count, span_count);
+  assert_equal_utf16_output(pointer_output, span_output, pointer_count);
+}
+
+static void
+assert_convert_utf8_to_utf16le_with_errors_span_matches_pointer(
+    const std::string &input) {
+  std::array<char16_t, 64> pointer_output{};
+  std::array<char16_t, 64> span_output{};
+
+  const simdutf::result pointer_result =
+      simdutf::convert_utf8_to_utf16le_with_errors(
+          input.data(), input.size(), pointer_output.data());
+  const simdutf::result span_result =
+      simdutf::convert_utf8_to_utf16le_with_errors(
+          std::span<const char>(input.data(), input.size()),
+          std::span<char16_t>(span_output.data(), span_output.size()));
+
+  ASSERT_EQUAL(pointer_result.error, span_result.error);
+  ASSERT_EQUAL(pointer_result.count, span_result.count);
+  if (span_result.error == simdutf::error_code::SUCCESS) {
+    assert_equal_utf16_output(pointer_output, span_output, span_result.count);
+  }
+}
+
+static void
+assert_convert_utf8_to_utf16be_with_errors_span_matches_pointer(
+    const std::string &input) {
+  std::array<char16_t, 64> pointer_output{};
+  std::array<char16_t, 64> span_output{};
+
+  const simdutf::result pointer_result =
+      simdutf::convert_utf8_to_utf16be_with_errors(
+          input.data(), input.size(), pointer_output.data());
+  const simdutf::result span_result =
+      simdutf::convert_utf8_to_utf16be_with_errors(
+          std::span<const char>(input.data(), input.size()),
+          std::span<char16_t>(span_output.data(), span_output.size()));
+
+  ASSERT_EQUAL(pointer_result.error, span_result.error);
+  ASSERT_EQUAL(pointer_result.count, span_result.count);
+  if (span_result.error == simdutf::error_code::SUCCESS) {
+    assert_equal_utf16_output(pointer_output, span_output, span_result.count);
+  }
+}
+
+TEST(convert_utf8_to_utf16_span_matches_pointer_api) {
+  const std::array<std::string, 7> inputs = {
+      std::string("hi"),
+      std::string(15, 'a'),
+      std::string(16, 'b'),
+      std::string(17, 'c'),
+      std::string("\xC3\xA9", 2),
+      std::string("\xE6\xBC\xA2", 3),
+      std::string("\xF0\x9F\x98\x80", 4)};
+
+  for (const std::string &input : inputs) {
+    assert_convert_utf8_to_utf16le_span_matches_pointer(input);
+    assert_convert_utf8_to_utf16be_span_matches_pointer(input);
+    assert_convert_utf8_to_utf16le_with_errors_span_matches_pointer(input);
+    assert_convert_utf8_to_utf16be_with_errors_span_matches_pointer(input);
+  }
+}
+
+TEST(convert_utf8_to_utf16_span_threshold_boundary_matches_pointer_api) {
+  // Exercise both sides of the <= 16 short-input cutoff.
+  for (size_t size = 14; size <= 18; size++) {
+    const std::string input(size, 'x');
+
+    assert_convert_utf8_to_utf16le_span_matches_pointer(input);
+    assert_convert_utf8_to_utf16be_span_matches_pointer(input);
+    assert_convert_utf8_to_utf16le_with_errors_span_matches_pointer(input);
+    assert_convert_utf8_to_utf16be_with_errors_span_matches_pointer(input);
+  }
+}
+
+TEST(convert_utf8_to_utf16_span_rejects_invalid_utf8_like_pointer_api) {
+  const std::array<std::string, 5> inputs = {
+      std::string("\xFF\xFF", 2),
+      std::string("\xC3", 1),
+      std::string("\xC0\xAF", 2),
+      std::string("\xED\xA0\x80", 3),
+      std::string("\xF4\x90\x80\x80", 4)};
+
+  for (const std::string &input : inputs) {
+    assert_convert_utf8_to_utf16le_span_matches_pointer(input);
+    assert_convert_utf8_to_utf16be_span_matches_pointer(input);
+    assert_convert_utf8_to_utf16le_with_errors_span_matches_pointer(input);
+    assert_convert_utf8_to_utf16be_with_errors_span_matches_pointer(input);
+  }
+}
+
 TEST(convert_utf16_to_utf8) {
   std::array<char16_t, 4> input{};
   std::string output;
@@ -396,142 +523,6 @@ TEST(convert_valid_utf32_to_latin1) {
   auto r1a = simdutf::convert_valid_utf32_to_latin1(input, output);
   auto r1b =
       simdutf::convert_valid_utf32_to_latin1(std::as_const(input), output);
-}
-
-// ---------------------------------------------------------------------------
-// Tests for the short-input scalar fast path in the convert_utf8_to_utf16le/be
-// span overloads (PR #986).  The overloads are simdutf_really_inline in
-// implementation.h; for inputs <= 16 bytes they call the scalar path directly
-// instead of going through the SIMD dispatcher.
-// ---------------------------------------------------------------------------
-
-// Helpers: compare span result against the C-style reference.
-namespace {
-std::vector<char16_t> ref_le(const char *u8, size_t n) {
-  std::vector<char16_t> out(n + 1);
-  out.resize(simdutf::convert_utf8_to_utf16le(u8, n, out.data()));
-  return out;
-}
-std::vector<char16_t> span_le(const char *u8, size_t n) {
-  std::vector<char16_t> out(n + 1);
-  std::span<char16_t> sp{out.data(), out.size()};
-  out.resize(simdutf::convert_utf8_to_utf16le(
-      std::span<const char>{u8, n}, sp));
-  return out;
-}
-std::vector<char16_t> ref_be(const char *u8, size_t n) {
-  std::vector<char16_t> out(n + 1);
-  out.resize(simdutf::convert_utf8_to_utf16be(u8, n, out.data()));
-  return out;
-}
-std::vector<char16_t> span_be(const char *u8, size_t n) {
-  std::vector<char16_t> out(n + 1);
-  std::span<char16_t> sp{out.data(), out.size()};
-  out.resize(simdutf::convert_utf8_to_utf16be(
-      std::span<const char>{u8, n}, sp));
-  return out;
-}
-} // namespace
-
-// All ASCII sizes 0..32 — exercises the scalar branch (<=16) and the
-// dispatch fallback (>16) to verify both paths produce identical output.
-TEST(span_convert_utf8_to_utf16le_ascii_matches_cstyle) {
-  const std::string s(32, 'a');
-  for (size_t n = 0; n <= 32; ++n) {
-    ASSERT_EQUAL(ref_le(s.data(), n), span_le(s.data(), n));
-  }
-}
-
-TEST(span_convert_utf8_to_utf16be_ascii_matches_cstyle) {
-  const std::string s(32, 'z');
-  for (size_t n = 0; n <= 32; ++n) {
-    ASSERT_EQUAL(ref_be(s.data(), n), span_be(s.data(), n));
-  }
-}
-
-// 2-byte UTF-8 sequences (é U+00E9 = 0xC3 0xA9).
-TEST(span_convert_utf8_to_utf16le_two_byte_matches_cstyle) {
-  std::string s;
-  for (int i = 0; i < 10; ++i) s += "\xc3\xa9"; // 20 bytes
-  for (size_t n = 0; n <= s.size(); n += 2) {
-    ASSERT_EQUAL(ref_le(s.data(), n), span_le(s.data(), n));
-  }
-}
-
-// 3-byte UTF-8 sequences (漢 U+6F22 = 0xE6 0xBC 0xA2).
-TEST(span_convert_utf8_to_utf16le_three_byte_matches_cstyle) {
-  std::string s;
-  for (int i = 0; i < 7; ++i) s += "\xe6\xbc\xa2"; // 21 bytes, straddles threshold
-  for (size_t n = 0; n <= s.size(); n += 3) {
-    ASSERT_EQUAL(ref_le(s.data(), n), span_le(s.data(), n));
-  }
-}
-
-// 4-byte UTF-8 sequences (😀 U+1F600 = 0xF0 0x9F 0x98 0x80).
-TEST(span_convert_utf8_to_utf16le_four_byte_matches_cstyle) {
-  std::string s;
-  for (int i = 0; i < 5; ++i) s += "\xf0\x9f\x98\x80"; // 20 bytes
-  for (size_t n = 0; n <= s.size(); n += 4) {
-    ASSERT_EQUAL(ref_le(s.data(), n), span_le(s.data(), n));
-  }
-}
-
-// Threshold boundary: 14, 15, 16 → scalar branch; 17, 18 → dispatch.
-TEST(span_convert_utf8_to_utf16le_threshold_boundary) {
-  const std::string s(32, 'B');
-  for (size_t n = 14; n <= 18; ++n) {
-    ASSERT_EQUAL(ref_le(s.data(), n), span_le(s.data(), n));
-  }
-}
-
-// Exactly 16 bytes of 2-byte sequences (8 × é): must be in scalar branch.
-TEST(span_convert_utf8_to_utf16le_exactly_16_bytes_two_byte_seq) {
-  std::string s;
-  for (int i = 0; i < 8; ++i) s += "\xc3\xa9";
-  ASSERT_EQUAL(size_t{16}, s.size());
-  ASSERT_EQUAL(ref_le(s.data(), 16), span_le(s.data(), 16));
-}
-
-// 17 bytes must fall through to the SIMD dispatcher and still be correct.
-TEST(span_convert_utf8_to_utf16le_17_bytes_falls_through_to_dispatch) {
-  const std::string s(17, 'C');
-  ASSERT_EQUAL(ref_le(s.data(), 17), span_le(s.data(), 17));
-}
-
-// _with_errors variants: invalid UTF-8 must return the same error code
-// and position via span as via C-style.
-TEST(span_convert_utf8_to_utf16le_with_errors_bad_continuation) {
-  const char bad[] = "hi\x80ok";
-  size_t len = sizeof(bad) - 1;
-  std::vector<char16_t> out_c(len + 1), out_s(len + 1);
-  auto rc = simdutf::convert_utf8_to_utf16le_with_errors(bad, len, out_c.data());
-  auto rs = simdutf::convert_utf8_to_utf16le_with_errors(
-      std::span<const char>{bad, len},
-      std::span<char16_t>{out_s.data(), out_s.size()});
-  ASSERT_EQUAL(rc.error, rs.error);
-  ASSERT_EQUAL(rc.count, rs.count);
-}
-
-TEST(span_convert_utf8_to_utf16be_with_errors_bad_continuation) {
-  const char bad[] = "AB\x80" "CD"; // split to stop hex escape at \x80
-  size_t len = sizeof(bad) - 1;
-  std::vector<char16_t> out_c(len + 1), out_s(len + 1);
-  auto rc = simdutf::convert_utf8_to_utf16be_with_errors(bad, len, out_c.data());
-  auto rs = simdutf::convert_utf8_to_utf16be_with_errors(
-      std::span<const char>{bad, len},
-      std::span<char16_t>{out_s.data(), out_s.size()});
-  ASSERT_EQUAL(rc.error, rs.error);
-  ASSERT_EQUAL(rc.count, rs.count);
-}
-
-// LE and BE must differ in byte order for non-ASCII output.
-TEST(span_convert_utf8_to_utf16le_and_be_byte_order_distinct) {
-  // é U+00E9: LE stores 0xE9 0x00, BE stores 0x00 0xE9.
-  auto le = span_le("\xc3\xa9", 2);
-  auto be = span_be("\xc3\xa9", 2);
-  ASSERT_EQUAL(size_t{1}, le.size());
-  ASSERT_EQUAL(size_t{1}, be.size());
-  ASSERT_TRUE(le[0] != be[0]);
 }
 #endif
 TEST_MAIN


### PR DESCRIPTION
## What changed

This adds a `<= 16` byte scalar fallback to the UTF-8 to UTF-16 span overloads:

- `convert_utf8_to_utf16le(std::span<const char>, std::span<char16_t>)`
- `convert_utf8_to_utf16be(std::span<const char>, std::span<char16_t>)`
- `convert_utf8_to_utf16le_with_errors(std::span<const char>, std::span<char16_t>)`
- `convert_utf8_to_utf16be_with_errors(std::span<const char>, std::span<char16_t>)`

For those short inputs, the span overload calls the scalar implementation directly instead of going through the selected implementation dispatch path.

## Scope

This keeps the optimization on the inline span/ranges path.

It does not change the C-style API, does not add a new public inline API, and does not move the fix into `implementation.cpp`. That keeps the patch limited to the non-breaking path discussed in issue `#925`.

## Benchmark data

Target reported by `shortbench`: `haswell`

```text
Function                                      Size   Pointer   Span
convert_utf8_to_utf16le                         1    10.9 ns   4.4 ns
convert_utf8_to_utf16le                        16    21.4 ns   6.7 ns
convert_utf8_to_utf16le                        31    34.9 ns   36.7 ns

convert_utf8_to_utf16le_with_errors             1    11.4 ns   3.6 ns
convert_utf8_to_utf16le_with_errors            16    19.7 ns   5.9 ns
```

The size `31` result is why the cutoff stays conservative. The scalar shortcut helps where dispatch overhead dominates, then the existing selected implementation path becomes competitive again.

`shortbench` now has pointer and span entries for the normal and `_with_errors` UTF-8 to UTF-16 paths, so each optimized span overload has a direct C-style baseline.

## Tests

The span tests compare the optimized overloads against the existing pointer API for:

- valid ASCII inputs
- multibyte UTF-8 inputs
- threshold boundary sizes `14, 15, 16, 17, 18`
- invalid UTF-8 cases: illegal bytes, truncated sequence, overlong encoding, surrogate encoding, and out-of-range code point

Local validation:

```text
ctest --output-on-failure -R '^span_tests$'
100% tests passed, 0 tests failed out of 1

ctest --output-on-failure -j 4
100% tests passed, 0 tests failed out of 91
```
