### PR TITLE
Avoid including algorithm just for std::min

### DIFF
--- a/benchmarks/shortbench.cpp
+++ b/benchmarks/shortbench.cpp
@@ -3,16 +3,16 @@
 // You can process the result with the script at scripts/shortinputplots.py
 // to generate plots. See the instructions in that script for more details.
 #include <algorithm>
-#include <array>
 #include <atomic>
 #include <cmath>
 #include <cstddef>
 #include <cstring>
+#include <exception>
 #include <fstream>
 #include <functional>
 #include <iostream>
 #include <span>
-#include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "simdutf.h"

--- a/benchmarks/shortbench.cpp
+++ b/benchmarks/shortbench.cpp
@@ -498,7 +498,7 @@ int main(int argc, char *argv[]) {
     } else {
       data = read_file(filename);
       file_size = data.size();
-      actual_max = std::min(max_size, file_size);
+      actual_max = simdutf::detail::min(max_size, file_size);
       input_desc = std::string("file: ") + filename;
     }
 

--- a/fuzz/safe_conversion.cpp
+++ b/fuzz/safe_conversion.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cassert>
 #include <cstdlib>
 #include <vector>
@@ -47,7 +48,8 @@ void test_utf16_to_utf8(std::span<const char16_t> input,
       simdutf::convert_utf16_to_utf8(input, reference);
 
   // ensure output is equal to the beginning of reference
-  const auto Ncompare = std::min(written_bytes_safe, written_bytes_unsafe);
+  const auto Ncompare =
+      simdutf::detail::min(written_bytes_safe, written_bytes_unsafe);
   const auto matches =
       std::ranges::equal(std::span(output).subspan(0, Ncompare),
                          std::span(reference).subspan(0, Ncompare));

--- a/fuzz/safe_conversion.cpp
+++ b/fuzz/safe_conversion.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
+#include <type_traits>
 #include <vector>
 
 #include "simdutf.h"

--- a/include/simdutf/base64_implementation.h
+++ b/include/simdutf/base64_implementation.h
@@ -3,7 +3,6 @@
 
 // this is not part of the public api
 
-#include <algorithm>   // for std::min
 #include <type_traits> // for is_same
 
 namespace simdutf {
@@ -71,7 +70,7 @@ simdutf_warn_unused simdutf_constexpr23 result base64_to_binary_safe_impl(
   size_t output_position = 0;
 
   // We also do a first pass using the fast path to decode as much as possible
-  size_t safe_input = (std::min)(
+  size_t safe_input = detail::min(
       remaining_input_length,
       base64_length_from_binary(remaining_output_length / 3 * 3, options));
   bool done_with_partial = (safe_input == remaining_input_length);

--- a/include/simdutf/base64_implementation.h
+++ b/include/simdutf/base64_implementation.h
@@ -3,7 +3,8 @@
 
 // this is not part of the public api
 
-#include <algorithm> // for std::min
+#include <algorithm>   // for std::min
+#include <type_traits> // for is_same
 
 namespace simdutf {
 

--- a/include/simdutf/common_defs.h
+++ b/include/simdutf/common_defs.h
@@ -1,14 +1,13 @@
 #ifndef SIMDUTF_COMMON_DEFS_H
 #define SIMDUTF_COMMON_DEFS_H
 
-#include <cstdlib>
-
 #include "simdutf/portability.h"
 #include "simdutf/avx512.h"
 
 // Sometimes logging is useful, but we want it disabled by default
 // and free of any logging code in release builds.
 #ifdef SIMDUTF_LOGGING
+  #include <cstdlib>
   #include <iostream>
   #define simdutf_log(msg)                                                     \
     std::cout << "[" << __FUNCTION__ << "]: " << msg << std::endl              \

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -59,6 +59,8 @@ namespace {
 constexpr std::size_t min(std::size_t a, std::size_t b) {
   return a < b ? a : b;
 }
+template <typename T, typename U>
+constexpr std::size_t min(const T &a, const U &b) = delete;
 } // namespace
 } // namespace detail
 } // namespace simdutf

--- a/include/simdutf/implementation.h
+++ b/include/simdutf/implementation.h
@@ -51,6 +51,18 @@
   #define SIMDUTF_FEATURE_BASE64 1
 #endif
 
+/// helpers placed in namespace detail are not a part of the public API
+namespace simdutf {
+namespace detail {
+namespace {
+// this is to avoid including <algorithm> just for min
+constexpr std::size_t min(std::size_t a, std::size_t b) {
+  return a < b ? a : b;
+}
+} // namespace
+} // namespace detail
+} // namespace simdutf
+
 #if SIMDUTF_CPLUSPLUS23
   #include <simdutf/constexpr_ptr.h>
 #endif

--- a/include/simdutf/scalar/atomic_util.h
+++ b/include/simdutf/scalar/atomic_util.h
@@ -29,7 +29,7 @@ inline void memcpy_atomic_read(char *dst, const char *src, size_t len) {
   // Handle unaligned start
   size_t offset = reinterpret_cast<std::uintptr_t>(src) % alignment;
   if (offset) {
-    size_t to_align = std::min(len, alignment - offset);
+    size_t to_align = detail::min(len, alignment - offset);
     bbb_memcpy_atomic_read(dst, src, to_align);
     src += to_align;
     dst += to_align;
@@ -76,7 +76,7 @@ inline void memcpy_atomic_write(char *dst, const char *src, size_t len) {
   // Handle unaligned start
   size_t offset = reinterpret_cast<std::uintptr_t>(dst) % alignment;
   if (offset) {
-    size_t to_align = std::min(len, alignment - offset);
+    size_t to_align = detail::min(len, alignment - offset);
     bbb_memcpy_atomic_write(dst, src, to_align);
     dst += to_align;
     src += to_align;

--- a/src/icelake/icelake_convert_utf16_to_utf32.inl.cpp
+++ b/src/icelake/icelake_convert_utf16_to_utf32.inl.cpp
@@ -18,7 +18,7 @@ convert_utf16_to_utf32(const char16_t *buf, size_t len,
       0x0e0f0c0d0a0b0809, 0x0607040502030001, 0x0e0f0c0d0a0b0809,
       0x0607040502030001, 0x0e0f0c0d0a0b0809);
   while (std::distance(buf, end) >= 32) {
-    // Always safe because buf + 32 <= end so that end - buf >= 32 bytes:
+    // Always safe because buf + 32 <= end so that end - buf >= 64 bytes:
     __m512i in = _mm512_loadu_si512((__m512i *)buf);
     if (big_endian) {
       in = _mm512_shuffle_epi8(in, byteflip);

--- a/src/icelake/icelake_convert_utf16_to_utf32.inl.cpp
+++ b/src/icelake/icelake_convert_utf16_to_utf32.inl.cpp
@@ -17,7 +17,7 @@ convert_utf16_to_utf32(const char16_t *buf, size_t len,
       0x0607040502030001, 0x0e0f0c0d0a0b0809, 0x0607040502030001,
       0x0e0f0c0d0a0b0809, 0x0607040502030001, 0x0e0f0c0d0a0b0809,
       0x0607040502030001, 0x0e0f0c0d0a0b0809);
-  while (std::distance(buf, end) >= 32) {
+  while (end - buf >= 32) {
     // Always safe because buf + 32 <= end so that end - buf >= 64 bytes:
     __m512i in = _mm512_loadu_si512((__m512i *)buf);
     if (big_endian) {

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1,5 +1,4 @@
 #include "simdutf.h"
-#include <algorithm>
 #include <climits>
 #include <type_traits>
 #include <utility>
@@ -1817,7 +1816,7 @@ simdutf_warn_unused result atomic_base64_to_binary_safe_impl(
   result r;
   while (!last_chunk) {
     last_chunk |= (temp_buffer.size() >= outlen - actual_out);
-    size_t temp_outlen = (std::min)(temp_buffer.size(), outlen - actual_out);
+    size_t temp_outlen = (detail::min)(temp_buffer.size(), outlen - actual_out);
     r = base64_to_binary_safe(input, length, temp_buffer.data(), temp_outlen,
                               options, last_chunk_handling_options,
                               decode_up_to_bad_char);
@@ -1972,7 +1971,7 @@ convert_utf16_to_utf8_safe(const char16_t *buf, size_t len, char *utf8_output,
     // The worst case for convert_utf16_to_utf8 is when you go from 1 char16_t
     // to 3 characters of UTF-8. So we can read at most utf8_len / 3 char16_t
     // characters.
-    auto read_len = std::min(len, utf8_len / 3);
+    auto read_len = detail::min(len, utf8_len / 3);
     if (read_len <= 16) {
       break;
     }
@@ -2551,7 +2550,7 @@ size_t atomic_binary_to_base64(const char *input, size_t length, char *output,
     #endif
   std::array<char, input_block_size> inbuf;
   for (size_t i = 0; i < length; i += input_block_size) {
-    const size_t current_block_size = std::min(input_block_size, length - i);
+    const size_t current_block_size = detail::min(input_block_size, length - i);
     simdutf::scalar::memcpy_atomic_read(inbuf.data(), input + i,
                                         current_block_size);
     const size_t written = binary_to_base64(inbuf.data(), current_block_size,
@@ -2571,7 +2570,7 @@ simdutf_warn_unused size_t convert_latin1_to_utf8_safe(
 
   while (true) {
     // convert_latin1_to_utf8 will never write more than input length * 2
-    auto read_len = std::min(len, utf8_len >> 1);
+    auto read_len = detail::min(len, utf8_len >> 1);
     if (read_len <= 16) {
       break;
     }

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1,7 +1,7 @@
 #include "simdutf.h"
 #include <climits>
+#include <initializer_list>
 #include <type_traits>
-#include <utility>
 #if SIMDUTF_ATOMIC_REF
   #include <array>
   #include "simdutf/scalar/atomic_util.h"

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -3369,7 +3369,7 @@ TEST(streaming_base64_roundtrip) {
     size_t outpos = 0;
     size_t pos = 0;
     for (; pos < buffer.size();) {
-      size_t count = std::min(window, buffer.size() - pos);
+      size_t count = simdutf::detail::min(window, buffer.size() - pos);
 
       simdutf::full_result r = implementation.base64_to_binary_details(
           buffer.data() + pos, count, back.data() + outpos,
@@ -3411,7 +3411,7 @@ TEST(readme_test) {
   size_t window = 512;
   for (size_t pos = 0; pos < base64.size(); pos += window) {
     // how many base64 characters we can process in this iteration
-    size_t count = std::min(window, base64.size() - pos);
+    size_t count = simdutf::detail::min(window, base64.size() - pos);
     simdutf::result r = simdutf::base64_to_binary(base64.data() + pos, count,
                                                   back.data() + outpos);
     if (r.error == simdutf::error_code::INVALID_BASE64_CHARACTER) {

--- a/tests/convert_utf16_to_utf8_safe_tests.cpp
+++ b/tests/convert_utf16_to_utf8_safe_tests.cpp
@@ -194,7 +194,7 @@ TEST(compile_time_check_of_issue_911) {
   constexpr auto input = u"\u00E9A"_utf16;
   constexpr auto expected = u8"\u00E9A"_utf8;
   constexpr auto actual = convert_insufficient_buf<input, 2>();
-  constexpr auto N = std::min(actual.size(), expected.size());
+  constexpr auto N = simdutf::detail::min(actual.size(), expected.size());
   static_assert(expected.shrink<N>() == actual.shrink<N>());
 }
 

--- a/tools/fastbase64.cpp
+++ b/tools/fastbase64.cpp
@@ -5,7 +5,9 @@
 #include <cstring>
 #include <filesystem>
 #include <memory>
+#include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 class ArgumentError : public std::runtime_error {

--- a/tools/fastbase64.cpp
+++ b/tools/fastbase64.cpp
@@ -308,7 +308,7 @@ void CommandLine::write_with_wrapping(std::FILE *fp, const char *data,
       current_col = 0;
     }
     int remaining = wrap_cols - current_col;
-    size_t to_write = std::min((size_t)remaining, length - i);
+    size_t to_write = simdutf::detail::min((size_t)remaining, length - i);
     if (std::fwrite(data + i, 1, to_write, fp) != to_write) {
       throw std::runtime_error("Failed to write: " +
                                std::string(strerror(errno)));


### PR DESCRIPTION
this defines our own min function. that enables not having to include algorithm, which is a heavy header.

after this fix, the amalgamated source is free of algorithm.

the branch also fixes some include incorrectness.

a questionable change included at the end: remove implicit use of the iterator header by replacing std::distance invoked on pointers.

to make it easier spot uses where the templated std::min would be needed, I made a deleted overload. if that ever fires, we can decide what to do (add an overload, make min() a template, or something else ).

I made all this by hand.