### PR TITLE
include what you use - std::abort

### DIFF
--- a/benchmarks/base64/openssl3_base64.h
+++ b/benchmarks/base64/openssl3_base64.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 namespace openssl3 {
 struct evp_Encode_Ctx_st {
   /* number saved in a partial encode/decode */

--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include <array>
+#include <cstdlib>
 #include <iostream>
 #include <chrono>
 #include <thread>

--- a/fuzz/atomic_base64.cpp
+++ b/fuzz/atomic_base64.cpp
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <array>
 #include <format>
 #include <iomanip>

--- a/fuzz/base64.cpp
+++ b/fuzz/base64.cpp
@@ -1,6 +1,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <array>
+#include <cstdlib>
 
 #include "helpers/common.h"
 #include "simdutf.h"

--- a/fuzz/misc.cpp
+++ b/fuzz/misc.cpp
@@ -1,6 +1,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <ranges>
+#include <cstdlib>
 
 #include "helpers/common.h"
 #include "simdutf.h"

--- a/fuzz/roundtrip.cpp
+++ b/fuzz/roundtrip.cpp
@@ -1,6 +1,7 @@
 #include <cstring>
 #include <fuzzer/FuzzedDataProvider.h>
 #include <memory>
+#include <cstdlib>
 #include <string>
 #include <iostream>
 

--- a/fuzz/safe_conversion.cpp
+++ b/fuzz/safe_conversion.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <cstdlib>
 #include <vector>
 
 #include "simdutf.h"

--- a/include/simdutf/common_defs.h
+++ b/include/simdutf/common_defs.h
@@ -1,6 +1,8 @@
 #ifndef SIMDUTF_COMMON_DEFS_H
 #define SIMDUTF_COMMON_DEFS_H
 
+#include <cstdlib>
+
 #include "simdutf/portability.h"
 #include "simdutf/avx512.h"
 

--- a/src/ppc64/ppc64_base64_internal_tests.cpp
+++ b/src/ppc64/ppc64_base64_internal_tests.cpp
@@ -1,3 +1,5 @@
+#include <cstdlib>
+
 namespace base64tests {
 const char *base64_std =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";

--- a/tests/helpers/random_utf16.cpp
+++ b/tests/helpers/random_utf16.cpp
@@ -2,6 +2,7 @@
 #include "simdutf.h"
 #include "../reference/encode_utf16.h"
 
+#include <cstdlib>
 #include <stdexcept>
 #include <vector>
 

--- a/tests/helpers/random_utf32.cpp
+++ b/tests/helpers/random_utf32.cpp
@@ -1,5 +1,6 @@
 #include "random_utf32.h"
 
+#include <cstdlib>
 #include <vector>
 
 namespace simdutf {

--- a/tests/helpers/transcode_test_base.cpp
+++ b/tests/helpers/transcode_test_base.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdlib>
 #include <stdexcept>
 #include <string>
 #include <vector>


### PR DESCRIPTION
this adds include of cstdlib everywhere std::abort is used.

The first commit is where it is absolutely needed.

The second commit is where is is strictly not needed, because it is transitively included.

Best practice is to include what you use. If you use std::abort, then include cstdlib.

The background to this is that I am working with an experimental standard library which has less transitive includes than libstdc++ and libc++.