### PR TITLE
fix: silence -Wunused-function warnings on internal scalar/generic helpers

### DIFF
--- a/include/simdutf/scalar/base64.h
+++ b/include/simdutf/scalar/base64.h
@@ -644,9 +644,8 @@ simdutf_constexpr23 size_t tail_encode_base64_impl(
 
 // Returns the number of bytes written. The destination buffer must be large
 // enough. It will add padding (=) if needed.
-inline simdutf_constexpr23 size_t tail_encode_base64(char *dst, const char *src,
-                                                     size_t srclen,
-                                                     base64_options options) {
+simdutf_maybe_unused inline simdutf_constexpr23 size_t tail_encode_base64(
+    char *dst, const char *src, size_t srclen, base64_options options) {
   return tail_encode_base64_impl(dst, src, srclen, options);
 }
 

--- a/include/simdutf/scalar/utf16.h
+++ b/include/simdutf/scalar/utf16.h
@@ -148,7 +148,8 @@ simdutf_really_inline constexpr bool high_surrogate(char16_t c) {
   return (0xd800 <= c && c <= 0xdbff);
 }
 
-simdutf_really_inline constexpr bool low_surrogate(char16_t c) {
+simdutf_maybe_unused simdutf_really_inline constexpr bool
+low_surrogate(char16_t c) {
   return (0xdc00 <= c && c <= 0xdfff);
 }
 

--- a/src/generic/utf8.h
+++ b/src/generic/utf8.h
@@ -17,8 +17,8 @@ simdutf_really_inline size_t count_code_points(const char *in, size_t size) {
 }
 
 #ifdef SIMDUTF_SIMD_HAS_BYTEMASK
-simdutf_really_inline size_t count_code_points_bytemask(const char *in,
-                                                        size_t size) {
+simdutf_maybe_unused simdutf_really_inline size_t
+count_code_points_bytemask(const char *in, size_t size) {
   using vector_i8 = simd8<int8_t>;
   using vector_u8 = simd8<uint8_t>;
   using vector_u64 = simd64<uint64_t>;
@@ -69,8 +69,8 @@ simdutf_really_inline size_t count_code_points_bytemask(const char *in,
 }
 #endif // SIMDUTF_SIMD_HAS_BYTEMASK
 
-simdutf_really_inline size_t utf16_length_from_utf8(const char *in,
-                                                    size_t size) {
+simdutf_maybe_unused simdutf_really_inline size_t
+utf16_length_from_utf8(const char *in, size_t size) {
   size_t pos = 0;
   size_t count = 0;
   // This algorithm could no doubt be improved!


### PR DESCRIPTION
## Problem

Building simdutf as a vendored amalgamation (the V8/Node.js build in #988) emits `-Wunused-function` for three internal helpers:

```
warning: unused function 'low_surrogate' [-Wunused-function]
warning: unused function 'tail_encode_base64' [-Wunused-function]
warning: unused function 'count_code_points_bytemask' [-Wunused-function]
```

These functions have internal linkage (anonymous namespace) in the amalgamated TU, so when a particular target does not reference one of them `-Wunused-function` fires. Each is genuinely used by some kernels and not others (e.g. `count_code_points_bytemask` only by westmere/haswell, `tail_encode_base64` by fallback/ppc64/rvv/lsx/lasx), or is currently uncalled (`low_surrogate`, whose templated sibling `is_low_surrogate` is the one in use).

## Fix

Mark the helpers `simdutf_maybe_unused` (the macro already used elsewhere in the tree, e.g. `src/ppc64/ppc64_base64_internal_tests.cpp`). This is codegen-neutral and is a no-op where the function is used.

While verifying, an arm64 build surfaced the same warning for a fourth generic helper, `utf16_length_from_utf8` (used by fallback/ppc64/westmere but overridden by the arm64 kernel), so it gets the same treatment.

## Validation

The amalgamated `simdutf.cpp` now compiles clean under the stricter gate:

```
c++ -std=c++20 -Wunused-function -Werror -c simdutf.cpp   # no warnings
```

Note that the unused set is target-dependent, so if you decide to add `-Wunused-function` to CI it may surface additional helpers on other architectures; happy to extend this PR to cover those.