### PR TITLE
Pack mixed-width UTF-32 blocks on vector and fallback paths

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -45,6 +45,11 @@ target_link_libraries(benchmark PUBLIC simdutf::benchmarks::benchmark)
 set_property(TARGET benchmark PROPERTY CXX_STANDARD 17)
 set_property(TARGET benchmark PROPERTY CXX_STANDARD_REQUIRED ON)
 
+add_executable(benchmark_utf32_to_utf8_mixed utf32_to_utf8_mixed.cpp)
+target_link_libraries(benchmark_utf32_to_utf8_mixed PUBLIC simdutf)
+set_property(TARGET benchmark_utf32_to_utf8_mixed PROPERTY CXX_STANDARD 17)
+set_property(TARGET benchmark_utf32_to_utf8_mixed PROPERTY CXX_STANDARD_REQUIRED ON)
+
 if(WIN32 AND BUILD_SHARED_LIBS)
   # Copy the simdutf dll into the benchmark directory
   add_custom_command(TARGET stream POST_BUILD        # Adds a post-build event

--- a/benchmarks/utf32_to_utf8_mixed.cpp
+++ b/benchmarks/utf32_to_utf8_mixed.cpp
@@ -138,7 +138,7 @@ bool verify_conversion(const simdutf::implementation *implementation,
                        const std::vector<char> &expected, char *output) {
   const simdutf::result result =
       implementation->convert_utf32_to_utf8_with_errors(input.data(),
-                                                         input.size(), output);
+                                                        input.size(), output);
   return result.error == simdutf::error_code::SUCCESS &&
          result.count == expected.size() &&
          std::equal(expected.begin(), expected.end(), output);
@@ -150,7 +150,7 @@ int main(int argc, char *argv[]) {
   options options;
   if (!parse_options(argc, argv, options)) {
     return argc > 1 && std::string_view(argv[1]) == "--help" ? EXIT_SUCCESS
-                                                                : EXIT_FAILURE;
+                                                             : EXIT_FAILURE;
   }
 
   const simdutf::implementation *implementation =
@@ -189,9 +189,8 @@ int main(int argc, char *argv[]) {
   const auto start = std::chrono::steady_clock::now();
   for (size_t iteration = 0; iteration < options.iterations; iteration++) {
     const simdutf::result result =
-        implementation->convert_utf32_to_utf8_with_errors(input.data(),
-                                                           input.size(),
-                                                           output.get());
+        implementation->convert_utf32_to_utf8_with_errors(
+            input.data(), input.size(), output.get());
     sink += result.count;
   }
   const auto finish = std::chrono::steady_clock::now();
@@ -209,7 +208,7 @@ int main(int argc, char *argv[]) {
   std::cout << std::fixed << std::setprecision(9)
             << "{\"metric\":\"ns/input_scalar\",\"value\":"
             << ns_per_input_scalar << "}" << '\n'
-            << "{\"metric\":\"ns/call\",\"value\":" << ns_per_call
-            << "}" << '\n';
+            << "{\"metric\":\"ns/call\",\"value\":" << ns_per_call << "}"
+            << '\n';
   return EXIT_SUCCESS;
 }

--- a/benchmarks/utf32_to_utf8_mixed.cpp
+++ b/benchmarks/utf32_to_utf8_mixed.cpp
@@ -1,0 +1,215 @@
+#include "simdutf.h"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cerrno>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+struct options {
+  std::string implementation{"haswell"};
+  std::string workload{"mixed"};
+  size_t size{32768};
+  size_t iterations{10000};
+};
+
+void print_usage(std::ostream &out, std::string_view program) {
+  out << "Usage: " << program
+      << " [--implementation NAME]"
+         " [--workload ascii|mixed|mixed-after-bmp|emoji]"
+         " [--size INPUT_SCALARS] [--iterations COUNT]\n";
+}
+
+bool parse_size(std::string_view text, size_t &value) {
+  if (text.empty()) {
+    return false;
+  }
+  char *end = nullptr;
+  errno = 0;
+  const unsigned long long parsed = std::strtoull(text.data(), &end, 10);
+  if (errno != 0 || end != text.data() + text.size() || parsed == 0 ||
+      parsed > size_t(-1)) {
+    return false;
+  }
+  value = static_cast<size_t>(parsed);
+  return true;
+}
+
+bool parse_options(int argc, char *argv[], options &parsed) {
+  for (int i = 1; i < argc; i++) {
+    const std::string_view argument{argv[i]};
+    if (argument == "--help") {
+      print_usage(std::cout, argv[0]);
+      return false;
+    }
+    if (i + 1 == argc) {
+      std::cerr << "missing value for " << argument << '\n';
+      return false;
+    }
+    const std::string_view value{argv[++i]};
+    if (argument == "--implementation") {
+      parsed.implementation = value;
+    } else if (argument == "--workload") {
+      parsed.workload = value;
+    } else if (argument == "--size") {
+      if (!parse_size(value, parsed.size)) {
+        std::cerr << "invalid --size value: " << value << '\n';
+        return false;
+      }
+    } else if (argument == "--iterations") {
+      if (!parse_size(value, parsed.iterations)) {
+        std::cerr << "invalid --iterations value: " << value << '\n';
+        return false;
+      }
+    } else {
+      std::cerr << "unknown argument: " << argument << '\n';
+      return false;
+    }
+  }
+  return true;
+}
+
+std::vector<char32_t> make_input(const options &options) {
+  std::vector<char32_t> input(options.size);
+  if (options.workload == "ascii") {
+    for (size_t i = 0; i < input.size(); i++) {
+      input[i] = char32_t(0x20 + (i % 95));
+    }
+  } else if (options.workload == "emoji") {
+    for (size_t i = 0; i < input.size(); i++) {
+      input[i] = char32_t(0x1f600 + (i % 64));
+    }
+  } else if (options.workload == "mixed" ||
+             options.workload == "mixed-after-bmp") {
+    constexpr std::array<char32_t, 4> codepoints{
+        {0x41, 0x00a2, 0x20ac, 0x1f600}};
+    const size_t bmp_prefix = options.workload == "mixed-after-bmp" ? 16 : 0;
+    for (size_t i = 0; i < input.size(); i++) {
+      if (i < bmp_prefix) {
+        input[i] = codepoints[i % 3];
+      } else {
+        const size_t mixed_index = i - bmp_prefix;
+        const size_t plan = (mixed_index / 4) & 0xff;
+        const size_t width = (plan >> ((mixed_index & 3) * 2)) & 0x3;
+        input[i] = codepoints[width];
+      }
+    }
+  } else {
+    throw std::invalid_argument(
+        "workload must be ascii, mixed, mixed-after-bmp, or emoji");
+  }
+  return input;
+}
+
+std::vector<char> encode_utf8(const std::vector<char32_t> &input) {
+  std::vector<char> output;
+  output.reserve(input.size() * 4);
+  for (const char32_t codepoint : input) {
+    if (codepoint <= 0x7f) {
+      output.push_back(static_cast<char>(codepoint));
+    } else if (codepoint <= 0x7ff) {
+      output.push_back(static_cast<char>(0xc0 | (codepoint >> 6)));
+      output.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
+    } else if (codepoint <= 0xffff) {
+      output.push_back(static_cast<char>(0xe0 | (codepoint >> 12)));
+      output.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3f)));
+      output.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
+    } else {
+      output.push_back(static_cast<char>(0xf0 | (codepoint >> 18)));
+      output.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3f)));
+      output.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3f)));
+      output.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
+    }
+  }
+  return output;
+}
+
+bool verify_conversion(const simdutf::implementation *implementation,
+                       const std::vector<char32_t> &input,
+                       const std::vector<char> &expected, char *output) {
+  const simdutf::result result =
+      implementation->convert_utf32_to_utf8_with_errors(input.data(),
+                                                         input.size(), output);
+  return result.error == simdutf::error_code::SUCCESS &&
+         result.count == expected.size() &&
+         std::equal(expected.begin(), expected.end(), output);
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  options options;
+  if (!parse_options(argc, argv, options)) {
+    return argc > 1 && std::string_view(argv[1]) == "--help" ? EXIT_SUCCESS
+                                                                : EXIT_FAILURE;
+  }
+
+  const simdutf::implementation *implementation =
+      simdutf::get_available_implementations()[options.implementation];
+  if (implementation == nullptr) {
+    std::cerr << "implementation is not compiled: " << options.implementation
+              << '\n';
+    return EXIT_FAILURE;
+  }
+  if (!implementation->supported_by_runtime_system()) {
+    std::cerr << "implementation is unsupported by this host: "
+              << options.implementation << '\n';
+    return EXIT_FAILURE;
+  }
+
+  std::vector<char32_t> input;
+  try {
+    input = make_input(options);
+  } catch (const std::invalid_argument &error) {
+    std::cerr << error.what() << '\n';
+    print_usage(std::cerr, argv[0]);
+    return EXIT_FAILURE;
+  }
+  const std::vector<char> expected = encode_utf8(input);
+  const size_t output_size = expected.size();
+  // The valid workloads use an exact-size allocation, rather than the common
+  // 4 * input.size() upper bound, to exercise packed-store bounds.
+  std::unique_ptr<char[]> output(new char[output_size]);
+
+  if (!verify_conversion(implementation, input, expected, output.get())) {
+    std::cerr << "warmup conversion failed\n";
+    return EXIT_FAILURE;
+  }
+
+  volatile size_t sink = 0;
+  const auto start = std::chrono::steady_clock::now();
+  for (size_t iteration = 0; iteration < options.iterations; iteration++) {
+    const simdutf::result result =
+        implementation->convert_utf32_to_utf8_with_errors(input.data(),
+                                                           input.size(),
+                                                           output.get());
+    sink += result.count;
+  }
+  const auto finish = std::chrono::steady_clock::now();
+  if (sink != options.iterations * output_size ||
+      !verify_conversion(implementation, input, expected, output.get())) {
+    std::cerr << "timed conversion failed\n";
+    return EXIT_FAILURE;
+  }
+
+  const double elapsed_ns =
+      std::chrono::duration<double, std::nano>(finish - start).count();
+  const double ns_per_input_scalar =
+      elapsed_ns / double(options.iterations * input.size());
+  const double ns_per_call = elapsed_ns / double(options.iterations);
+  std::cout << std::fixed << std::setprecision(9)
+            << "{\"metric\":\"ns/input_scalar\",\"value\":"
+            << ns_per_input_scalar << "}" << '\n'
+            << "{\"metric\":\"ns/call\",\"value\":" << ns_per_call
+            << "}" << '\n';
+  return EXIT_SUCCESS;
+}

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -1,7 +1,187 @@
 #include "simdutf/fallback/begin.h"
 
+#if defined(SIMDUTF_IS_X86_64) && !defined(SIMDUTF_REGULAR_VISUAL_STUDIO)
+  #include <immintrin.h>
+#endif
+
+#if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
+  #if defined(SIMDUTF_IS_X86_64) && !defined(SIMDUTF_REGULAR_VISUAL_STUDIO)
+SIMDUTF_TARGET_REGION("ssse3,sse4.1")
 namespace simdutf {
 namespace SIMDUTF_IMPLEMENTATION {
+namespace {
+
+struct utf32_packed_progress {
+  size_t input;
+  size_t output;
+};
+
+constexpr size_t utf32_code_units_per_pack = 4;
+constexpr size_t utf8_packed_store_bytes = 16;
+constexpr size_t utf32_pack_groups_per_batch = 16;
+// A four-code-unit result has at least four useful bytes, so twelve following
+// valid code units back the remaining bytes of its 16-byte wide store.
+constexpr size_t utf32_pack_lookahead =
+    utf8_packed_store_bytes - utf32_code_units_per_pack;
+
+simdutf_really_inline uint8_t spread_four_bits(uint8_t bits) {
+  bits = static_cast<uint8_t>((bits | (bits << 2)) & 0x33);
+  return static_cast<uint8_t>((bits | (bits << 1)) & 0x55);
+}
+
+bool sse41_valid_utf32_blocks(const char32_t *buf, size_t block_count) {
+  const __m128i v_10ffff = _mm_set1_epi32(0x10ffff);
+  const __m128i v_fffff800 = _mm_set1_epi32(static_cast<int32_t>(0xfffff800u));
+  const __m128i v_d800 = _mm_set1_epi32(0xd800);
+  __m128i maximum = v_10ffff;
+  __m128i surrogate = _mm_setzero_si128();
+  for (size_t block = 0; block < block_count; block++) {
+    const __m128i input =
+        _mm_loadu_si128(reinterpret_cast<const __m128i *>(buf + block * 4));
+    maximum = _mm_max_epu32(maximum, input);
+    surrogate = _mm_or_si128(
+        surrogate, _mm_cmpeq_epi32(_mm_and_si128(input, v_fffff800), v_d800));
+  }
+  return static_cast<uint32_t>(
+             _mm_movemask_epi8(_mm_cmpeq_epi32(maximum, v_10ffff))) == 0xffff &&
+         _mm_movemask_epi8(surrogate) == 0;
+}
+
+utf32_packed_progress sse41_pack_utf32_to_utf8(const char32_t *buf, size_t len,
+                                               char *utf8_output) {
+  const __m128i v_007f = _mm_set1_epi32(0x007f);
+  const __m128i v_07ff = _mm_set1_epi32(0x07ff);
+  const __m128i v_ffff = _mm_set1_epi32(0xffff);
+  const __m128i v_3f000000 = _mm_set1_epi32(static_cast<int32_t>(0x3f000000u));
+  const __m128i v_003f0000 = _mm_set1_epi32(0x003f0000);
+  const __m128i v_00003f00 = _mm_set1_epi32(0x00003f00);
+  const __m128i v_808080f0 = _mm_set1_epi32(static_cast<int32_t>(0x808080f0u));
+  const __m128i v_40 = _mm_set1_epi32(0x40);
+  const __m128i v_60 = _mm_set1_epi32(0x60);
+  size_t pos = 0;
+  char *const output_start = utf8_output;
+  while (pos + utf32_pack_groups_per_batch * utf32_code_units_per_pack +
+             utf32_pack_lookahead <=
+         len) {
+    // Validate the whole batch and its lookahead before the first wide store.
+    // If it contains an error, scalar code resumes at this batch and preserves
+    // the exact first-error index and output prefix.
+    if (!sse41_valid_utf32_blocks(
+            buf + pos, utf32_pack_groups_per_batch +
+                           utf32_pack_lookahead / utf32_code_units_per_pack)) {
+      break;
+    }
+    for (size_t group = 0; group < utf32_pack_groups_per_batch; group++) {
+      const __m128i input =
+          _mm_loadu_si128(reinterpret_cast<const __m128i *>(buf + pos));
+      // The three comparison masks both classify each lane and form the two
+      // bits per lane used to select a compacting PSHUFB row below.
+      const __m128i more_than_7f = _mm_cmpgt_epi32(input, v_007f);
+      const __m128i more_than_7ff = _mm_cmpgt_epi32(input, v_07ff);
+      const __m128i more_than_ffff = _mm_cmpgt_epi32(input, v_ffff);
+      const __m128i four_byte = _mm_or_si128(
+          _mm_or_si128(_mm_and_si128(_mm_slli_epi32(input, 24), v_3f000000),
+                       _mm_and_si128(_mm_slli_epi32(input, 10), v_003f0000)),
+          _mm_or_si128(_mm_and_si128(_mm_srli_epi32(input, 4), v_00003f00),
+                       _mm_srli_epi32(input, 18)));
+      const __m128i four_byte_with_prefix = _mm_or_si128(four_byte, v_808080f0);
+      __m128i encoded = _mm_blendv_epi8(
+          input, _mm_xor_si128(_mm_srli_epi32(four_byte_with_prefix, 16), v_40),
+          more_than_7f);
+      encoded = _mm_blendv_epi8(
+          encoded,
+          _mm_xor_si128(_mm_srli_epi32(four_byte_with_prefix, 8), v_60),
+          more_than_7ff);
+      encoded = _mm_blendv_epi8(encoded, four_byte_with_prefix, more_than_ffff);
+
+      const uint8_t more_than_7f_mask =
+          static_cast<uint8_t>(_mm_movemask_ps(_mm_castsi128_ps(more_than_7f)));
+      const uint8_t more_than_7ff_mask = static_cast<uint8_t>(
+          _mm_movemask_ps(_mm_castsi128_ps(more_than_7ff)));
+      const uint8_t more_than_ffff_mask = static_cast<uint8_t>(
+          _mm_movemask_ps(_mm_castsi128_ps(more_than_ffff)));
+      const uint8_t low_width_bits = static_cast<uint8_t>(
+          more_than_7f_mask ^ more_than_7ff_mask ^ more_than_ffff_mask);
+      const uint8_t high_width_bits = more_than_7ff_mask;
+      const uint8_t key =
+          static_cast<uint8_t>(spread_four_bits(low_width_bits) |
+                               (spread_four_bits(high_width_bits) << 1));
+      const uint8_t *row =
+          simdutf::tables::utf32_to_utf8::pack_1_2_3_4_utf8_bytes.rows[key];
+      const __m128i packed = _mm_shuffle_epi8(
+          encoded, _mm_loadu_si128(reinterpret_cast<const __m128i *>(row + 1)));
+      _mm_storeu_si128(reinterpret_cast<__m128i *>(utf8_output), packed);
+      utf8_output += row[0];
+      pos += 4;
+    }
+  }
+  return {pos, size_t(utf8_output - output_start)};
+}
+
+} // unnamed namespace
+} // namespace SIMDUTF_IMPLEMENTATION
+} // namespace simdutf
+SIMDUTF_UNTARGET_REGION
+  #endif
+#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
+
+namespace simdutf {
+namespace SIMDUTF_IMPLEMENTATION {
+
+#if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
+namespace {
+
+struct utf32_ascii_progress {
+  size_t input;
+  size_t output;
+};
+
+utf32_ascii_progress copy_utf32_ascii_prefix(const char32_t *buf, size_t len,
+                                             char *utf8_output) {
+  size_t pos = 0;
+  char *const output_start = utf8_output;
+  while (pos + 4 <= len) {
+    const uint32_t word0 = static_cast<uint32_t>(buf[pos]);
+    const uint32_t word1 = static_cast<uint32_t>(buf[pos + 1]);
+    const uint32_t word2 = static_cast<uint32_t>(buf[pos + 2]);
+    const uint32_t word3 = static_cast<uint32_t>(buf[pos + 3]);
+    if (((word0 | word1 | word2 | word3) & 0xffffff80) != 0) {
+      break;
+    }
+    utf8_output[0] = static_cast<char>(word0);
+    utf8_output[1] = static_cast<char>(word1);
+    utf8_output[2] = static_cast<char>(word2);
+    utf8_output[3] = static_cast<char>(word3);
+    utf8_output += 4;
+    pos += 4;
+  }
+  return {pos, size_t(utf8_output - output_start)};
+}
+
+} // unnamed namespace
+#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
+
+#if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
+  #if defined(SIMDUTF_IS_X86_64) && !defined(SIMDUTF_REGULAR_VISUAL_STUDIO)
+simdutf_never_inline bool fallback_sse41_supported() {
+  // Keep this cache constant-initialized: the no-libc++ build cannot use the
+  // guard helpers generated for dynamically initialized function statics.
+  static uint32_t cached = 0;
+  uint32_t state = __atomic_load_n(&cached, __ATOMIC_ACQUIRE);
+  if (state == 0) {
+    const uint32_t detected = (internal::detect_supported_architectures() &
+                               internal::instruction_set::SSE42) != 0
+                                  ? 2
+                                  : 1;
+    uint32_t expected = 0;
+    __atomic_compare_exchange_n(&cached, &expected, detected, false,
+                                __ATOMIC_RELEASE, __ATOMIC_ACQUIRE);
+    state = __atomic_load_n(&cached, __ATOMIC_ACQUIRE);
+  }
+  return state == 2;
+}
+  #endif
+#endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
 
 #if SIMDUTF_FEATURE_DETECT_ENCODING
 simdutf_warn_unused int
@@ -325,7 +505,28 @@ simdutf_warn_unused size_t implementation::convert_utf32_to_utf8(
 
 simdutf_warn_unused result implementation::convert_utf32_to_utf8_with_errors(
     const char32_t *buf, size_t len, char *utf8_output) const noexcept {
-  return scalar::utf32_to_utf8::convert_with_errors(buf, len, utf8_output);
+  const utf32_ascii_progress ascii =
+      copy_utf32_ascii_prefix(buf, len, utf8_output);
+  #if defined(SIMDUTF_IS_X86_64) && !defined(SIMDUTF_REGULAR_VISUAL_STUDIO)
+  if (fallback_sse41_supported()) {
+    const utf32_packed_progress progress = sse41_pack_utf32_to_utf8(
+        buf + ascii.input, len - ascii.input, utf8_output + ascii.output);
+    const result tail = scalar::utf32_to_utf8::convert_with_errors(
+        buf + ascii.input + progress.input, len - ascii.input - progress.input,
+        utf8_output + ascii.output + progress.output);
+    if (tail.error) {
+      return result(tail.error, tail.count + ascii.input + progress.input);
+    }
+    return result(error_code::SUCCESS,
+                  ascii.output + progress.output + tail.count);
+  }
+  #endif
+  const result tail = scalar::utf32_to_utf8::convert_with_errors(
+      buf + ascii.input, len - ascii.input, utf8_output + ascii.output);
+  if (tail.error) {
+    return result(tail.error, tail.count + ascii.input);
+  }
+  return result(error_code::SUCCESS, ascii.output + tail.count);
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf32_to_utf8(

--- a/src/haswell/avx2_convert_utf32_to_utf8.cpp
+++ b/src/haswell/avx2_convert_utf32_to_utf8.cpp
@@ -1,3 +1,17 @@
+// The cold mixed-width packer reports only completed input and output. It
+// leaves the first invalid block for the existing scalar error path.
+struct avx2_utf32_progress {
+  size_t input;
+  size_t output;
+};
+
+#if !defined(SIMDUTF_REGULAR_VISUAL_STUDIO)
+__attribute__((cold))
+#endif
+avx2_utf32_progress
+avx2_pack_mixed_utf32_to_utf8(const char32_t *buf, size_t len,
+                              char *utf8_output);
+
 std::pair<const char32_t *, char *>
 avx2_convert_utf32_to_utf8(const char32_t *buf, size_t len, char *utf8_output) {
   const char32_t *end = buf + len;
@@ -286,6 +300,41 @@ avx2_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
   const char32_t *end = buf + len;
   const char32_t *start = buf;
 
+  // Keep the common all-ASCII stream independent of the mixed-width
+  // continuation below. Four AVX2 loads make two exact 16-byte stores and
+  // avoid the width-plan handoff entirely.
+  const __m256i ascii_mask = _mm256_set1_epi32(-128);
+  while (end - buf >= std::ptrdiff_t(32)) {
+    const __m256i in0 =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf));
+    const __m256i in1 =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf) + 1);
+    const __m256i in2 =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf) + 2);
+    const __m256i in3 =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf) + 3);
+    const __m256i any_non_ascii =
+        _mm256_or_si256(_mm256_or_si256(in0, in1), _mm256_or_si256(in2, in3));
+    if (!_mm256_testz_si256(any_non_ascii, ascii_mask)) {
+      break;
+    }
+
+    const __m256i packed01 =
+        _mm256_permute4x64_epi64(_mm256_packus_epi32(in0, in1), 0b11011000);
+    const __m256i packed23 =
+        _mm256_permute4x64_epi64(_mm256_packus_epi32(in2, in3), 0b11011000);
+    const __m128i utf8_01 =
+        _mm_packus_epi16(_mm256_castsi256_si128(packed01),
+                         _mm256_extractf128_si256(packed01, 1));
+    const __m128i utf8_23 =
+        _mm_packus_epi16(_mm256_castsi256_si128(packed23),
+                         _mm256_extractf128_si256(packed23, 1));
+    _mm_storeu_si128(reinterpret_cast<__m128i *>(utf8_output), utf8_01);
+    _mm_storeu_si128(reinterpret_cast<__m128i *>(utf8_output + 16), utf8_23);
+    buf += 32;
+    utf8_output += 32;
+  }
+
   const __m256i v_0000 = _mm256_setzero_si256();
   const __m256i v_ffff0000 = _mm256_set1_epi32((uint32_t)0xffff0000);
   const __m256i v_ff80 = _mm256_set1_epi16((uint16_t)0xff80);
@@ -526,42 +575,37 @@ avx2_convert_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
       utf8_output += row3[0];
       buf += 16;
     } else {
-      // case: at least one 32-bit word is larger than 0xFFFF <=> it will
-      // produce four UTF-8 bytes. Let us do a scalar fallback. It may seem
-      // wasteful to use scalar code, but being efficient with SIMD may require
-      // large, non-trivial tables?
-      size_t forward = 15;
+      // Preserve only the BMP prefix of the first wide block. The packer takes
+      // over at its first four-byte or otherwise invalid scalar and leaves a
+      // failing block for the established scalar error path.
       size_t k = 0;
-      if (size_t(end - buf) < forward + 1) {
-        forward = size_t(end - buf - 1);
-      }
-      for (; k < forward; k++) {
-        uint32_t word = buf[k];
-        if ((word & 0xFFFFFF80) == 0) { // 1-byte (ASCII)
+      for (; k < 16; k++) {
+        const uint32_t word = buf[k];
+        if ((word & 0xffff0000) != 0) {
+          break;
+        }
+        if ((word & 0xffffff80) == 0) { // 1-byte (ASCII)
           *utf8_output++ = char(word);
-        } else if ((word & 0xFFFFF800) == 0) { // 2-byte
+        } else if ((word & 0xfffff800) == 0) { // 2-byte
           *utf8_output++ = char((word >> 6) | 0b11000000);
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
-        } else if ((word & 0xFFFF0000) == 0) { // 3-byte
-          if (word >= 0xD800 && word <= 0xDFFF) {
+        } else { // 3-byte
+          if (word >= 0xd800 && word <= 0xdfff) {
             return std::make_pair(
                 result(error_code::SURROGATE, buf - start + k), utf8_output);
           }
           *utf8_output++ = char((word >> 12) | 0b11100000);
           *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
           *utf8_output++ = char((word & 0b111111) | 0b10000000);
-        } else { // 4-byte
-          if (word > 0x10FFFF) {
-            return std::make_pair(
-                result(error_code::TOO_LARGE, buf - start + k), utf8_output);
-          }
-          *utf8_output++ = char((word >> 18) | 0b11110000);
-          *utf8_output++ = char(((word >> 12) & 0b111111) | 0b10000000);
-          *utf8_output++ = char(((word >> 6) & 0b111111) | 0b10000000);
-          *utf8_output++ = char((word & 0b111111) | 0b10000000);
         }
       }
       buf += k;
+      const avx2_utf32_progress packed =
+          avx2_pack_mixed_utf32_to_utf8(buf, size_t(end - buf), utf8_output);
+      buf += packed.input;
+      utf8_output += packed.output;
+      return std::make_pair(result(error_code::SUCCESS, buf - start),
+                            utf8_output);
     }
   } // while
 

--- a/src/haswell/avx2_convert_utf32_to_utf8_mixed.cpp
+++ b/src/haswell/avx2_convert_utf32_to_utf8_mixed.cpp
@@ -1,0 +1,271 @@
+#include "simdutf/haswell/begin.h"
+
+namespace simdutf {
+namespace SIMDUTF_IMPLEMENTATION {
+namespace {
+
+simdutf_really_inline uint8_t spread_four_bits(uint8_t bits) {
+  bits = static_cast<uint8_t>((bits | (bits << 2)) & 0x33);
+  return static_cast<uint8_t>((bits | (bits << 1)) & 0x55);
+}
+
+// Pack eight valid UTF-32 code units. Each group of four is compressed with a
+// PSHUFB plan indexed by its two-bit-per-code-unit UTF-8 widths.
+simdutf_really_inline char *avx2_pack_eight_utf32_to_utf8(__m256i input,
+                                                          char *utf8_output) {
+  const __m256i v_007f = _mm256_set1_epi32(0x007f);
+  const __m256i v_07ff = _mm256_set1_epi32(0x07ff);
+  const __m256i v_ffff = _mm256_set1_epi32(0xffff);
+  const __m256i v_24 = _mm256_set1_epi32(24);
+  const __m256i v_3f000000 =
+      _mm256_set1_epi32(static_cast<int32_t>(0x3f000000u));
+  const __m256i v_003f0000 = _mm256_set1_epi32(0x003f0000);
+  const __m256i v_00003f00 = _mm256_set1_epi32(0x00003f00);
+  const __m256i v_808080f0 =
+      _mm256_set1_epi32(static_cast<int32_t>(0x808080f0u));
+  const __m256i v_80808000 =
+      _mm256_set1_epi32(static_cast<int32_t>(0x80808000u));
+  const __m256i correction_table =
+      _mm256_setr_epi8(static_cast<char>(0x80), 0x40, 0x60, 0, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0, 0, static_cast<char>(0x80), 0x40, 0x60, 0,
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+
+  // Each comparison is all ones in lanes that need the next UTF-8 byte. Their
+  // negated sum is therefore the width minus one (from zero through three).
+  const __m256i more_than_7f = _mm256_cmpgt_epi32(input, v_007f);
+  const __m256i more_than_7ff = _mm256_cmpgt_epi32(input, v_07ff);
+  const __m256i more_than_ffff = _mm256_cmpgt_epi32(input, v_ffff);
+  const __m256i widths = _mm256_sub_epi32(
+      _mm256_setzero_si256(),
+      _mm256_add_epi32(_mm256_add_epi32(more_than_7f, more_than_7ff),
+                       more_than_ffff));
+
+  // Form a four-byte UTF-8 sequence in every 32-bit lane. For shorter
+  // sequences, shift away unused leading continuation bytes and correct the
+  // leading byte below.
+  __m256i encoded = _mm256_or_si256(
+      _mm256_or_si256(
+          _mm256_and_si256(_mm256_slli_epi32(input, 24), v_3f000000),
+          _mm256_and_si256(_mm256_slli_epi32(input, 10), v_003f0000)),
+      _mm256_or_si256(_mm256_and_si256(_mm256_srli_epi32(input, 4), v_00003f00),
+                      _mm256_srli_epi32(input, 18)));
+  encoded = _mm256_or_si256(encoded, v_808080f0);
+
+  const __m256i shifts = _mm256_sub_epi32(v_24, _mm256_slli_epi32(widths, 3));
+  const __m256i correction = _mm256_shuffle_epi8(
+      correction_table, _mm256_or_si256(widths, v_80808000));
+  encoded = _mm256_xor_si256(_mm256_srlv_epi32(encoded, shifts), correction);
+  // The generic four-byte representation carries six payload bits. Restore
+  // the seventh ASCII bit by selecting the original lane for one-byte input.
+  encoded = _mm256_blendv_epi8(input, encoded, more_than_7f);
+
+  const uint8_t more_than_7f_mask = static_cast<uint8_t>(
+      _mm256_movemask_ps(_mm256_castsi256_ps(more_than_7f)));
+  const uint8_t more_than_7ff_mask = static_cast<uint8_t>(
+      _mm256_movemask_ps(_mm256_castsi256_ps(more_than_7ff)));
+  const uint8_t more_than_ffff_mask = static_cast<uint8_t>(
+      _mm256_movemask_ps(_mm256_castsi256_ps(more_than_ffff)));
+  const uint8_t low_width_bits = static_cast<uint8_t>(
+      more_than_7f_mask ^ more_than_7ff_mask ^ more_than_ffff_mask);
+  const uint8_t high_width_bits = more_than_7ff_mask;
+  const uint8_t key0 =
+      static_cast<uint8_t>(spread_four_bits(low_width_bits & 0x0f) |
+                           (spread_four_bits(high_width_bits & 0x0f) << 1));
+  const uint8_t key1 =
+      static_cast<uint8_t>(spread_four_bits(low_width_bits >> 4) |
+                           (spread_four_bits(high_width_bits >> 4) << 1));
+
+  const uint8_t *row0 =
+      simdutf::tables::utf32_to_utf8::pack_1_2_3_4_utf8_bytes.rows[key0];
+  const uint8_t *row1 =
+      simdutf::tables::utf32_to_utf8::pack_1_2_3_4_utf8_bytes.rows[key1];
+  const __m128i packed0 = _mm_shuffle_epi8(
+      _mm256_castsi256_si128(encoded),
+      _mm_loadu_si128(reinterpret_cast<const __m128i *>(row0 + 1)));
+  const __m128i packed1 = _mm_shuffle_epi8(
+      _mm256_extracti128_si256(encoded, 1),
+      _mm_loadu_si128(reinterpret_cast<const __m128i *>(row1 + 1)));
+
+  _mm_storeu_si128(reinterpret_cast<__m128i *>(utf8_output), packed0);
+  utf8_output += row0[0];
+  _mm_storeu_si128(reinterpret_cast<__m128i *>(utf8_output), packed1);
+  return utf8_output + row1[0];
+}
+
+simdutf_really_inline char *
+avx2_pack_eight_four_byte_utf32_to_utf8(__m256i input, char *utf8_output) {
+  const __m256i v_3f000000 =
+      _mm256_set1_epi32(static_cast<int32_t>(0x3f000000u));
+  const __m256i v_003f0000 = _mm256_set1_epi32(0x003f0000);
+  const __m256i v_00003f00 = _mm256_set1_epi32(0x00003f00);
+  const __m256i v_808080f0 =
+      _mm256_set1_epi32(static_cast<int32_t>(0x808080f0u));
+  const __m256i encoded = _mm256_or_si256(
+      _mm256_or_si256(
+          _mm256_and_si256(_mm256_slli_epi32(input, 24), v_3f000000),
+          _mm256_and_si256(_mm256_slli_epi32(input, 10), v_003f0000)),
+      _mm256_or_si256(
+          _mm256_and_si256(_mm256_srli_epi32(input, 4), v_00003f00),
+          _mm256_or_si256(_mm256_srli_epi32(input, 18), v_808080f0)));
+  _mm256_storeu_si256(reinterpret_cast<__m256i *>(utf8_output), encoded);
+  return utf8_output + 32;
+}
+
+// Once a non-BMP block has been encountered, process the rest of the vector
+// region with a two-bit width plan per input code unit. Invalid blocks are left
+// untouched for the scalar resume path, which reports the exact first error.
+simdutf_really_inline bool avx2_all_non_bmp_block(const char32_t *input) {
+  const __m256i in =
+      _mm256_loadu_si256(reinterpret_cast<const __m256i *>(input));
+  const __m256i nextin =
+      _mm256_loadu_si256(reinterpret_cast<const __m256i *>(input) + 1);
+  const __m256i v_ffff = _mm256_set1_epi32(0xffff);
+  const __m256i all_non_bmp =
+      _mm256_cmpgt_epi32(_mm256_min_epu32(in, nextin), v_ffff);
+  return static_cast<uint32_t>(_mm256_movemask_epi8(all_non_bmp)) == 0xffffffff;
+}
+
+std::pair<result, char *> avx2_convert_mixed_utf32_to_utf8_with_errors(
+    const char32_t *buf, size_t len, char *utf8_output, size_t input_offset);
+std::pair<result, char *> avx2_convert_four_byte_utf32_to_utf8_with_errors(
+    const char32_t *buf, size_t len, char *utf8_output, size_t input_offset);
+
+#if !defined(SIMDUTF_REGULAR_VISUAL_STUDIO)
+__attribute__((cold))
+#endif
+simdutf_never_inline avx2_utf32_progress
+avx2_pack_mixed_utf32_to_utf8(const char32_t *buf, size_t len,
+                              char *utf8_output) {
+  // Both packers reserve a 12-code-point tail for their wide stores.
+  if (len < 16 + 12) {
+    return {0, 0};
+  }
+  const std::pair<result, char *> ret =
+      avx2_all_non_bmp_block(buf)
+          ? avx2_convert_four_byte_utf32_to_utf8_with_errors(buf, len,
+                                                             utf8_output, 0)
+          : avx2_convert_mixed_utf32_to_utf8_with_errors(buf, len, utf8_output,
+                                                         0);
+  return {ret.first.count, size_t(ret.second - utf8_output)};
+}
+
+simdutf_never_inline std::pair<result, char *>
+avx2_convert_mixed_utf32_to_utf8_with_errors(const char32_t *buf, size_t len,
+                                             char *utf8_output,
+                                             size_t input_offset) {
+  const char32_t *const start = buf;
+  const char32_t *const end = buf + len;
+  const __m256i v_10ffff = _mm256_set1_epi32(0x10ffff);
+  const __m256i v_fffff800 =
+      _mm256_set1_epi32(static_cast<int32_t>(0xfffff800u));
+  const __m256i v_d800 = _mm256_set1_epi32(0xd800);
+  // A packed four-code-unit store can write 16 bytes even when its useful
+  // prefix is shorter. Four useful bytes plus the 12-code-unit tail suffice.
+  const size_t safety_margin = 12;
+
+  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+    const __m256i in =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf));
+    const __m256i nextin =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf) + 1);
+    const __m256i max_input =
+        _mm256_max_epu32(_mm256_max_epu32(in, nextin), v_10ffff);
+    if (static_cast<uint32_t>(_mm256_movemask_epi8(
+            _mm256_cmpeq_epi32(max_input, v_10ffff))) != 0xffffffff) {
+      break;
+    }
+
+    const __m256i surrogate_bytemask = _mm256_or_si256(
+        _mm256_cmpeq_epi32(_mm256_and_si256(in, v_fffff800), v_d800),
+        _mm256_cmpeq_epi32(_mm256_and_si256(nextin, v_fffff800), v_d800));
+    if (static_cast<uint32_t>(_mm256_movemask_epi8(surrogate_bytemask)) != 0) {
+      break;
+    }
+
+    // Each packed four-code-unit result uses a 16-byte store. Validate the
+    // twelve following code units before those stores so their padding is
+    // backed by output that is known to exist even when the next block fails.
+    const __m256i tail =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf + 12));
+    const __m256i tailnext =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf + 20));
+    const __m256i tail_max_input =
+        _mm256_max_epu32(_mm256_max_epu32(tail, tailnext), v_10ffff);
+    if (static_cast<uint32_t>(_mm256_movemask_epi8(
+            _mm256_cmpeq_epi32(tail_max_input, v_10ffff))) != 0xffffffff) {
+      break;
+    }
+    const __m256i tail_surrogate_bytemask = _mm256_or_si256(
+        _mm256_cmpeq_epi32(_mm256_and_si256(tail, v_fffff800), v_d800),
+        _mm256_cmpeq_epi32(_mm256_and_si256(tailnext, v_fffff800), v_d800));
+    if (static_cast<uint32_t>(_mm256_movemask_epi8(tail_surrogate_bytemask)) !=
+        0) {
+      break;
+    }
+
+    utf8_output = avx2_pack_eight_utf32_to_utf8(in, utf8_output);
+    utf8_output = avx2_pack_eight_utf32_to_utf8(nextin, utf8_output);
+    buf += 16;
+  }
+
+  return std::make_pair(
+      result(error_code::SUCCESS, input_offset + size_t(buf - start)),
+      utf8_output);
+}
+
+simdutf_never_inline std::pair<result, char *>
+avx2_convert_four_byte_utf32_to_utf8_with_errors(const char32_t *buf,
+                                                 size_t len, char *utf8_output,
+                                                 size_t input_offset) {
+  const char32_t *const start = buf;
+  const char32_t *const end = buf + len;
+  const __m256i v_10ffff = _mm256_set1_epi32(0x10ffff);
+  const __m256i v_ffff = _mm256_set1_epi32(0xffff);
+  const __m256i v_fffff800 =
+      _mm256_set1_epi32(static_cast<int32_t>(0xfffff800u));
+  const __m256i v_d800 = _mm256_set1_epi32(0xd800);
+  const size_t safety_margin = 12;
+
+  while (end - buf >= std::ptrdiff_t(16 + safety_margin)) {
+    const __m256i in =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf));
+    const __m256i nextin =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i *>(buf) + 1);
+    const __m256i max_input =
+        _mm256_max_epu32(_mm256_max_epu32(in, nextin), v_10ffff);
+    if (static_cast<uint32_t>(_mm256_movemask_epi8(
+            _mm256_cmpeq_epi32(max_input, v_10ffff))) != 0xffffffff) {
+      break;
+    }
+
+    const __m256i surrogate_bytemask = _mm256_or_si256(
+        _mm256_cmpeq_epi32(_mm256_and_si256(in, v_fffff800), v_d800),
+        _mm256_cmpeq_epi32(_mm256_and_si256(nextin, v_fffff800), v_d800));
+    if (static_cast<uint32_t>(_mm256_movemask_epi8(surrogate_bytemask)) != 0) {
+      break;
+    }
+
+    const __m256i all_non_bmp =
+        _mm256_cmpgt_epi32(_mm256_min_epu32(in, nextin), v_ffff);
+    if (static_cast<uint32_t>(_mm256_movemask_epi8(all_non_bmp)) !=
+        0xffffffff) {
+      return avx2_convert_mixed_utf32_to_utf8_with_errors(
+          buf, size_t(end - buf), utf8_output,
+          input_offset + size_t(buf - start));
+    }
+
+    utf8_output = avx2_pack_eight_four_byte_utf32_to_utf8(in, utf8_output);
+    utf8_output = avx2_pack_eight_four_byte_utf32_to_utf8(nextin, utf8_output);
+    buf += 16;
+  }
+
+  return std::make_pair(
+      result(error_code::SUCCESS, input_offset + size_t(buf - start)),
+      utf8_output);
+}
+
+} // unnamed namespace
+} // namespace SIMDUTF_IMPLEMENTATION
+} // namespace simdutf
+
+#include "simdutf/haswell/end.h"

--- a/src/simdutf.cpp
+++ b/src/simdutf.cpp
@@ -6,6 +6,7 @@
 // should not depend on a kernel.
 #include "tables/utf8_to_utf16_tables.h"
 #include "tables/utf16_to_utf8_tables.h"
+#include "tables/utf32_to_utf8_tables.h"
 #include "tables/utf32_to_utf16_tables.h"
 // End of tables.
 
@@ -147,6 +148,11 @@ SIMDUTF_DISABLE_UNDESIRED_WARNINGS
 #if SIMDUTF_IMPLEMENTATION_LSX
   #include "lsx/implementation.cpp"
 #endif
+#if SIMDUTF_IMPLEMENTATION_HASWELL
+  #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
+    #include "haswell/avx2_convert_utf32_to_utf8_mixed.cpp"
+  #endif // SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF32
+#endif   // SIMDUTF_IMPLEMENTATION_HASWELL
 
 #include "simdutf_c.cpp"
 SIMDUTF_POP_DISABLE_WARNINGS

--- a/src/tables/utf32_to_utf8_tables.h
+++ b/src/tables/utf32_to_utf8_tables.h
@@ -1,0 +1,42 @@
+// Compact four UTF-8 code units, each stored in a 32-bit lane.
+#ifndef SIMDUTF_UTF32_TO_UTF8_TABLES_H
+#define SIMDUTF_UTF32_TO_UTF8_TABLES_H
+
+namespace simdutf {
+namespace {
+namespace tables {
+namespace utf32_to_utf8 {
+
+// Each row starts with the packed byte count, followed by a PSHUFB control
+// vector. The row index contains four two-bit (width - 1) fields, one per
+// input lane from least to most significant.
+struct pack_1_2_3_4_utf8_bytes_table {
+  uint8_t rows[256][17] = {};
+
+  constexpr pack_1_2_3_4_utf8_bytes_table() {
+    for (uint16_t key = 0; key < 256; key++) {
+      uint8_t output_index = 0;
+      for (uint8_t lane = 0; lane < 4; lane++) {
+        const uint8_t width =
+            static_cast<uint8_t>(((key >> (lane * 2)) & 0x3) + 1);
+        for (uint8_t byte = 0; byte < width; byte++) {
+          rows[key][output_index + 1] = static_cast<uint8_t>(lane * 4 + byte);
+          output_index++;
+        }
+      }
+      rows[key][0] = output_index;
+      for (; output_index < 16; output_index++) {
+        rows[key][output_index + 1] = static_cast<uint8_t>(0x80);
+      }
+    }
+  }
+};
+
+constexpr pack_1_2_3_4_utf8_bytes_table pack_1_2_3_4_utf8_bytes{};
+
+} // namespace utf32_to_utf8
+} // namespace tables
+} // unnamed namespace
+} // namespace simdutf
+
+#endif // SIMDUTF_UTF32_TO_UTF8_TABLES_H

--- a/tests/convert_utf32_to_utf8_with_errors_tests.cpp
+++ b/tests/convert_utf32_to_utf8_with_errors_tests.cpp
@@ -2,10 +2,12 @@
 
 #include <array>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include <tests/helpers/fixed_string.h>
 #include <tests/helpers/random_int.h>
+#include <tests/reference/encode_utf8.h>
 #include <tests/helpers/test.h>
 #include <tests/helpers/transcode_test_base.h>
 
@@ -162,6 +164,299 @@ TEST_LOOP(convert_into_3_or_4_UTF8_bytes) {
     transcode_utf32_to_utf8_test_base test(random, size);
     ASSERT_TRUE(test(procedure));
     ASSERT_TRUE(test.check_size(size_procedure));
+  }
+}
+
+TEST(convert_all_mixed_width_plans_into_exact_output) {
+  const std::array<char32_t, 4> codepoints{{0x41, 0x00a2, 0x20ac, 0x1f600}};
+  const std::array<std::array<char, 4>, 4> encodings{{
+      {{0x41, 0, 0, 0}},
+      {{char(0xc2), char(0xa2), 0, 0}},
+      {{char(0xe2), char(0x82), char(0xac), 0}},
+      {{char(0xf0), char(0x9f), char(0x98), char(0x80)}},
+  }};
+  const std::array<size_t, 4> widths{{1, 2, 3, 4}};
+
+  std::vector<char32_t> input;
+  std::vector<char> expected;
+  input.reserve(256 * 4 + 12);
+  for (uint16_t plan = 0; plan < 256; plan++) {
+    for (size_t lane = 0; lane < 4; lane++) {
+      const size_t width = (plan >> (lane * 2)) & 0x3;
+      input.push_back(codepoints[width]);
+      expected.insert(expected.end(), encodings[width].begin(),
+                      encodings[width].begin() + widths[width]);
+    }
+  }
+  // Keep the last four plans in the vector region: the converter intentionally
+  // reserves a 12-code-point scalar tail for wide stores.
+  for (size_t i = 0; i < 12; i++) {
+    input.push_back(codepoints[0]);
+    expected.push_back(encodings[0][0]);
+  }
+
+  std::unique_ptr<char[]> output(new char[expected.size()]);
+  const simdutf::result result =
+      implementation.convert_utf32_to_utf8_with_errors(
+          input.data(), input.size(), output.get());
+  ASSERT_EQUAL(result.error, simdutf::error_code::SUCCESS);
+  ASSERT_EQUAL(result.count, expected.size());
+  for (size_t i = 0; i < expected.size(); i++) {
+    ASSERT_EQUAL(output[i], expected[i]);
+  }
+}
+
+TEST(convert_mixed_width_packed_tail_uses_exact_output) {
+  std::vector<char32_t> input(28, 0x41);
+  input[0] = 0x1f600;
+  std::vector<char> expected;
+  expected.reserve(4 * input.size());
+  for (const char32_t codepoint : input) {
+    simdutf::tests::reference::utf8::encode(
+        static_cast<uint32_t>(codepoint), [&expected](uint8_t byte) {
+          expected.push_back(static_cast<char>(byte));
+        });
+  }
+
+  std::unique_ptr<char[]> output(new char[expected.size()]);
+  const simdutf::result result =
+      implementation.convert_utf32_to_utf8_with_errors(
+          input.data(), input.size(), output.get());
+  ASSERT_EQUAL(result.error, simdutf::error_code::SUCCESS);
+  ASSERT_EQUAL(result.count, expected.size());
+  for (size_t i = 0; i < expected.size(); i++) {
+    ASSERT_EQUAL(output[i], expected[i]);
+  }
+}
+
+TEST(convert_mixed_width_error_uses_only_the_valid_output_prefix) {
+  std::array<char32_t, 28> input{};
+  input.fill(0x41);
+  input[0] = 0x1f600;
+  input[16] = 0x110000;
+  std::array<char, 19> output{};
+
+  const simdutf::result result =
+      implementation.convert_utf32_to_utf8_with_errors(
+          input.data(), input.size(), output.data());
+  ASSERT_EQUAL(result.error, simdutf::error_code::TOO_LARGE);
+  ASSERT_EQUAL(result.count, 16);
+  ASSERT_EQUAL(output[0], char(0xf0));
+  ASSERT_EQUAL(output[1], char(0x9f));
+  ASSERT_EQUAL(output[2], char(0x98));
+  ASSERT_EQUAL(output[3], char(0x80));
+  for (size_t i = 4; i < output.size(); i++) {
+    ASSERT_EQUAL(output[i], char(0x41));
+  }
+}
+
+TEST(convert_mixed_width_packer_checks_ahead_of_exact_error_prefix) {
+  std::array<char32_t, 56> input{};
+  input.fill(0x41);
+  input[0] = 0x1f600;
+  input[43] = 0x110000;
+  std::array<char, 46> output{};
+
+  const simdutf::result result =
+      implementation.convert_utf32_to_utf8_with_errors(
+          input.data(), input.size(), output.data());
+  ASSERT_EQUAL(result.error, simdutf::error_code::TOO_LARGE);
+  ASSERT_EQUAL(result.count, 43);
+  ASSERT_EQUAL(output[0], char(0xf0));
+  ASSERT_EQUAL(output[1], char(0x9f));
+  ASSERT_EQUAL(output[2], char(0x98));
+  ASSERT_EQUAL(output[3], char(0x80));
+  for (size_t i = 4; i < output.size(); i++) {
+    ASSERT_EQUAL(output[i], char(0x41));
+  }
+}
+
+TEST(convert_non_bmp_prefix_then_bmp_into_exact_output) {
+  std::vector<char32_t> input(64, 0x41);
+  input[0] = 0x1f600;
+  std::vector<char> expected;
+  expected.reserve(4 * input.size());
+  for (const char32_t codepoint : input) {
+    simdutf::tests::reference::utf8::encode(
+        static_cast<uint32_t>(codepoint), [&expected](uint8_t byte) {
+          expected.push_back(static_cast<char>(byte));
+        });
+  }
+
+  std::unique_ptr<char[]> output(new char[expected.size()]);
+  const simdutf::result result =
+      implementation.convert_utf32_to_utf8_with_errors(
+          input.data(), input.size(), output.get());
+  ASSERT_EQUAL(result.error, simdutf::error_code::SUCCESS);
+  ASSERT_EQUAL(result.count, expected.size());
+  for (size_t i = 0; i < expected.size(); i++) {
+    ASSERT_EQUAL(output[i], expected[i]);
+  }
+}
+
+TEST(convert_alternating_bmp_and_mixed_blocks_into_exact_output) {
+  const std::array<char32_t, 4> bmp{{0x41, 0x7f, 0x80, 0xffff}};
+  const std::array<char32_t, 4> mixed{{0x41, 0x00a2, 0x20ac, 0x1f600}};
+  std::vector<char32_t> input(140);
+  std::vector<char> expected;
+  expected.reserve(4 * input.size());
+  for (size_t i = 0; i < input.size(); i++) {
+    const bool mixed_block = (i / 16) % 2 != 0;
+    const char32_t codepoint =
+        i < 128 ? (mixed_block ? mixed[i % mixed.size()] : bmp[i % bmp.size()])
+                : bmp[i % bmp.size()];
+    input[i] = codepoint;
+    simdutf::tests::reference::utf8::encode(
+        static_cast<uint32_t>(codepoint), [&expected](uint8_t byte) {
+          expected.push_back(static_cast<char>(byte));
+        });
+  }
+
+  std::unique_ptr<char[]> output(new char[expected.size()]);
+  const simdutf::result result =
+      implementation.convert_utf32_to_utf8_with_errors(
+          input.data(), input.size(), output.get());
+  ASSERT_EQUAL(result.error, simdutf::error_code::SUCCESS);
+  ASSERT_EQUAL(result.count, expected.size());
+  for (size_t i = 0; i < expected.size(); i++) {
+    ASSERT_EQUAL(output[i], expected[i]);
+  }
+}
+
+TEST(convert_mixed_width_after_bmp_prefix_into_exact_output) {
+  const std::array<char32_t, 8> bmp{
+      {0, 0x7f, 0x80, 0x7ff, 0x800, 0xd7ff, 0xe000, 0xffff}};
+  const std::array<char32_t, 4> mixed{{0x7f, 0x80, 0xffff, 0x10ffff}};
+  std::vector<char32_t> input(128);
+  std::vector<char> expected;
+  expected.reserve(4 * input.size());
+  for (size_t i = 0; i < input.size(); i++) {
+    const char32_t codepoint =
+        i < 16 ? bmp[i % bmp.size()] : mixed[i % mixed.size()];
+    input[i] = codepoint;
+    simdutf::tests::reference::utf8::encode(
+        static_cast<uint32_t>(codepoint), [&expected](uint8_t byte) {
+          expected.push_back(static_cast<char>(byte));
+        });
+  }
+
+  std::unique_ptr<char[]> output(new char[expected.size()]);
+  const simdutf::result result =
+      implementation.convert_utf32_to_utf8_with_errors(
+          input.data(), input.size(), output.get());
+  ASSERT_EQUAL(result.error, simdutf::error_code::SUCCESS);
+  ASSERT_EQUAL(result.count, expected.size());
+  for (size_t i = 0; i < expected.size(); i++) {
+    ASSERT_EQUAL(output[i], expected[i]);
+  }
+}
+
+TEST(convert_four_byte_prefix_then_mixed_into_exact_output) {
+  const std::array<char32_t, 4> four_byte{
+      {0x10000, 0x1f600, 0x10fffd, 0x10ffff}};
+  const std::array<char32_t, 4> mixed{{0x7f, 0x80, 0xffff, 0x10000}};
+  // Exercise the four-byte kernel and its mixed-width handoff.
+  std::vector<char32_t> input(128);
+  std::vector<char> expected;
+  expected.reserve(4 * input.size());
+  for (size_t i = 0; i < input.size(); i++) {
+    const char32_t codepoint = i < 16   ? four_byte[i % four_byte.size()]
+                               : i < 32 ? mixed[i % mixed.size()]
+                                        : char32_t(0x41);
+    input[i] = codepoint;
+    simdutf::tests::reference::utf8::encode(
+        static_cast<uint32_t>(codepoint), [&expected](uint8_t byte) {
+          expected.push_back(static_cast<char>(byte));
+        });
+  }
+
+  std::unique_ptr<char[]> output(new char[expected.size()]);
+  const simdutf::result result =
+      implementation.convert_utf32_to_utf8_with_errors(
+          input.data(), input.size(), output.get());
+  ASSERT_EQUAL(result.error, simdutf::error_code::SUCCESS);
+  ASSERT_EQUAL(result.count, expected.size());
+  for (size_t i = 0; i < expected.size(); i++) {
+    ASSERT_EQUAL(output[i], expected[i]);
+  }
+}
+
+TEST(convert_mixed_width_wide_lookahead_preserves_exact_error_prefix) {
+  const std::array<char32_t, 4> valid{{0x41, 0x00a2, 0x20ac, 0x1f600}};
+  for (const std::pair<char32_t, simdutf::error_code> invalid : {
+           std::make_pair(char32_t(0xd800), simdutf::error_code::SURROGATE),
+           std::make_pair(char32_t(0x110000), simdutf::error_code::TOO_LARGE),
+       }) {
+    for (size_t error_position = 0; error_position < 140; error_position++) {
+      std::vector<char32_t> input(140);
+      std::vector<char> expected;
+      expected.reserve(4 * error_position);
+      for (size_t i = 0; i < input.size(); i++) {
+        input[i] = valid[i % valid.size()];
+        if (i < error_position) {
+          simdutf::tests::reference::utf8::encode(
+              static_cast<uint32_t>(input[i]), [&expected](uint8_t byte) {
+                expected.push_back(static_cast<char>(byte));
+              });
+        }
+      }
+      input[error_position] = invalid.first;
+      std::unique_ptr<char[]> output(new char[expected.size()]);
+      const simdutf::result result =
+          implementation.convert_utf32_to_utf8_with_errors(
+              input.data(), input.size(), output.get());
+      ASSERT_EQUAL(result.error, invalid.second);
+      ASSERT_EQUAL(result.count, error_position);
+      for (size_t i = 0; i < expected.size(); i++) {
+        ASSERT_EQUAL(output[i], expected[i]);
+      }
+    }
+  }
+}
+
+TEST(convert_four_byte_errors_preserve_positions) {
+  const std::array<char32_t, 4> valid{{0x10000, 0x1f600, 0x10fffd, 0x10ffff}};
+  for (const std::pair<char32_t, simdutf::error_code> invalid : {
+           std::make_pair(char32_t(0xd800), simdutf::error_code::SURROGATE),
+           std::make_pair(char32_t(0x110000), simdutf::error_code::TOO_LARGE),
+       }) {
+    for (size_t error_position = 0; error_position < 32; error_position++) {
+      std::vector<char32_t> input(64);
+      for (size_t i = 0; i < input.size(); i++) {
+        input[i] = valid[i % valid.size()];
+      }
+      input[error_position] = invalid.first;
+      std::vector<char> output(4 * input.size());
+      const simdutf::result result =
+          implementation.convert_utf32_to_utf8_with_errors(
+              input.data(), input.size(), output.data());
+      ASSERT_EQUAL(result.error, invalid.second);
+      ASSERT_EQUAL(result.count, error_position);
+    }
+  }
+}
+
+TEST(convert_mixed_width_errors_preserve_positions) {
+  const std::array<char32_t, 4> valid{{0x41, 0x00a2, 0x20ac, 0x1f600}};
+  for (const size_t bmp_prefix : {size_t(0), size_t(16)}) {
+    for (const std::pair<char32_t, simdutf::error_code> invalid : {
+             std::make_pair(char32_t(0xd800), simdutf::error_code::SURROGATE),
+             std::make_pair(char32_t(0x110000), simdutf::error_code::TOO_LARGE),
+         }) {
+      for (size_t error_position = 0; error_position < 32; error_position++) {
+        std::vector<char32_t> input(64);
+        for (size_t i = 0; i < input.size(); i++) {
+          input[i] = i < bmp_prefix ? valid[i % 3] : valid[i % valid.size()];
+        }
+        input[error_position] = invalid.first;
+        std::vector<char> output(4 * input.size());
+        const simdutf::result result =
+            implementation.convert_utf32_to_utf8_with_errors(
+                input.data(), input.size(), output.data());
+        ASSERT_EQUAL(result.error, invalid.second);
+        ASSERT_EQUAL(result.count, error_position);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

The UTF-32→UTF-8 converters fall back to scalar code as soon as a block contains mixed widths. This PR keeps such blocks on the vector path:

- **Haswell (AVX2):** three comparison masks classify each lane and form two bits per code unit (its UTF-8 width); each group of four lanes is compacted with a PSHUFB plan indexed by those widths, packing eight valid code units at a time (new width-indexed tables).
- **Fallback:** validates a batch plus lookahead before issuing 16-byte wide stores; on an invalid code unit, scalar code resumes at that batch, preserving the exact first-error index and output prefix — the `_with_errors` contract is unchanged.

## Performance

Recorded verification runs (x86-64), 32768-scalar inputs:

| workload | before | after |
|---|---|---|
| AVX2, all-width mixed | 4.82 ns/scalar | 1.12 ns/scalar |
| AVX2, mixed after BMP prefix | 4.79 ns/scalar | 1.12 ns/scalar |
| AVX2, emoji (all 4-byte) | 2.14 ns/scalar | 0.27 ns/scalar |
| forced fallback, all-width mixed | 1.66 ns/scalar | 1.35 ns/scalar |
| forced fallback, emoji | 2.40 ns/scalar | 1.35 ns/scalar |

## Testing

- Full test suite passes, with extended `convert_utf32_to_utf8_with_errors` coverage pinning the first-error index and output prefix across the new batch boundaries.
- Verified across implementations including the forced-fallback path; tests also pass on arm64 (which dispatches to unchanged kernels).

Full verification record: https://app.perfloop.ai/t/oss/case_nqbvgjwvc2