### PR TITLE
add missing includes

### DIFF
--- a/include/simdutf/base64_implementation.h
+++ b/include/simdutf/base64_implementation.h
@@ -3,6 +3,8 @@
 
 // this is not part of the public api
 
+#include <algorithm> // for std::min
+
 namespace simdutf {
 
 template <typename chartype>

--- a/tests/helpers/random_utf16.h
+++ b/tests/helpers/random_utf16.h
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <random>
+#include <utility>
 #include <vector>
 
 namespace simdutf {

--- a/tests/helpers/random_utf8.h
+++ b/tests/helpers/random_utf8.h
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <random>
+#include <utility>
 #include <vector>
 
 namespace simdutf {


### PR DESCRIPTION
my experimental c++ standard library chokes on these files.

if one uses std::pair, one has to include utility. this was implicitly included by some other header before.

same thing with std::min, which needs algorithm.
