### PR TITLE
optimize the utf16 to utf8 transcoding.

### DIFF
--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -239,6 +239,9 @@ Benchmark::Benchmark(std::vector<input::Testcase> &&testcases)
   register_function("convert_utf16le_to_utf8_with_errors",
                     &Benchmark::run_convert_utf16le_to_utf8_with_errors,
                     simdutf::encoding_type::UTF16_LE);
+  register_function("convert_utf16le_to_utf8_with_replacement",
+                    &Benchmark::run_convert_utf16le_to_utf8_with_replacement,
+                    simdutf::encoding_type::UTF16_LE);
   register_function(
       "convert_utf16le_to_utf8_with_dynamic_allocation",
       &Benchmark::run_convert_utf16le_to_utf8_with_dynamic_allocation,
@@ -2802,6 +2805,40 @@ void Benchmark::run_convert_utf16le_to_utf8(
   auto proc = [&implementation, data, size, &output_buffer, &sink]() {
     sink =
         implementation.convert_utf16le_to_utf8(data, size, output_buffer.get());
+  };
+  count_events(proc, iterations); // warming up!
+  const auto result = count_events(proc, iterations);
+  if ((sink == 0) && (size != 0) && (iterations > 0)) {
+    std::cerr << "The output is zero which might indicate an error.\n";
+  }
+  size_t char_count = get_active_implementation()->count_utf16le(data, size);
+  print_summary(result, input_data.size(), char_count);
+}
+
+void Benchmark::run_convert_utf16le_to_utf8_with_replacement(
+    const simdutf::implementation &implementation, size_t iterations) {
+  const simdutf::encoding_type bom =
+      BOM::check_bom(input_data.data(), input_data.size());
+  const char16_t *data = reinterpret_cast<const char16_t *>(
+      input_data.data() + BOM::bom_byte_size(bom));
+  size_t size = input_data.size() - BOM::bom_byte_size(bom);
+  if (size % 2 != 0) {
+    printf("# The input size is not divisible by two (it is %zu + %zu for BOM)",
+           size_t(input_data.size()), size_t(BOM::bom_byte_size(bom)));
+    printf(" Running function on truncated input.\n");
+  }
+
+  size /= 2;
+
+  // Unpaired surrogates are replaced by U+FFFD (3 bytes); as with the plain
+  // converter, four bytes per 16-bit word is a safe over-allocation.
+  std::unique_ptr<char[]> output_buffer{new char[size * 4]};
+
+  volatile size_t sink{0};
+
+  auto proc = [&implementation, data, size, &output_buffer, &sink]() {
+    sink = implementation.convert_utf16le_to_utf8_with_replacement(
+        data, size, output_buffer.get());
   };
   count_events(proc, iterations); // warming up!
   const auto result = count_events(proc, iterations);

--- a/benchmarks/src/benchmark.h
+++ b/benchmarks/src/benchmark.h
@@ -179,6 +179,8 @@ private:
                                  size_t iterations);
   void run_convert_utf16le_to_utf8_with_errors(
       const simdutf::implementation &implementation, size_t iterations);
+  void run_convert_utf16le_to_utf8_with_replacement(
+      const simdutf::implementation &implementation, size_t iterations);
   void
   run_convert_utf16le_to_utf32(const simdutf::implementation &implementation,
                                size_t iterations);

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -178,6 +178,7 @@ convert_utf8_1_to_2_byte_to_utf16(uint8x16_t in, size_t shufutf8_idx) {
   // transcoding from UTF-8 to UTF-16
   #include "generic/utf8_to_utf16/utf8_to_utf16.h"
   #include "generic/utf8_to_utf16/valid_utf8_to_utf16.h"
+  #include "generic/utf16_to_utf8/utf16_to_utf8_with_replacement.h"
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
   // transcoding from UTF-8 to UTF-32
@@ -1195,14 +1196,26 @@ implementation::utf8_length_from_utf16be_with_replacement(
 simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::LITTLE>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16le(b, l);
+      },
       input, length, utf8_buffer);
 }
 
 simdutf_warn_unused size_t
 implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::BIG>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16be(b, l);
+      },
       input, length, utf8_buffer);
 }
 

--- a/src/generic/utf16_to_utf8/utf16_to_utf8_with_replacement.h
+++ b/src/generic/utf16_to_utf8/utf16_to_utf8_with_replacement.h
@@ -1,0 +1,47 @@
+// Note: no include guard on purpose. This header is included once inside each
+// SIMD kernel's translation unit (and re-expanded per kernel in the
+// amalgamation), matching the other generic/ transcoder headers.
+namespace simdutf {
+namespace SIMDUTF_IMPLEMENTATION {
+namespace {
+namespace utf16_to_utf8 {
+
+// Convert possibly ill-formed UTF-16 to UTF-8, substituting each unpaired
+// surrogate with U+FFFD (0xEF 0xBF 0xBD). Runs the SIMD *_with_errors converter
+// at full speed and only pays extra where an unpaired surrogate is found.
+//
+// convert_with_errors behaves like convert_utf16{le,be}_to_utf8_with_errors: on
+// SUCCESS, result.count is the number of UTF-8 bytes written; on a SURROGATE
+// error, result.count is the index of the first unpaired surrogate.
+// utf8_length is utf8_length_from_utf16{le,be}; only ever called on a prefix
+// already proved valid, so it matches the bytes just written.
+template <typename ConvertWithErrors, typename Utf8Length>
+simdutf_really_inline size_t convert_with_replacement_via(
+    ConvertWithErrors convert_with_errors, Utf8Length utf8_length,
+    const char16_t *buf, size_t len, char *utf8_output) {
+  char *const start = utf8_output;
+  size_t pos = 0;
+  while (pos < len) {
+    result r = convert_with_errors(buf + pos, len - pos, utf8_output);
+    if (r.error != error_code::SURROGATE) {
+      utf8_output += r.count; // SUCCESS: r.count == UTF-8 bytes written
+      break;
+    }
+    // buf[pos + r.count] is unpaired; the valid prefix is already written.
+    const size_t valid_units = r.count;
+    utf8_output += utf8_length(buf + pos, valid_units);
+    pos += valid_units;
+    // Emit U+FFFD and skip the offending code unit.
+    utf8_output[0] = char(0xef);
+    utf8_output[1] = char(0xbf);
+    utf8_output[2] = char(0xbd);
+    utf8_output += 3;
+    pos += 1;
+  }
+  return size_t(utf8_output - start);
+}
+
+} // namespace utf16_to_utf8
+} // unnamed namespace
+} // namespace SIMDUTF_IMPLEMENTATION
+} // namespace simdutf

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -108,6 +108,8 @@ namespace utf16 {
   #include "generic/utf8_to_utf16/valid_utf8_to_utf16.h"
   #include "generic/utf8_to_utf16/utf8_to_utf16.h"
   #include "generic/utf8/utf16_length_from_utf8_bytemask.h"
+  // transcoding from UTF-16 to UTF-8
+  #include "generic/utf16_to_utf8/utf16_to_utf8_with_replacement.h"
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
@@ -1171,14 +1173,26 @@ implementation::utf8_length_from_utf16be_with_replacement(
 simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::LITTLE>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16le(b, l);
+      },
       input, length, utf8_buffer);
 }
 
 simdutf_warn_unused size_t
 implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::BIG>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16be(b, l);
+      },
       input, length, utf8_buffer);
 }
 

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -3,6 +3,12 @@
 #include "simdutf/icelake/intrinsics.h"
 
 #include "simdutf/icelake/begin.h"
+#if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
+  // transcoding from UTF-16 to UTF-8 (self-wrapping generic header; must be
+  // included at namespace scope zero, unlike icelake's own .inl.cpp files which
+  // are included inside the simdutf::icelake namespace below)
+  #include "generic/utf16_to_utf8/utf16_to_utf8_with_replacement.h"
+#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
 namespace {
@@ -1683,14 +1689,26 @@ implementation::utf8_length_from_utf16be_with_replacement(
 simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::LITTLE>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16le(b, l);
+      },
       input, length, utf8_buffer);
 }
 
 simdutf_warn_unused size_t
 implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::BIG>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16be(b, l);
+      },
       input, length, utf8_buffer);
 }
 

--- a/src/lasx/implementation.cpp
+++ b/src/lasx/implementation.cpp
@@ -193,6 +193,8 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
   #include "generic/utf8_to_utf16/valid_utf8_to_utf16.h"
   #include "generic/utf8_to_utf16/utf8_to_utf16.h"
   #include "generic/utf8/utf16_length_from_utf8_bytemask.h"
+  // transcoding from UTF-16 to UTF-8
+  #include "generic/utf16_to_utf8/utf16_to_utf8_with_replacement.h"
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
   // transcoding from UTF-8 to UTF-32
@@ -1321,14 +1323,26 @@ implementation::utf8_length_from_utf16be_with_replacement(
 simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::LITTLE>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16le(b, l);
+      },
       input, length, utf8_buffer);
 }
 
 simdutf_warn_unused size_t
 implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::BIG>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16be(b, l);
+      },
       input, length, utf8_buffer);
 }
 

--- a/src/lsx/implementation.cpp
+++ b/src/lsx/implementation.cpp
@@ -191,6 +191,8 @@ convert_utf8_1_to_2_byte_to_utf16(__m128i in, size_t shufutf8_idx) {
   #include "generic/utf8_to_utf16/valid_utf8_to_utf16.h"
   #include "generic/utf8_to_utf16/utf8_to_utf16.h"
   #include "generic/utf8/utf16_length_from_utf8_bytemask.h"
+  // transcoding from UTF-16 to UTF-8
+  #include "generic/utf16_to_utf8/utf16_to_utf8_with_replacement.h"
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
@@ -1207,14 +1209,26 @@ implementation::utf8_length_from_utf16be_with_replacement(
 simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::LITTLE>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16le(b, l);
+      },
       input, length, utf8_buffer);
 }
 
 simdutf_warn_unused size_t
 implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::BIG>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16be(b, l);
+      },
       input, length, utf8_buffer);
 }
 

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -119,6 +119,7 @@ enum class ErrorReporting {
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
   #include "generic/utf8_to_utf16/utf8_to_utf16.h"
   #include "generic/utf8_to_utf16/valid_utf8_to_utf16.h"
+  #include "generic/utf16_to_utf8/utf16_to_utf8_with_replacement.h"
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
@@ -789,14 +790,26 @@ implementation::utf8_length_from_utf16be_with_replacement(
 simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::LITTLE>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16le(b, l);
+      },
       input, length, utf8_buffer);
 }
 
 simdutf_warn_unused size_t
 implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::BIG>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16be(b, l);
+      },
       input, length, utf8_buffer);
 }
 

--- a/src/rvv/implementation.cpp
+++ b/src/rvv/implementation.cpp
@@ -10,6 +10,12 @@ namespace {
 } // namespace SIMDUTF_IMPLEMENTATION
 } // namespace simdutf
 
+#if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
+  // transcoding from UTF-16 to UTF-8 (self-wrapping generic header, must be
+  // included at namespace scope zero)
+  #include "generic/utf16_to_utf8/utf16_to_utf8_with_replacement.h"
+#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
+
 //
 // Implementation-specific overrides
 //
@@ -119,14 +125,26 @@ implementation::utf8_length_from_utf16be_with_replacement(
 simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::LITTLE>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16le(b, l);
+      },
       input, length, utf8_buffer);
 }
 
 simdutf_warn_unused size_t
 implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::BIG>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16be(b, l);
+      },
       input, length, utf8_buffer);
 }
 

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -109,6 +109,8 @@ must_be_2_3_continuation(const simd8<uint8_t> prev2,
   #include "generic/utf8_to_utf16/valid_utf8_to_utf16.h"
   #include "generic/utf8_to_utf16/utf8_to_utf16.h"
   #include "generic/utf8/utf16_length_from_utf8_bytemask.h"
+  // transcoding from UTF-16 to UTF-8
+  #include "generic/utf16_to_utf8/utf16_to_utf8_with_replacement.h"
 #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
@@ -1260,14 +1262,26 @@ implementation::utf8_length_from_utf16be_with_replacement(
 simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::LITTLE>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16le(b, l);
+      },
       input, length, utf8_buffer);
 }
 
 simdutf_warn_unused size_t
 implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
-  return scalar::utf16_to_utf8::convert_with_replacement<endianness::BIG>(
+  return utf16_to_utf8::convert_with_replacement_via(
+      [this](const char16_t *b, size_t l, char *o) {
+        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
+      },
+      [this](const char16_t *b, size_t l) {
+        return this->utf8_length_from_utf16be(b, l);
+      },
       input, length, utf8_buffer);
 }
 

--- a/tests/convert_utf16_to_utf8_with_replacement_tests.cpp
+++ b/tests/convert_utf16_to_utf8_with_replacement_tests.cpp
@@ -344,6 +344,50 @@ TEST_LOOP(output_is_valid_utf8_le) {
   ASSERT_TRUE(simdutf::validate_utf8(output.data(), written));
 }
 
+// Stress the SIMD block boundaries: slide an unpaired high surrogate, an
+// unpaired low surrogate, and a valid surrogate pair through every offset of a
+// multi-block buffer, comparing the with_replacement output byte-for-byte
+// against the independent to_well_formed + convert oracle. This is the case a
+// naive SIMD implementation is most likely to get wrong (a valid pair or a lone
+// surrogate landing on a 16-unit lane boundary).
+TEST(surrogate_sweep_across_boundaries_le) {
+  const size_t length = 200; // spans many 16-unit SIMD lanes
+  for (size_t p = 0; p + 1 < length; p++) {
+    for (int mode = 0; mode < 3; mode++) {
+      std::vector<char16_t> input(length);
+      for (size_t i = 0; i < length; i++) {
+        // valid, non-surrogate BMP content (mix of 1-, 2- and 3-byte forms)
+        input[i] = to_utf16le(char16_t(0x0041 + (i % 0x0500)));
+      }
+      if (mode == 0) {
+        input[p] = to_utf16le(char16_t(0xD800)); // unpaired high
+      } else if (mode == 1) {
+        input[p] = to_utf16le(char16_t(0xDC00)); // unpaired low
+      } else {
+        input[p] = to_utf16le(char16_t(0xD800)); // valid pair straddling p/p+1
+        input[p + 1] = to_utf16le(char16_t(0xDC00));
+      }
+
+      // Oracle: replace unpaired surrogates, then convert as valid UTF-16.
+      std::vector<char16_t> well_formed(length);
+      simdutf::to_well_formed_utf16le(input.data(), length, well_formed.data());
+      const size_t utf8_len =
+          simdutf::utf8_length_from_utf16le(well_formed.data(), length);
+      std::vector<char> expected(utf8_len + 1);
+      const size_t nexp = simdutf::convert_utf16le_to_utf8(
+          well_formed.data(), length, expected.data());
+
+      std::vector<char> actual(utf8_len + 1);
+      const size_t nact =
+          implementation.convert_utf16le_to_utf8_with_replacement(
+              input.data(), length, actual.data());
+
+      ASSERT_EQUAL(nexp, nact);
+      ASSERT_TRUE(std::memcmp(expected.data(), actual.data(), nact) == 0);
+    }
+  }
+}
+
 #if SIMDUTF_CPLUSPLUS23
 
 namespace {


### PR DESCRIPTION
@anonrig provided a scalar UTF-16 to UTF-8 transcoding function. I am just strapping a SIMD optimized version on an optimistic basis. *IF* the content is proper UTF-16, then it should run at full speed (as if there were no replacement needed).

The speed is decent according to my tests.