### PR TITLE
Add CI job that builds and tests from an archive without git

### DIFF
--- a/.github/workflows/ubuntu-archive.yml
+++ b/.github/workflows/ubuntu-archive.yml
@@ -1,0 +1,28 @@
+name: Ubuntu 24.04 CI (archive build, no git)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  archive-build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Recover the project as an archive (no .git)
+        run: |
+          git archive --format=tar.gz --prefix=simdutf-archive/ -o ${{ runner.temp }}/simdutf-archive.tar.gz HEAD &&
+          tar -xzf ${{ runner.temp }}/simdutf-archive.tar.gz -C ${{ runner.temp }} &&
+          test ! -e ${{ runner.temp }}/simdutf-archive/.git
+      - name: Build and test from the archive
+        run: |
+          cd ${{ runner.temp }}/simdutf-archive &&
+          mkdir build &&
+          cd build &&
+          cmake -DCMAKE_CXX_FLAGS=-Werror -DSIMDUTF_ALWAYS_INCLUDE_FALLBACK=ON -DCMAKE_BUILD_TYPE=Release ..   -DSIMDUTF_BENCHMARKS=OFF -DSIMDUTF_FAST_TESTS=ON -DSIMDUTF_TOOL_TESTS=ON &&
+          cmake --build .   &&
+          ctest -j --output-on-failure


### PR DESCRIPTION
## Summary

Closes #923.

All existing CI jobs recover the project with `actions/checkout`, so they only ever exercise a `git clone`. This adds a single job (`.github/workflows/ubuntu-archive.yml`) that:

1. packages the checked-out tree into a `.tar.gz` with `git archive --prefix=simdutf-archive/`,
2. extracts it to a clean directory under `RUNNER_TEMP` and asserts no `.git` is present,
3. configures, builds, and runs `ctest` from that directory (Release, `-Werror`, fast tests, tool tests).

This confirms the library builds when a user obtains the source as a release archive rather than a git clone, and guards against a future change that accidentally makes the build depend on git metadata.

## Verification

Reproduced the archive path locally on macOS (Apple clang, CMake 4.3): `git archive` of `HEAD` extracts with no `.git`, and a git-less configure + build of the library succeeds. The project version is hard-coded in `CMakeLists.txt` (no `git describe`), and CPM fetches dependencies into the build tree, so nothing in the current build depends on `.git`.

## AI usage disclosure

Per the [AI Usage Policy](https://github.com/simdutf/simdutf/blob/master/AI_USAGE_POLICY.md): this change was drafted with AI assistance. I reviewed it, ran the archive/build steps locally to confirm they work, and I am the author and accountable for it.