### PR TITLE
Draft: investigate safe UTF-16 ASCII preflight

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -98,4 +98,9 @@ add_executable(shortbench shortbench.cpp)
 target_link_libraries(shortbench PUBLIC simdutf::benchmarks::benchmark)
 target_compile_features(shortbench PRIVATE cxx_std_20)
 
+add_executable(benchmark_safe_utf16_to_utf8 benchmark_safe_utf16_to_utf8.cpp)
+target_link_libraries(benchmark_safe_utf16_to_utf8 PRIVATE simdutf)
+set_property(TARGET benchmark_safe_utf16_to_utf8 PROPERTY CXX_STANDARD 17)
+set_property(TARGET benchmark_safe_utf16_to_utf8 PROPERTY CXX_STANDARD_REQUIRED ON)
+
 add_subdirectory(find)

--- a/benchmarks/benchmark_safe_utf16_to_utf8.cpp
+++ b/benchmarks/benchmark_safe_utf16_to_utf8.cpp
@@ -1,0 +1,289 @@
+// Benchmark capacity-limited UTF-16 to UTF-8 conversion.
+#include "simdutf.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+constexpr size_t guard_length = 32;
+constexpr char marker = char(0xa5);
+
+enum class input_kind {
+  ascii,
+  one_to_three_byte,
+  three_to_four_byte,
+  late_three_byte,
+};
+
+struct options {
+  size_t input_length{256};
+  size_t iterations{1000000};
+  size_t output_capacity{0};
+  const char *implementation_name{"haswell"};
+  input_kind kind{input_kind::ascii};
+  bool capacity_specified{false};
+  bool json{false};
+};
+
+enum class parse_result { success, help, error };
+
+void print_usage(const char *program) {
+  std::printf(
+      "Usage: %s [--size N] [--iterations N] [--capacity N] "
+      "[--implementation NAME] "
+      "[--input ascii|one-to-three|three-to-four|late-three] [--json]\n",
+      program);
+}
+
+bool parse_size(const char *text, size_t &value) {
+  size_t parsed = 0;
+  if (*text == '\0') {
+    return false;
+  }
+  for (const char *p = text; *p != '\0'; ++p) {
+    if (*p < '0' || *p > '9') {
+      return false;
+    }
+    const size_t digit = size_t(*p - '0');
+    if (parsed > (std::numeric_limits<size_t>::max() - digit) / 10) {
+      return false;
+    }
+    parsed = parsed * 10 + digit;
+  }
+  value = parsed;
+  return true;
+}
+
+bool parse_input_kind(const char *text, input_kind &kind) {
+  const std::string_view name(text);
+  if (name == "ascii") {
+    kind = input_kind::ascii;
+  } else if (name == "one-to-three") {
+    kind = input_kind::one_to_three_byte;
+  } else if (name == "three-to-four") {
+    kind = input_kind::three_to_four_byte;
+  } else if (name == "late-three") {
+    kind = input_kind::late_three_byte;
+  } else {
+    return false;
+  }
+  return true;
+}
+
+parse_result parse_options(int argc, char *argv[], options &result) {
+  for (int i = 1; i < argc; ++i) {
+    if (std::strcmp(argv[i], "--size") == 0 && i + 1 < argc) {
+      if (!parse_size(argv[++i], result.input_length) ||
+          result.input_length == 0) {
+        return parse_result::error;
+      }
+    } else if (std::strcmp(argv[i], "--iterations") == 0 && i + 1 < argc) {
+      if (!parse_size(argv[++i], result.iterations) || result.iterations == 0) {
+        return parse_result::error;
+      }
+    } else if (std::strcmp(argv[i], "--capacity") == 0 && i + 1 < argc) {
+      if (!parse_size(argv[++i], result.output_capacity)) {
+        return parse_result::error;
+      }
+      result.capacity_specified = true;
+    } else if (std::strcmp(argv[i], "--implementation") == 0 &&
+               i + 1 < argc) {
+      result.implementation_name = argv[++i];
+    } else if (std::strcmp(argv[i], "--input") == 0 && i + 1 < argc) {
+      if (!parse_input_kind(argv[++i], result.kind)) {
+        return parse_result::error;
+      }
+    } else if (std::strcmp(argv[i], "--json") == 0) {
+      result.json = true;
+    } else if (std::strcmp(argv[i], "--help") == 0 ||
+               std::strcmp(argv[i], "-h") == 0) {
+      return parse_result::help;
+    } else {
+      return parse_result::error;
+    }
+  }
+  return parse_result::success;
+}
+
+const char *input_kind_name(input_kind kind) {
+  switch (kind) {
+  case input_kind::ascii:
+    return "ascii";
+  case input_kind::one_to_three_byte:
+    return "one-to-three";
+  case input_kind::three_to_four_byte:
+    return "three-to-four";
+  case input_kind::late_three_byte:
+    return "late-three";
+  }
+  return "unknown";
+}
+
+void make_input(input_kind kind, std::vector<char16_t> &input) {
+  switch (kind) {
+  case input_kind::ascii:
+    for (size_t i = 0; i < input.size(); ++i) {
+      input[i] = char16_t((i * 37 + 13) & 0x7f);
+    }
+    break;
+  case input_kind::one_to_three_byte:
+    for (size_t i = 0; i < input.size(); ++i) {
+      switch (i % 3) {
+      case 0:
+        input[i] = u'A';
+        break;
+      case 1:
+        input[i] = char16_t(0x00e9);
+        break;
+      default:
+        input[i] = char16_t(0x4e00);
+        break;
+      }
+    }
+    break;
+  case input_kind::three_to_four_byte:
+    for (size_t i = 0; i < input.size();) {
+      input[i++] = char16_t(0x4e00);
+      if (i + 1 < input.size()) {
+        input[i++] = char16_t(0xd83d);
+        input[i++] = char16_t(0xde00);
+      }
+    }
+    break;
+  case input_kind::late_three_byte:
+    std::fill(input.begin(), input.end(), u'A');
+    input.back() = char16_t(0x4e00);
+    break;
+  }
+}
+
+bool matches_reference(const std::vector<char> &output,
+                       const std::vector<char> &reference, size_t written,
+                       size_t reference_written, size_t output_capacity) {
+  if (written != reference_written) {
+    return false;
+  }
+  for (size_t i = 0; i < written; ++i) {
+    if (output[i] != reference[i]) {
+      return false;
+    }
+  }
+  for (size_t i = output_capacity; i < output.size(); ++i) {
+    if (output[i] != marker) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  options options{};
+  switch (parse_options(argc, argv, options)) {
+  case parse_result::success:
+    break;
+  case parse_result::help:
+    print_usage(argv[0]);
+    return 0;
+  case parse_result::error:
+    std::fprintf(stderr, "invalid benchmark arguments\n");
+    print_usage(argv[0]);
+    return 1;
+  }
+  if (options.iterations >
+      std::numeric_limits<size_t>::max() / options.input_length) {
+    std::fprintf(stderr, "iteration count is too large\n");
+    return 1;
+  }
+
+  const simdutf::implementation *const implementation =
+      simdutf::get_available_implementations()[options.implementation_name];
+  const simdutf::implementation *const fallback =
+      simdutf::get_available_implementations()["fallback"];
+  if (implementation == nullptr ||
+      !implementation->supported_by_runtime_system() || fallback == nullptr) {
+    std::fprintf(stderr, "the requested implementation is unavailable\n");
+    return 1;
+  }
+
+  std::vector<char16_t> input(options.input_length);
+  make_input(options.kind, input);
+  if (!options.capacity_specified) {
+    options.output_capacity =
+        simdutf::utf8_length_from_utf16(input.data(), input.size());
+  }
+  if (options.output_capacity >
+      std::numeric_limits<size_t>::max() - guard_length) {
+    std::fprintf(stderr, "output capacity is too large\n");
+    return 1;
+  }
+
+  std::vector<char> reference(options.output_capacity + guard_length, marker);
+  std::vector<char> output(options.output_capacity + guard_length, marker);
+  simdutf::get_active_implementation() = fallback;
+  const size_t reference_written = simdutf::convert_utf16_to_utf8_safe(
+      input.data(), input.size(), reference.data(), options.output_capacity);
+
+  simdutf::get_active_implementation() = implementation;
+  constexpr size_t warmup_iterations = 10000;
+  size_t warmup_written = 0;
+  for (size_t i = 0; i < warmup_iterations; ++i) {
+    warmup_written = simdutf::convert_utf16_to_utf8_safe(
+        input.data(), input.size(), output.data(), options.output_capacity);
+  }
+  if (!matches_reference(output, reference, warmup_written, reference_written,
+                         options.output_capacity)) {
+    std::fprintf(stderr, "warmup conversion did not match fallback\n");
+    return 1;
+  }
+  if (reference_written >
+      std::numeric_limits<size_t>::max() / options.iterations) {
+    std::fprintf(stderr, "iteration count is too large\n");
+    return 1;
+  }
+
+  std::fill(output.begin(), output.end(), marker);
+  size_t total_written = 0;
+  const auto start = std::chrono::steady_clock::now();
+  for (size_t i = 0; i < options.iterations; ++i) {
+    total_written += simdutf::convert_utf16_to_utf8_safe(
+        input.data(), input.size(), output.data(), options.output_capacity);
+  }
+  const auto end = std::chrono::steady_clock::now();
+
+  if (total_written != options.iterations * reference_written ||
+      !matches_reference(output, reference, reference_written, reference_written,
+                         options.output_capacity)) {
+    std::fprintf(stderr, "timed conversion did not match fallback\n");
+    return 1;
+  }
+
+  const double elapsed_ns =
+      std::chrono::duration<double, std::nano>(end - start).count();
+  const double ns_per_operation = elapsed_ns / double(options.iterations);
+  if (!std::isfinite(ns_per_operation) || ns_per_operation <= 0) {
+    std::fprintf(stderr, "invalid elapsed time\n");
+    return 1;
+  }
+
+  if (options.json) {
+    std::printf("{\"metric\":\"ns/op\",\"value\":%.9f}\n",
+                ns_per_operation);
+  } else {
+    std::printf(
+        "%s UTF-16 to UTF-8, input: %s, size: %zu, capacity: %zu, "
+        "iterations: %zu\n",
+        options.implementation_name, input_kind_name(options.kind),
+        options.input_length, options.output_capacity, options.iterations);
+    std::printf("%.3f ns/op\n", ns_per_operation);
+  }
+  return 0;
+}

--- a/doc/safe_utf16_to_utf8_preflight.md
+++ b/doc/safe_utf16_to_utf8_preflight.md
@@ -1,0 +1,62 @@
+# Safe UTF-16 to UTF-8 preflight: residual handoff
+
+Status: draft evidence only. Do not merge this optimization or present it as a
+general performance result until the residual below has a sealed green result.
+
+## What is supported
+
+The candidate commit `38d0fc678d9d38bcc36c582a2b483d0e926372f5` is directly
+on top of the comparison/harness commit `af4bf61e7076d98a89e6dcf687588f3d14b1f282`.
+For the public `convert_utf16_to_utf8_safe` API on Haswell, ASCII input of 256
+UTF-16 code units, and exact output capacity, ten alternating paired runs
+measured a median of 139.904 ns/op for the comparison and 42.504 ns/op for the
+candidate. The paired-median improvement was 97.488 ns/op, with a 95% interval
+of 95.783 to 98.962 ns/op.
+
+The focused benchmark validates the selected public implementation against the
+fallback implementation, checks output guards, and consumes the timed result.
+The candidate also passed the available CMake, sanitizer, and differential
+correctness checks. Those results support this narrow ASCII selector only.
+
+## Residual: a missed no-regression path
+
+The candidate takes its new path when the output capacity equals the UTF-16
+length, the input is 32 through 4096 code units, and code units at positions
+0, `len / 2`, and `len - 1` are ASCII. It then calls the Haswell UTF-16 ASCII
+validator before deciding whether to use the direct converter.
+
+At length 256, input that is ASCII except for U+00E9 at index 127 passes the
+three cheap samples: positions 0, 128, and 255 are all ASCII. The candidate
+therefore enters the vector ASCII preflight, which discovers the interior
+non-ASCII code unit and falls through to the old safe-conversion path. That
+adds preflight work to a valid public-API workload that receives none of the
+ASCII fast-path benefit.
+
+The benchmark selectors do not exercise this state:
+
+- `ascii` takes the new fast path.
+- `one-to-three` and `three-to-four` have non-ASCII data at a sampled position.
+- `late-three` puts its non-ASCII code unit at `len - 1`, also a sampled
+  position.
+
+They either bypass the preflight immediately or take the fast path; none leaves
+all three samples ASCII while making the subsequent validation fail.
+
+## Handoff to the next session
+
+Do not change the optimization in this draft. First add a sealed public-API
+paired Haswell selector with these properties:
+
+1. 256 UTF-16 code units and output capacity 256.
+2. ASCII input except U+00E9 at index 127.
+3. Existing fallback-result and output-guard validation before and after the
+   timed loop.
+4. Alternating comparison/candidate runs under the same build, implementation,
+   and selector.
+5. An explicit no-regression gate: the paired comparison-minus-candidate median
+   and its lower confidence bound must both be at least zero.
+
+If that selector regresses, the next session should repair the preflight shape
+and then rerun the narrow ASCII win and this no-regression selector together.
+If it passes, it closes this residual only; broader architecture and workload
+coverage still need their own claims and measurements.

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -1963,6 +1963,41 @@ simdutf_warn_unused size_t
 convert_utf16_to_utf8_safe(const char16_t *buf, size_t len, char *utf8_output,
                            size_t utf8_len) noexcept {
   const auto start{utf8_output};
+  #if SIMDUTF_FEATURE_ASCII
+  // ASCII has one output byte per input code unit. When the caller provides
+  // exactly that much output space, avoid repeatedly shrinking a conservative
+  // three-byte slice. The haswell converter can process the whole ASCII prefix
+  // in one entry and retains its usual scalar tail. Restrict this extra scan to
+  // the short-input range where it costs less than the avoided re-entries.
+  constexpr size_t ascii_preflight_min_length = 32;
+  constexpr size_t ascii_preflight_max_length = 4096;
+  // Avoid a full preflight for common non-ASCII insufficient-buffer inputs.
+  if (utf8_len == len && len >= ascii_preflight_min_length &&
+      len <= ascii_preflight_max_length && buf[0] <= 0x7f &&
+      buf[len / 2] <= 0x7f && buf[len - 1] <= 0x7f) {
+    const implementation *active_implementation = get_default_implementation();
+    if (active_implementation->name() == "haswell") {
+      // Refresh the pointer after first-use implementation detection.
+      active_implementation = get_default_implementation();
+      #if SIMDUTF_IS_BIG_ENDIAN
+      const bool is_ascii =
+          active_implementation->validate_utf16be_as_ascii(buf, len);
+      #else
+      const bool is_ascii =
+          active_implementation->validate_utf16le_as_ascii(buf, len);
+      #endif // SIMDUTF_IS_BIG_ENDIAN
+      if (is_ascii) {
+        #if SIMDUTF_IS_BIG_ENDIAN
+        return active_implementation->convert_utf16be_to_utf8(buf, len,
+                                                               utf8_output);
+        #else
+        return active_implementation->convert_utf16le_to_utf8(buf, len,
+                                                               utf8_output);
+        #endif // SIMDUTF_IS_BIG_ENDIAN
+      }
+    }
+  }
+  #endif // SIMDUTF_FEATURE_ASCII
   // We might be able to go faster by first scanning the input buffer to
   // determine how many char16_t characters we can read without exceeding the
   // utf8_len. This is a one-pass algorithm that has the benefit of not

--- a/tests/convert_utf16_to_utf8_safe_tests.cpp
+++ b/tests/convert_utf16_to_utf8_safe_tests.cpp
@@ -64,6 +64,85 @@ TEST(issue911) {
   ASSERT_TRUE(written <= 2);
 }
 
+TEST(ascii_exact_capacity_preserves_output_bounds) {
+  constexpr size_t max_input_length = 4096;
+  constexpr size_t guard_length = 32;
+  constexpr char marker = char(0xa5);
+  std::array<char16_t, max_input_length> input{};
+  for (size_t i = 0; i < input.size(); ++i) {
+    input[i] = char16_t(i & 0x7f);
+  }
+
+  std::vector<char> output(max_input_length + 2 * guard_length, marker);
+  char *const destination = output.data() + guard_length;
+  for (const size_t input_length : {size_t(32), size_t(33), size_t(1024),
+                                    max_input_length}) {
+    const size_t written = simdutf::convert_utf16_to_utf8_safe(
+        input.data(), input_length, destination, input_length);
+    ASSERT_EQUAL(written, input_length);
+    for (size_t i = 0; i < input_length; ++i) {
+      ASSERT_EQUAL(destination[i], char(i & 0x7f));
+    }
+    for (size_t i = 0; i < guard_length; ++i) {
+      ASSERT_EQUAL(output[i], marker);
+    }
+    for (size_t i = guard_length + input_length; i < output.size(); ++i) {
+      ASSERT_EQUAL(output[i], marker);
+    }
+
+    for (size_t i = 0; i < output.size(); ++i) {
+      output[i] = marker;
+    }
+    const size_t limited_written = simdutf::convert_utf16_to_utf8_safe(
+        input.data(), input_length, destination, input_length - 1);
+    ASSERT_EQUAL(limited_written, input_length - 1);
+    for (size_t i = 0; i < limited_written; ++i) {
+      ASSERT_EQUAL(destination[i], char(i & 0x7f));
+    }
+    for (size_t i = guard_length + input_length - 1; i < output.size(); ++i) {
+      ASSERT_EQUAL(output[i], marker);
+    }
+  }
+}
+
+TEST(safe_utf16_to_utf8_preserves_surrogate_prefixes) {
+  constexpr size_t input_length = 64;
+  constexpr size_t guard_length = 16;
+  constexpr char marker = char(0xa5);
+  std::array<char16_t, input_length> input{};
+  input.fill(u'A');
+  input[31] = char16_t(0xd800);
+  std::vector<char> output(input_length + guard_length, marker);
+  const size_t malformed_written = simdutf::convert_utf16_to_utf8_safe(
+      input.data(), input.size(), output.data(), input.size());
+  ASSERT_EQUAL(malformed_written, size_t(0));
+  for (size_t i = 0; i < 31; ++i) {
+    ASSERT_EQUAL(output[i], 'A');
+  }
+  for (size_t i = input.size(); i < output.size(); ++i) {
+    ASSERT_EQUAL(output[i], marker);
+  }
+
+  input.fill(u'A');
+  input[20] = char16_t(0xd800);
+  input[21] = char16_t(0xdc00);
+  std::vector<char> expected(input.size() * 3);
+  const size_t expected_written =
+      simdutf::convert_utf16_to_utf8(input.data(), input.size(), expected.data());
+  ASSERT_EQUAL(expected_written, input.size() + 2);
+
+  for (size_t i = 0; i < output.size(); ++i) {
+    output[i] = marker;
+  }
+  const size_t limited_written = simdutf::convert_utf16_to_utf8_safe(
+      input.data(), input.size(), output.data(), input.size());
+  ASSERT_EQUAL(limited_written, input.size());
+  ASSERT_BYTES_EQUAL(output, expected, limited_written);
+  for (size_t i = limited_written; i < output.size(); ++i) {
+    ASSERT_EQUAL(output[i], marker);
+  }
+}
+
 TEST(convert_pure_ASCII) {
   size_t counter = 0;
   auto generator = [&counter]() -> uint32_t { return counter++ & 0x7f; };


### PR DESCRIPTION
## Status

Draft evidence handoff only. This PR is not ready to merge or share as a general performance result.

## What changed

This branch contains the candidate optimization, its focused benchmark and correctness tests, plus doc/safe_utf16_to_utf8_preflight.md. The document records the evidence that is supported and the proof that is still missing.

## Supported result

The public safe UTF-16-to-UTF-8 API has a sealed paired win for Haswell ASCII at N=256 and exact capacity: 139.904 to 42.504 ns/op, a 97.488 ns/op paired-median improvement across ten alternating pairs.

## Blocking residual

At N=256, ASCII except U+00E9 at index 127 leaves sample positions 0, 128, and 255 ASCII. The candidate enters the vector ASCII preflight, discovers the interior non-ASCII code unit, and then falls back to the old path after extra work. Existing benchmark modes never cover that branch.

The committed handoff names the required sealed public-API paired Haswell selector, fallback/guard checks, and explicit no-regression gate. Do not repair the optimization in this PR; assign that to the next session.

## Verification

- Targeted Release build: convert_utf16_to_utf8_safe_tests and benchmark_safe_utf16_to_utf8 passed locally.
- Artifact chain: the candidate Git bundle and patch hashes match the recorded candidate; candidate 38d0fc6 is directly atop comparison/harness commit af4bf61.

## AI disclosure

This is an AI-assisted draft created under operator direction. It remains draft pending human review of the evidence and wording before it is offered for maintainer review.