### PR TITLE
Add convert_utf16_to_utf8_with_replacement to the C API

### DIFF
--- a/include/simdutf_c.h
+++ b/include/simdutf_c.h
@@ -220,6 +220,20 @@ simdutf_result
 simdutf_convert_utf16be_to_utf8_with_errors(const char16_t *input,
                                             size_t length, char *output);
 
+/* Convert possibly broken UTF-16 to UTF-8, replacing each unpaired surrogate
+   with U+FFFD (EF BF BD). These always succeed and return the number of bytes
+   written. Size the output buffer with the matching
+   simdutf_utf8_length_from_utf16*_with_replacement function. */
+size_t simdutf_convert_utf16_to_utf8_with_replacement(const char16_t *input,
+                                                      size_t length,
+                                                      char *output);
+size_t simdutf_convert_utf16le_to_utf8_with_replacement(const char16_t *input,
+                                                        size_t length,
+                                                        char *output);
+size_t simdutf_convert_utf16be_to_utf8_with_replacement(const char16_t *input,
+                                                        size_t length,
+                                                        char *output);
+
 size_t simdutf_convert_valid_utf16_to_utf8(const char16_t *input, size_t length,
                                            char *output);
 size_t simdutf_convert_valid_utf16_to_latin1(const char16_t *input,

--- a/src/simdutf_c.cpp
+++ b/src/simdutf_c.cpp
@@ -321,6 +321,24 @@ size_t simdutf_convert_utf16be_to_utf8(const char16_t *input, size_t length,
   return simdutf::convert_utf16be_to_utf8(input, length, output);
 }
 
+size_t simdutf_convert_utf16_to_utf8_with_replacement(const char16_t *input,
+                                                      size_t length,
+                                                      char *output) {
+  return simdutf::convert_utf16_to_utf8_with_replacement(input, length, output);
+}
+size_t simdutf_convert_utf16le_to_utf8_with_replacement(const char16_t *input,
+                                                        size_t length,
+                                                        char *output) {
+  return simdutf::convert_utf16le_to_utf8_with_replacement(input, length,
+                                                           output);
+}
+size_t simdutf_convert_utf16be_to_utf8_with_replacement(const char16_t *input,
+                                                        size_t length,
+                                                        char *output) {
+  return simdutf::convert_utf16be_to_utf8_with_replacement(input, length,
+                                                           output);
+}
+
 size_t simdutf_convert_valid_utf16_to_utf8(const char16_t *input, size_t length,
                                            char *output) {
   return simdutf::convert_valid_utf16_to_utf8(input, length, output);

--- a/tests/simdutf_c_tests.cpp
+++ b/tests/simdutf_c_tests.cpp
@@ -1,4 +1,5 @@
 #include <tests/helpers/test.h>
+#include <tests/helpers/utf16.h>
 #include <cstring>
 #include "simdutf_c.h"
 
@@ -276,19 +277,16 @@ TEST(convert_utf16_c) {
 // U+FFFD encoded in UTF-8.
 static const char fffd[3] = {char(0xEF), char(0xBF), char(0xBD)};
 
-static char16_t byteswap16(char16_t value) {
-  return char16_t(uint16_t((uint16_t(value) >> 8) | (uint16_t(value) << 8)));
-}
-
 TEST(convert_utf16le_to_utf8_with_replacement_c) {
   // 'A', unpaired high surrogate, 'B', unpaired low surrogate, valid pair
-  // (U+1F600).
-  const char16_t input[] = {u'A',
-                            char16_t(0xD800),
-                            u'B',
-                            char16_t(0xDC00),
-                            char16_t(0xD83D),
-                            char16_t(0xDE00)};
+  // (U+1F600). to_utf16le stores the code units little-endian whatever the
+  // host byte order is.
+  const char16_t input[] = {to_utf16le(u'A'),
+                            to_utf16le(char16_t(0xD800)),
+                            to_utf16le(u'B'),
+                            to_utf16le(char16_t(0xDC00)),
+                            to_utf16le(char16_t(0xD83D)),
+                            to_utf16le(char16_t(0xDE00))};
   const size_t length = sizeof(input) / sizeof(input[0]);
 
   char out[32] = {0};
@@ -313,17 +311,13 @@ TEST(convert_utf16le_to_utf8_with_replacement_c) {
 }
 
 TEST(convert_utf16be_to_utf8_with_replacement_c) {
-  const char16_t native[] = {u'A',
-                             char16_t(0xD800),
-                             u'B',
-                             char16_t(0xDC00),
-                             char16_t(0xD83D),
-                             char16_t(0xDE00)};
-  constexpr size_t length = sizeof(native) / sizeof(native[0]);
-  char16_t input[length] = {0};
-  for (size_t i = 0; i < length; i++) {
-    input[i] = byteswap16(native[i]);
-  }
+  const char16_t input[] = {to_utf16be(u'A'),
+                            to_utf16be(char16_t(0xD800)),
+                            to_utf16be(u'B'),
+                            to_utf16be(char16_t(0xDC00)),
+                            to_utf16be(char16_t(0xD83D)),
+                            to_utf16be(char16_t(0xDE00))};
+  const size_t length = sizeof(input) / sizeof(input[0]);
 
   char out[32] = {0};
   size_t n =

--- a/tests/simdutf_c_tests.cpp
+++ b/tests/simdutf_c_tests.cpp
@@ -273,4 +273,102 @@ TEST(convert_utf16_c) {
   ASSERT_TRUE(std::memcmp(out, "hello", 5) == 0);
 }
 
+// U+FFFD encoded in UTF-8.
+static const char fffd[3] = {char(0xEF), char(0xBF), char(0xBD)};
+
+static char16_t byteswap16(char16_t value) {
+  return char16_t(uint16_t((uint16_t(value) >> 8) | (uint16_t(value) << 8)));
+}
+
+TEST(convert_utf16le_to_utf8_with_replacement_c) {
+  // 'A', unpaired high surrogate, 'B', unpaired low surrogate, valid pair
+  // (U+1F600).
+  const char16_t input[] = {u'A',
+                            char16_t(0xD800),
+                            u'B',
+                            char16_t(0xDC00),
+                            char16_t(0xD83D),
+                            char16_t(0xDE00)};
+  const size_t length = sizeof(input) / sizeof(input[0]);
+
+  char out[32] = {0};
+  size_t n =
+      simdutf_convert_utf16le_to_utf8_with_replacement(input, length, out);
+  // 'A' + FFFD + 'B' + FFFD + 4-byte U+1F600
+  ASSERT_EQUAL(n, size_t(1 + 3 + 1 + 3 + 4));
+  ASSERT_EQUAL(out[0], 'A');
+  ASSERT_TRUE(std::memcmp(out + 1, fffd, 3) == 0);
+  ASSERT_EQUAL(out[4], 'B');
+  ASSERT_TRUE(std::memcmp(out + 5, fffd, 3) == 0);
+  ASSERT_EQUAL(uint8_t(out[8]), uint8_t(0xF0));
+  ASSERT_EQUAL(uint8_t(out[9]), uint8_t(0x9F));
+  ASSERT_EQUAL(uint8_t(out[10]), uint8_t(0x98));
+  ASSERT_EQUAL(uint8_t(out[11]), uint8_t(0x80));
+
+  // The output must be valid UTF-8 and match the companion length function.
+  ASSERT_TRUE(simdutf_validate_utf8(out, n));
+  simdutf_result len =
+      simdutf_utf8_length_from_utf16le_with_replacement(input, length);
+  ASSERT_EQUAL(len.count, n);
+}
+
+TEST(convert_utf16be_to_utf8_with_replacement_c) {
+  const char16_t native[] = {u'A',
+                             char16_t(0xD800),
+                             u'B',
+                             char16_t(0xDC00),
+                             char16_t(0xD83D),
+                             char16_t(0xDE00)};
+  constexpr size_t length = sizeof(native) / sizeof(native[0]);
+  char16_t input[length] = {0};
+  for (size_t i = 0; i < length; i++) {
+    input[i] = byteswap16(native[i]);
+  }
+
+  char out[32] = {0};
+  size_t n =
+      simdutf_convert_utf16be_to_utf8_with_replacement(input, length, out);
+  ASSERT_EQUAL(n, size_t(1 + 3 + 1 + 3 + 4));
+  ASSERT_EQUAL(out[0], 'A');
+  ASSERT_TRUE(std::memcmp(out + 1, fffd, 3) == 0);
+  ASSERT_EQUAL(out[4], 'B');
+  ASSERT_TRUE(std::memcmp(out + 5, fffd, 3) == 0);
+  ASSERT_EQUAL(uint8_t(out[8]), uint8_t(0xF0));
+  ASSERT_EQUAL(uint8_t(out[9]), uint8_t(0x9F));
+  ASSERT_EQUAL(uint8_t(out[10]), uint8_t(0x98));
+  ASSERT_EQUAL(uint8_t(out[11]), uint8_t(0x80));
+
+  ASSERT_TRUE(simdutf_validate_utf8(out, n));
+  simdutf_result len =
+      simdutf_utf8_length_from_utf16be_with_replacement(input, length);
+  ASSERT_EQUAL(len.count, n);
+}
+
+TEST(convert_utf16_to_utf8_with_replacement_c) {
+  // Native endianness: agrees with the plain converter on valid input.
+  char16_t valid[5] = {u'h', u'e', u'l', u'l', u'o'};
+  char out[16] = {0};
+  size_t n = simdutf_convert_utf16_to_utf8_with_replacement(valid, 5, out);
+  ASSERT_EQUAL(n, size_t(5));
+  ASSERT_TRUE(std::memcmp(out, "hello", 5) == 0);
+
+  // A lone high surrogate at the end of the input becomes U+FFFD.
+  const char16_t truncated[2] = {u'X', char16_t(0xD800)};
+  char out2[16] = {0};
+  size_t n2 =
+      simdutf_convert_utf16_to_utf8_with_replacement(truncated, 2, out2);
+  ASSERT_EQUAL(n2, size_t(4));
+  ASSERT_EQUAL(out2[0], 'X');
+  ASSERT_TRUE(std::memcmp(out2 + 1, fffd, 3) == 0);
+  ASSERT_TRUE(simdutf_validate_utf8(out2, n2));
+
+  simdutf_result len =
+      simdutf_utf8_length_from_utf16_with_replacement(truncated, 2);
+  ASSERT_EQUAL(len.count, n2);
+
+  // Empty input writes nothing.
+  ASSERT_EQUAL(simdutf_convert_utf16_to_utf8_with_replacement(nullptr, 0, out),
+               size_t(0));
+}
+
 TEST_MAIN


### PR DESCRIPTION
The C API exposes `simdutf_utf8_length_from_utf16{,le,be}_with_replacement` but not the matching conversion. A C caller can size the output buffer for a replacement-mode transcode without being able to fill it, so the feature added in #936 is effectively unreachable from C.

This adds the three missing entry points:

```c
size_t simdutf_convert_utf16_to_utf8_with_replacement(const char16_t *input,
                                                      size_t length,
                                                      char *output);
size_t simdutf_convert_utf16le_to_utf8_with_replacement(const char16_t *input,
                                                        size_t length,
                                                        char *output);
size_t simdutf_convert_utf16be_to_utf8_with_replacement(const char16_t *input,
                                                        size_t length,
                                                        char *output);
```

They are thin wrappers over the existing C++ functions, written the same way as the rest of `src/simdutf_c.cpp`. No behaviour change to any existing function, and nothing outside the C wrapper is touched.

## Tests

Three tests added to `tests/simdutf_c_tests.cpp`, one per entry point. Each uses input containing an unpaired high surrogate, an unpaired low surrogate, and a valid surrogate pair (U+1F600), and checks:

- the exact output bytes, including `EF BF BD` at each replacement site and the 4-byte encoding of the valid pair,
- that the output passes `simdutf_validate_utf8`,
- that the returned byte count equals `simdutf_utf8_length_from_utf16*_with_replacement(...).count`.

The native-endianness test additionally covers a lone high surrogate at the very end of the input and an empty input.

## Verification

- `ctest` on aarch64 macOS: 91/91 passing.
- `simdutf_c_tests` on an AVX-512 Xeon (Emerald Rapids), exercising all four runtime kernels — icelake, haswell, westmere, fallback: all passing.
- Regenerated the amalgamation and compiled a standalone C11 consumer of the new functions against it with `cc -std=c11 -Wall -Wextra`: clean, and correct at runtime.

While confirming the gap I also ran a differential stress test of the underlying `convert_utf16*_to_utf8_with_replacement` implementation against both a scalar reference and the `to_well_formed_utf16` + `convert_utf16_to_utf8` approach from nodejs/node#65324 — 15.9M cases across all x86 and arm64 kernels under ASAN/UBSAN, plus 15.4M libFuzzer executions of `fuzz/with_replacement`, with no failures. That code is unchanged by this PR; the result is just background confirmation that the newly exposed functions are sound.