### PR TITLE
tools/fastbase64: fix size_t -> int conversion warning

### DIFF
--- a/tools/fastbase64.cpp
+++ b/tools/fastbase64.cpp
@@ -313,7 +313,7 @@ void CommandLine::write_with_wrapping(std::FILE *fp, const char *data,
       throw std::runtime_error("Failed to write: " +
                                std::string(strerror(errno)));
     }
-    current_col += to_write;
+    current_col += static_cast<int>(to_write);
     i += to_write;
   }
 }


### PR DESCRIPTION
## Summary

`CommandLine::write_with_wrapping` accumulates a `size_t` (`to_write`) into an `int` (`current_col`):

```cpp
current_col += to_write;   // size_t -> int
```

`-Wconversion` flags this as a possibly value-changing narrowing. The value is actually bounded — `to_write <= remaining == wrap_cols - current_col`, so `current_col + to_write <= wrap_cols` and always fits in `int` — but the conversion is implicit. Make it explicit.

## Change

```cpp
current_col += static_cast<int>(to_write);
```

Pure warning cleanup, no behavior change. Surfaced while building the tree with `-Wconversion -Werror`; `fastbase64` now compiles clean under that flag.