### PR TITLE
icelake: use unsigned shift base in all remaining tail/mask expressions

### DIFF
--- a/src/icelake/icelake_convert_latin1_to_utf32.inl.cpp
+++ b/src/icelake/icelake_convert_latin1_to_utf32.inl.cpp
@@ -16,7 +16,7 @@ void avx512_convert_latin1_to_utf32(const char *buf, size_t len,
     utf32_output += 16;
   }
 
-  __mmask16 mask = __mmask16((1 << len) - 1);
+  __mmask16 mask = __mmask16((1U << len) - 1);
   __m128i in = _mm_maskz_loadu_epi8(mask, buf);
   __m512i out = _mm512_cvtepu8_epi32(in);
   _mm512_mask_storeu_epi32((__m512i *)utf32_output, mask, out);

--- a/src/icelake/icelake_convert_utf16_to_utf32.inl.cpp
+++ b/src/icelake/icelake_convert_utf16_to_utf32.inl.cpp
@@ -108,7 +108,7 @@ convert_utf16_to_utf32(const char16_t *buf, size_t len,
         // The following could be unsafe in some cases?
         //_mm512_storeu_epi32((__m512i *) utf32_output, compressed_second);
         _mm512_mask_storeu_epi32((__m512i *)utf32_output,
-                                 __mmask16((1 << howmany2) - 1),
+                                 __mmask16((1U << howmany2) - 1),
                                  compressed_second);
         utf32_output += howmany2;
         // Only process 31 code units, but keep track if the 31st word is a high

--- a/src/icelake/icelake_convert_utf32_to_latin1.inl.cpp
+++ b/src/icelake/icelake_convert_utf32_to_latin1.inl.cpp
@@ -19,7 +19,7 @@ size_t icelake_convert_utf32_to_latin1(const char32_t *buf, size_t len,
     buf += 16;
   }
   if (buf < end) {
-    uint16_t mask = uint16_t((1 << (end - buf)) - 1);
+    uint16_t mask = uint16_t((1U << (end - buf)) - 1);
     __m512i in = _mm512_maskz_loadu_epi32(mask, buf);
     if (_mm512_cmpgt_epu32_mask(in, v_0xFF)) {
       return 0;
@@ -57,7 +57,7 @@ icelake_convert_utf32_to_latin1_with_errors(const char32_t *buf, size_t len,
     buf += 16;
   }
   if (buf < end) {
-    uint16_t mask = uint16_t((1 << (end - buf)) - 1);
+    uint16_t mask = uint16_t((1U << (end - buf)) - 1);
     __m512i in = _mm512_maskz_loadu_epi32(mask, buf);
     if (_mm512_cmpgt_epu32_mask(in, v_0xFF)) {
       while (uint32_t(*buf) <= 0xff) {

--- a/src/icelake/icelake_convert_utf32_to_utf16.inl.cpp
+++ b/src/icelake/icelake_convert_utf32_to_utf16.inl.cpp
@@ -84,7 +84,7 @@ avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
 
   size_t remaining_len = size_t(end - buf);
   if (remaining_len) {
-    __mmask16 input_mask = __mmask16((1 << remaining_len) - 1);
+    __mmask16 input_mask = __mmask16((1U << remaining_len) - 1);
     __m512i in = _mm512_maskz_loadu_epi32(input_mask, buf);
     const __mmask16 saturation_bitmask =
         _mm512_cmpeq_epi32_mask(_mm512_and_si512(in, v_ffff0000), v_00000000) &
@@ -104,7 +104,8 @@ avx512_convert_utf32_to_utf16(const char32_t *buf, size_t len,
       utf16_output += remaining_len;
       buf += remaining_len;
     } else {
-      const __mmask32 output_max_mask = (1 << (remaining_len * 2)) - 1;
+      const __mmask32 output_max_mask =
+          __mmask32((uint64_t(1) << (remaining_len * 2)) - 1);
       const __mmask32 output_mask =
           (~_pdep_u32(saturation_bitmask, 0xAAAAAAAA)) & output_max_mask;
       const __mmask16 surrogate_bitmask =
@@ -218,7 +219,7 @@ avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
           code = error_code::SURROGATE;
           error_idx = surrogate_idx;
         }
-        output_mask &= ((1 << (2 * error_idx)) - 1);
+        output_mask &= __mmask32((uint64_t(1) << (2 * error_idx)) - 1);
       }
       __m512i v1, v2, v;
       in = _mm512_mask_sub_epi32(in, surrogate_bitmask, in, v_10000);
@@ -254,7 +255,7 @@ avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
 
   size_t remaining_len = size_t(end - buf);
   if (remaining_len) {
-    __mmask16 input_mask = __mmask16((1 << remaining_len) - 1);
+    __mmask16 input_mask = __mmask16((1U << remaining_len) - 1);
     __m512i in = _mm512_maskz_loadu_epi32(input_mask, buf);
     const __mmask16 saturation_bitmask =
         _mm512_cmpeq_epi32_mask(_mm512_and_si512(in, v_ffff0000), v_00000000) &
@@ -280,7 +281,8 @@ avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
       _mm256_mask_storeu_epi16(utf16_output, input_mask, utf16_packed);
       utf16_output += remaining_len;
     } else {
-      const __mmask32 output_max_mask = (1 << (remaining_len * 2)) - 1;
+      const __mmask32 output_max_mask =
+          __mmask32((uint64_t(1) << (remaining_len * 2)) - 1);
       __mmask32 output_mask =
           (~_pdep_u32(saturation_bitmask, 0xAAAAAAAA)) & output_max_mask;
       const __mmask16 surrogate_bitmask =
@@ -300,7 +302,7 @@ avx512_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
           code = error_code::SURROGATE;
           error_idx = surrogate_idx;
         }
-        output_mask &= ((1 << (2 * error_idx)) - 1);
+        output_mask &= __mmask32((uint64_t(1) << (2 * error_idx)) - 1);
       }
       __m512i v1, v2, v;
       in = _mm512_mask_sub_epi32(in, surrogate_bitmask, in, v_10000);

--- a/src/icelake/icelake_from_utf8.inl.cpp
+++ b/src/icelake/icelake_from_utf8.inl.cpp
@@ -46,7 +46,7 @@ validating_utf8_to_fixed_length(const char *str, size_t len, OUTPUT *dwords) {
     __m512i vec1 = expand_and_identify(lane1, lane2, valid_count1);
     if (valid_count0 + valid_count1 <= 16) {
       vec0 = _mm512_mask_expand_epi32(
-          vec0, __mmask16(((1 << valid_count1) - 1) << valid_count0), vec1);
+          vec0, __mmask16(((1U << valid_count1) - 1) << valid_count0), vec1);
       valid_count0 += valid_count1;
       vec0 = expand_utf8_to_utf32(vec0);
       SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0, true)
@@ -66,7 +66,7 @@ validating_utf8_to_fixed_length(const char *str, size_t len, OUTPUT *dwords) {
     __m512i vec3 = expand_and_identify(lane3, lane4, valid_count3);
     if (valid_count2 + valid_count3 <= 16) {
       vec2 = _mm512_mask_expand_epi32(
-          vec2, __mmask16(((1 << valid_count3) - 1) << valid_count2), vec3);
+          vec2, __mmask16(((1U << valid_count3) - 1) << valid_count2), vec3);
       valid_count2 += valid_count3;
       vec2 = expand_utf8_to_utf32(vec2);
       SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec2, valid_count2, true)
@@ -98,7 +98,7 @@ validating_utf8_to_fixed_length(const char *str, size_t len, OUTPUT *dwords) {
       __m512i vec1 = expand_and_identify(lane1, lane2, valid_count1);
       if (valid_count0 + valid_count1 <= 16) {
         vec0 = _mm512_mask_expand_epi32(
-            vec0, __mmask16(((1 << valid_count1) - 1) << valid_count0), vec1);
+            vec0, __mmask16(((1U << valid_count1) - 1) << valid_count0), vec1);
         valid_count0 += valid_count1;
         vec0 = expand_utf8_to_utf32(vec0);
         SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0, true)
@@ -178,7 +178,7 @@ validating_utf8_to_fixed_length_with_constant_checks(const char *str,
     __m512i vec1 = expand_and_identify(lane1, lane2, valid_count1);
     if (valid_count0 + valid_count1 <= 16) {
       vec0 = _mm512_mask_expand_epi32(
-          vec0, __mmask16(((1 << valid_count1) - 1) << valid_count0), vec1);
+          vec0, __mmask16(((1U << valid_count1) - 1) << valid_count0), vec1);
       valid_count0 += valid_count1;
       vec0 = expand_utf8_to_utf32(vec0);
       SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0, true)
@@ -198,7 +198,7 @@ validating_utf8_to_fixed_length_with_constant_checks(const char *str,
     __m512i vec3 = expand_and_identify(lane3, lane4, valid_count3);
     if (valid_count2 + valid_count3 <= 16) {
       vec2 = _mm512_mask_expand_epi32(
-          vec2, __mmask16(((1 << valid_count3) - 1) << valid_count2), vec3);
+          vec2, __mmask16(((1U << valid_count3) - 1) << valid_count2), vec3);
       valid_count2 += valid_count3;
       vec2 = expand_utf8_to_utf32(vec2);
       SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec2, valid_count2, true)
@@ -234,7 +234,7 @@ validating_utf8_to_fixed_length_with_constant_checks(const char *str,
       __m512i vec1 = expand_and_identify(lane1, lane2, valid_count1);
       if (valid_count0 + valid_count1 <= 16) {
         vec0 = _mm512_mask_expand_epi32(
-            vec0, __mmask16(((1 << valid_count1) - 1) << valid_count0), vec1);
+            vec0, __mmask16(((1U << valid_count1) - 1) << valid_count0), vec1);
         valid_count0 += valid_count1;
         vec0 = expand_utf8_to_utf32(vec0);
         SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0, true)

--- a/src/icelake/icelake_from_valid_utf8.inl.cpp
+++ b/src/icelake/icelake_from_valid_utf8.inl.cpp
@@ -62,7 +62,7 @@ valid_utf8_to_fixed_length(const char *str, size_t len, OUTPUT *dwords) {
     __m512i vec1 = expand_and_identify(lane1, lane2, valid_count1);
     if (valid_count0 + valid_count1 <= 16) {
       vec0 = _mm512_mask_expand_epi32(
-          vec0, __mmask16(((1 << valid_count1) - 1) << valid_count0), vec1);
+          vec0, __mmask16(((1U << valid_count1) - 1) << valid_count0), vec1);
       valid_count0 += valid_count1;
       vec0 = expand_utf8_to_utf32(vec0);
       SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0, true)
@@ -82,7 +82,7 @@ valid_utf8_to_fixed_length(const char *str, size_t len, OUTPUT *dwords) {
     __m512i vec3 = expand_and_identify(lane3, lane4, valid_count3);
     if (valid_count2 + valid_count3 <= 16) {
       vec2 = _mm512_mask_expand_epi32(
-          vec2, __mmask16(((1 << valid_count3) - 1) << valid_count2), vec3);
+          vec2, __mmask16(((1U << valid_count3) - 1) << valid_count2), vec3);
       valid_count2 += valid_count3;
       vec2 = expand_utf8_to_utf32(vec2);
       SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec2, valid_count2, true)
@@ -113,7 +113,7 @@ valid_utf8_to_fixed_length(const char *str, size_t len, OUTPUT *dwords) {
       __m512i vec1 = expand_and_identify(lane1, lane2, valid_count1);
       if (valid_count0 + valid_count1 <= 16) {
         vec0 = _mm512_mask_expand_epi32(
-            vec0, __mmask16(((1 << valid_count1) - 1) << valid_count0), vec1);
+            vec0, __mmask16(((1U << valid_count1) - 1) << valid_count0), vec1);
         valid_count0 += valid_count1;
         vec0 = expand_utf8_to_utf32(vec0);
         SIMDUTF_ICELAKE_WRITE_UTF16_OR_UTF32(vec0, valid_count0, true)

--- a/src/icelake/icelake_macros.inl.cpp
+++ b/src/icelake/icelake_macros.inl.cpp
@@ -70,7 +70,7 @@
                                                                                \
     if (UTF32) {                                                               \
       if (MASKED) {                                                            \
-        const __mmask16 valid = uint16_t((1 << valid_count) - 1);              \
+        const __mmask16 valid = uint16_t((1U << valid_count) - 1);             \
         _mm512_mask_storeu_epi32((__m512i *)output, valid, out);               \
       } else {                                                                 \
         _mm512_storeu_si512((__m512i *)output, out);                           \
@@ -91,7 +91,7 @@
   {                                                                            \
     if (UTF32) {                                                               \
       if (MASKED) {                                                            \
-        const __mmask16 valid_mask = uint16_t((1 << VALID_COUNT) - 1);         \
+        const __mmask16 valid_mask = uint16_t((1U << VALID_COUNT) - 1);        \
         _mm512_mask_storeu_epi32((__m512i *)output, valid_mask, INPUT);        \
       } else {                                                                 \
         _mm512_storeu_si512((__m512i *)output, INPUT);                         \

--- a/src/icelake/icelake_utf32_validation.inl.cpp
+++ b/src/icelake/icelake_utf32_validation.inl.cpp
@@ -40,7 +40,7 @@ bool validate_utf32(const char32_t *buf, size_t len) {
   // Handle remaining 0-15 values with masked load
   if (buf < end) {
     __m512i utf32 =
-        _mm512_maskz_loadu_epi32(__mmask16((1 << (end - buf)) - 1), buf);
+        _mm512_maskz_loadu_epi32(__mmask16((1U << (end - buf)) - 1), buf);
     currentoffsetmax =
         _mm512_max_epu32(_mm512_add_epi32(utf32, offset), currentoffsetmax);
     currentmax = _mm512_max_epu32(utf32, currentmax);

--- a/src/icelake/icelake_utf8_common.inl.cpp
+++ b/src/icelake/icelake_utf8_common.inl.cpp
@@ -456,7 +456,7 @@ simdutf_really_inline size_t utf32_to_utf16_masked(const __m512i byteflip,
                                                    unsigned int count,
                                                    char16_t *output) {
 
-  const __mmask16 valid = uint16_t((1 << count) - 1);
+  const __mmask16 valid = uint16_t((1U << count) - 1);
   // 1. check if we have any surrogate pairs
   const __m512i v_0000_ffff = _mm512_set1_epi32(0x0000ffff);
   const __mmask16 sp_mask =
@@ -599,7 +599,9 @@ simdutf_really_inline size_t utf32_to_utf16(const __m512i byteflip,
     __m512i compressed = _mm512_maskz_compress_epi16(nonzero, t5);
     _mm512_mask_storeu_epi16(
         output,
-        (1 << (count + static_cast<unsigned int>(count_ones(sp_mask)))) - 1,
+        __mmask32((uint64_t(1) << (count + static_cast<unsigned int>(
+                                               count_ones(sp_mask)))) -
+                  1),
         compressed);
     //_mm512_mask_compressstoreu_epi16(output, nonzero, t5);
   }


### PR DESCRIPTION
## Summary

Several icelake kernels build AVX-512 lane masks with a **signed** `1 << n` base where `n` is a lane count that can reach 31 or 32:

- `icelake_convert_utf32_to_utf16.inl.cpp`: `(1 << (remaining_len * 2)) - 1` and `(1 << (2 * error_idx)) - 1` — feed a `__mmask32`, shift can reach 32.
- `icelake_utf8_common.inl.cpp`: `(1 << (count + count_ones(sp_mask))) - 1` — `count` (≤16) plus surrogate count (≤16) can reach 32.

`1 << 31` (signed overflow) and `1 << 32` (shift ≥ width) are **undefined behavior**. A compiler is free to compute a different mask, silently corrupting output. This is the same bug class already fixed for `latin1_to_utf16` (#977) and `utf16_to_latin1` (#976), and is a plausible source of the MSVC-only flaky failures we've seen in the `convert_utf8_to_utf16` / `convert_utf32_to_utf16` tests (deterministic seed, yet fails only under MSVC codegen — the signature of compiler-dependent UB).

## Change

Make the shift base unsigned everywhere it feeds a mask:
- **`uint64_t(1)`** where the shift amount can reach 32 (the `*2` output masks, the error-truncation masks, and the `utf32_to_utf16` store mask);
- **`1U`** for the `__mmask16` sites whose shift stays ≤ 16 (matches the #976/#977 style).

Purely defensive: no functional change on well-behaved compilers; the mask becomes well-defined regardless of toolchain.

## Testing

All conversion/validation tests pass on an AVX-512 (icelake) Linux host — 66/66 in the `convert|validate|utf` set, and the specific `convert_utf8_to_utf16{le,be}` / `convert_utf32_to_utf16{le,be}` tests pass under `-a icelake`. Clean under ASan and UBSan (GCC).

Note: this does not include `src/icelake/icelake_base64.inl.cpp`, whose masks already use a wide `(__mmask64)1` base.