### PR TITLE
arm64: test comparison masks with shrn + fcmp instead of a reduction

### DIFF
--- a/src/arm64/arm_convert_utf16_to_utf32.cpp
+++ b/src/arm64/arm_convert_utf16_to_utf32.cpp
@@ -70,7 +70,7 @@ arm_convert_utf16_to_utf32(const char16_t *buf, size_t len,
         vceqq_u16(vandq_u16(in, v_f800), v_d800);
     // It might seem like checking for surrogates_bitmask == 0xc000 could help.
     // However, it is likely an uncommon occurrence.
-    if (vmaxvq_u16(surrogates_bytemask) == 0) {
+    if (!any_lane_set(surrogates_bytemask)) {
       // case: no surrogate pairs, extend all 16-bit code units to 32-bit code
       // units
       vst1q_u32(utf32_output, vmovl_u16(vget_low_u16(in)));
@@ -140,7 +140,7 @@ arm_convert_utf16_to_utf32_with_errors(const char16_t *buf, size_t len,
         vceqq_u16(vandq_u16(in, v_f800), v_d800);
     // It might seem like checking for surrogates_bitmask == 0xc000 could help.
     // However, it is likely an uncommon occurrence.
-    if (vmaxvq_u16(surrogates_bytemask) == 0) {
+    if (!any_lane_set(surrogates_bytemask)) {
       // case: no surrogate pairs, extend all 16-bit code units to 32-bit code
       // units
       vst1q_u32(utf32_output, vmovl_u16(vget_low_u16(in)));

--- a/src/arm64/arm_convert_utf16_to_utf8.cpp
+++ b/src/arm64/arm_convert_utf16_to_utf8.cpp
@@ -147,7 +147,7 @@ arm_convert_utf16_to_utf8(const char16_t *buf, size_t len, char *utf8_out) {
         vceqq_u16(vandq_u16(in, v_f800), v_d800);
     // It might seem like checking for surrogates_bitmask == 0xc000 could help.
     // However, it is likely an uncommon occurrence.
-    if (vmaxvq_u16(surrogates_bytemask) == 0) {
+    if (!any_lane_set(surrogates_bytemask)) {
       // case: code units from register produce either 1, 2 or 3 UTF-8 bytes
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
       const uint16x8_t dup_even = simdutf_make_uint16x8_t(
@@ -416,7 +416,7 @@ arm_convert_utf16_to_utf8_with_errors(const char16_t *buf, size_t len,
         vceqq_u16(vandq_u16(in, v_f800), v_d800);
     // It might seem like checking for surrogates_bitmask == 0xc000 could help.
     // However, it is likely an uncommon occurrence.
-    if (vmaxvq_u16(surrogates_bytemask) == 0) {
+    if (!any_lane_set(surrogates_bytemask)) {
       // case: code units from register produce either 1, 2 or 3 UTF-8 bytes
 #ifdef SIMDUTF_REGULAR_VISUAL_STUDIO
       const uint16x8_t dup_even = simdutf_make_uint16x8_t(
@@ -693,7 +693,7 @@ arm64_utf8_length_from_utf16_with_replacement(const char16_t *in, size_t size) {
     auto is_surrogate = vcleq_u8(
         vsubq_u8(base_input.val[idx], vdupq_n_u8(0xd8)), vdupq_n_u8(7));
     // We count on the fact that most inputs do not have surrogates.
-    if (vmaxvq_u32(vreinterpretq_u32_u8(is_surrogate)) ||
+    if (any_lane_set(vreinterpretq_u16_u8(is_surrogate)) ||
         scalar::utf16::is_low_surrogate<big_endian>(in[pos + N])) {
       any_surrogates = true;
       // there is at least one surrogate in the block

--- a/src/arm64/arm_convert_utf32_to_utf16.cpp
+++ b/src/arm64/arm_convert_utf32_to_utf16.cpp
@@ -112,7 +112,7 @@ arm_convert_utf32_to_utf16(const char32_t *buf, size_t len,
   }
 
   // check for invalid input
-  if (vmaxvq_u32(vreinterpretq_u32_u16(forbidden_bytemask)) != 0) {
+  if (any_lane_set(forbidden_bytemask)) {
     return std::make_pair(nullptr, reinterpret_cast<char16_t *>(utf16_output));
   }
 
@@ -142,7 +142,7 @@ arm_convert_utf32_to_utf16_with_errors(const char32_t *buf, size_t len,
       const uint16x8_t v_f800 = vmovq_n_u16((uint16_t)0xf800);
       const uint16x8_t forbidden_bytemask =
           vceqq_u16(vandq_u16(utf16_packed, v_f800), v_d800);
-      if (vmaxvq_u16(forbidden_bytemask) != 0) {
+      if (any_lane_set(forbidden_bytemask)) {
         return std::make_pair(result(error_code::SURROGATE, buf - start),
                               reinterpret_cast<char16_t *>(utf16_output));
       }

--- a/src/arm64/arm_convert_utf32_to_utf8.cpp
+++ b/src/arm64/arm_convert_utf32_to_utf8.cpp
@@ -243,7 +243,7 @@ arm_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_out) {
   } // while
 
   // check for invalid input
-  if (vmaxvq_u16(forbidden_bytemask) != 0) {
+  if (any_lane_set(forbidden_bytemask)) {
     return std::make_pair(nullptr, reinterpret_cast<char *>(utf8_output));
   }
   return std::make_pair(buf, reinterpret_cast<char *>(utf8_output));
@@ -334,7 +334,7 @@ arm_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
         const uint16x8_t v_dfff = vmovq_n_u16((uint16_t)0xdfff);
         const uint16x8_t forbidden_bytemask = vandq_u16(
             vcleq_u16(utf16_packed, v_dfff), vcgeq_u16(utf16_packed, v_d800));
-        if (vmaxvq_u16(forbidden_bytemask) != 0) {
+        if (any_lane_set(forbidden_bytemask)) {
           return std::make_pair(result(error_code::SURROGATE, buf - start),
                                 reinterpret_cast<char *>(utf8_output));
         }

--- a/src/arm64/arm_utf16fix.cpp
+++ b/src/arm64/arm_utf16fix.cpp
@@ -1,15 +1,12 @@
 
 /*
- * Returns if a vector of type uint8x16_t is all zero.
+ * Returns whether a vector of type uint8x16_t is not all zero. The input is
+ * always a combination of comparison masks (bytes equal to 0x00 or 0xff), so we
+ * can use the two-instruction test (shrn + fcmp) instead of a reduction
+ * followed by a costly move to a general-purpose register.
  */
-simdutf_really_inline int veq_non_zero(uint8x16_t v) {
-  // might compile to two instructions:
-  //	umaxv   s0, v0.4s
-  //	fmov	w0, s0
-  // On Apple hardware, they both have a latency of 3 cycles, with a throughput
-  // of four instructions per cycle. So that's 6 cycles of latency (!!!) for the
-  // two instructions. A narrowing shift has the same latency and throughput.
-  return vmaxvq_u32(vreinterpretq_u32_u8(v));
+simdutf_really_inline bool veq_non_zero(uint8x16_t v) {
+  return any_lane_set(vreinterpretq_u16_u8(v));
 }
 
 /*

--- a/src/arm64/arm_validate_utf32le.cpp
+++ b/src/arm64/arm_validate_utf32le.cpp
@@ -15,15 +15,9 @@ const char32_t *arm_validate_utf32le(const char32_t *input, size_t size) {
     input += 4;
   }
 
-  uint32x4_t is_zero =
-      veorq_u32(vmaxq_u32(currentmax, standardmax), standardmax);
-  if (vmaxvq_u32(is_zero) != 0) {
-    return nullptr;
-  }
-
-  is_zero = veorq_u32(vmaxq_u32(currentoffsetmax, standardoffsetmax),
-                      standardoffsetmax);
-  if (vmaxvq_u32(is_zero) != 0) {
+  const uint32x4_t too_large = vcgtq_u32(currentmax, standardmax);
+  const uint32x4_t surrogate = vcgtq_u32(currentoffsetmax, standardoffsetmax);
+  if (any_lane_set(vreinterpretq_u16_u32(vorrq_u32(too_large, surrogate)))) {
     return nullptr;
   }
 
@@ -46,15 +40,16 @@ const result arm_validate_utf32le_with_errors(const char32_t *input,
     currentmax = vmaxq_u32(in, currentmax);
     currentoffsetmax = vmaxq_u32(vaddq_u32(in, offset), currentoffsetmax);
 
-    uint32x4_t is_zero =
-        veorq_u32(vmaxq_u32(currentmax, standardmax), standardmax);
-    if (vmaxvq_u32(is_zero) != 0) {
-      return result(error_code::TOO_LARGE, input - start);
-    }
-
-    is_zero = veorq_u32(vmaxq_u32(currentoffsetmax, standardoffsetmax),
-                        standardoffsetmax);
-    if (vmaxvq_u32(is_zero) != 0) {
+    // Both accumulators are running maxima, so a single test per iteration is
+    // enough: we only need to tell the two error kinds apart once we know that
+    // one of them occurred.
+    const uint32x4_t too_large = vcgtq_u32(currentmax, standardmax);
+    const uint32x4_t surrogate = vcgtq_u32(currentoffsetmax, standardoffsetmax);
+    if (simdutf_unlikely(any_lane_set(
+            vreinterpretq_u16_u32(vorrq_u32(too_large, surrogate))))) {
+      if (any_lane_set(vreinterpretq_u16_u32(too_large))) {
+        return result(error_code::TOO_LARGE, input - start);
+      }
       return result(error_code::SURROGATE, input - start);
     }
 

--- a/src/simdutf/arm64/simd.h
+++ b/src/simdutf/arm64/simd.h
@@ -66,6 +66,32 @@ namespace {
 } // namespace
 #endif // SIMDUTF_REGULAR_VISUAL_STUDIO
 
+// Returns true if any lane of `mask` is set. The argument *must* be the result
+// of a lane-wise comparison, i.e. each byte must be either 0x00 or 0xff. The
+// lane width of the comparison is irrelevant: byte and 32-bit masks should be
+// reinterpreted with vreinterpretq_u16_u8 / vreinterpretq_u16_u32 by the
+// caller.
+//
+// This compiles to two instructions (shrn + fcmp) and, unlike a reduction such
+// as vmaxvq_u8, it never moves the value to a general-purpose register. Such a
+// transfer has a latency of about 3 cycles on Apple hardware, on top of the 3
+// cycles of the reduction itself.
+//
+// Both steps rely on the input being a comparison mask. The narrowing shift
+// keeps bits 4..11 of each 16-bit lane, so it only preserves 'is non-zero' when
+// every byte is 0x00 or 0xff. The floating-point comparison is safe for the
+// same reason: the only non-zero bit pattern that compares equal to 0.0 is -0.0
+// (0x8000000000000000), and the most significant byte of the narrowed value can
+// only be 0x00, 0x0f, 0xf0 or 0xff.
+//
+// There is deliberately a single overload: Visual Studio defines every 128-bit
+// NEON type as the same union type, so overloading on uint8x16_t, uint16x8_t
+// and uint32x4_t does not compile there.
+simdutf_really_inline bool any_lane_set(const uint16x8_t mask) {
+  const uint8x8_t narrowed = vshrn_n_u16(mask, 4);
+  return vget_lane_f64(vreinterpret_f64_u8(narrowed), 0) != 0.0;
+}
+
 template <typename T> struct simd8;
 
 //

--- a/src/simdutf/arm64/simd32-inl.h
+++ b/src/simdutf/arm64/simd32-inl.h
@@ -57,7 +57,11 @@ template <> struct simd32<bool> {
 
   simdutf_really_inline simd32(const uint32x4_t v) : value(v) {}
 
-  simdutf_really_inline bool any() const { return vmaxvq_u32(value) != 0; }
+  // simd32<bool> is only ever produced by lane-wise comparisons (and bitwise
+  // combinations thereof), so the cheap any_lane_set is always applicable.
+  simdutf_really_inline bool any() const {
+    return any_lane_set(vreinterpretq_u16_u32(value));
+  }
 };
 
 //----------------------------------------------------------------------


### PR DESCRIPTION
Checking whether a NEON comparison mask has any lane set was done with a reduction (vmaxvq_*) followed by a move to a general-purpose register. On Apple hardware both instructions have a latency of about 3 cycles, so the test costs ~6 cycles.

When the vector is the result of a lane-wise comparison (every byte is 0x00 or 0xff), a narrowing shift by 4 preserves 'is non-zero', and the result can be compared against zero directly in the floating-point register file:

	shrn.8b	v0, v0, #4
	fcmp	d0, #0.0

This is two instructions and no cross-domain transfer. Both steps require the input to be a comparison mask: shrn #4 keeps bits 4..11 of each 16-bit lane, and the only non-zero bit pattern that compares equal to 0.0 is -0.0, whose most significant byte (0x80) cannot be produced from a mask.

This adds simd::any_lane_set() and uses it where the operand is already known to be a comparison mask: simd32<bool>::any() (which covers the generic UTF-32 validation loop), the utf16fix illsequencing test, the surrogate tests in UTF-16 to UTF-8/UTF-32, and the forbidden-code-point tests in UTF-32 to UTF-8/UTF-16.

In arm_validate_utf32le, veorq(vmaxq(a, b), b) is non-zero exactly when a > b, so it is replaced by vcgtq_u32; the _with_errors loop then tests both accumulators at once and only tells the two error kinds apart on the unlikely error path.



This is a micro-optimization that might not deliver an obvious win in general, but it saves a bit of latency here and there.