### PR TITLE
utf16_to_utf8: report bytes written on error, drop the utf8_length re-walk

### DIFF
--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -697,60 +697,36 @@ simdutf_warn_unused size_t implementation::convert_utf16be_to_utf8(
   return saved_bytes;
 }
 
+template <endianness big_endian>
+simdutf_really_inline full_result convert_utf16_to_utf8_with_details(
+    const char16_t *buf, size_t len, char *utf8_output) {
+  std::pair<result, char *> ret =
+      arm_convert_utf16_to_utf8_with_errors<big_endian>(buf, len, utf8_output);
+  if (ret.first.error) {
+    return full_result(ret.first.error, ret.first.count,
+                       size_t(ret.second - utf8_output));
+  }
+  if (ret.first.count != len) {
+    full_result sres =
+        scalar::utf16_to_utf8::convert_with_errors<big_endian, false>(
+            buf + ret.first.count, len - ret.first.count, ret.second, 0);
+    return full_result(sres.error, ret.first.count + sres.input_count,
+                       size_t(ret.second - utf8_output) + sres.output_count);
+  }
+  return full_result(error_code::SUCCESS, len,
+                     size_t(ret.second - utf8_output));
+}
+
 simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  // ret.first.count is always the position in the buffer, not the number of
-  // code units written even if finished
-  std::pair<result, char *> ret =
-      arm_convert_utf16_to_utf8_with_errors<endianness::LITTLE>(buf, len,
+  return convert_utf16_to_utf8_with_details<endianness::LITTLE>(buf, len,
                                                                 utf8_output);
-  if (ret.first.error) {
-    return ret.first;
-  } // Can return directly since scalar fallback already found correct
-    // ret.first.count
-  if (ret.first.count != len) { // All good so far, but not finished
-    result scalar_res =
-        scalar::utf16_to_utf8::convert_with_errors<endianness::LITTLE>(
-            buf + ret.first.count, len - ret.first.count, ret.second);
-    if (scalar_res.error) {
-      scalar_res.count += ret.first.count;
-      return scalar_res;
-    } else {
-      ret.second += scalar_res.count;
-    }
-  }
-  ret.first.count =
-      ret.second -
-      utf8_output; // Set count to the number of 8-bit code units written
-  return ret.first;
 }
 
 simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  // ret.first.count is always the position in the buffer, not the number of
-  // code units written even if finished
-  std::pair<result, char *> ret =
-      arm_convert_utf16_to_utf8_with_errors<endianness::BIG>(buf, len,
+  return convert_utf16_to_utf8_with_details<endianness::BIG>(buf, len,
                                                              utf8_output);
-  if (ret.first.error) {
-    return ret.first;
-  } // Can return directly since scalar fallback already found correct
-    // ret.first.count
-  if (ret.first.count != len) { // All good so far, but not finished
-    result scalar_res =
-        scalar::utf16_to_utf8::convert_with_errors<endianness::BIG>(
-            buf + ret.first.count, len - ret.first.count, ret.second);
-    if (scalar_res.error) {
-      scalar_res.count += ret.first.count;
-      return scalar_res;
-    } else {
-      ret.second += scalar_res.count;
-    }
-  }
-  ret.first.count =
-      ret.second -
-      utf8_output; // Set count to the number of 8-bit code units written
-  return ret.first;
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_utf8(
@@ -1197,11 +1173,8 @@ simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
-      [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16le(b, l);
+      [](const char16_t *b, size_t l, char *o) {
+        return convert_utf16_to_utf8_with_details<endianness::LITTLE>(b, l, o);
       },
       input, length, utf8_buffer);
 }
@@ -1210,11 +1183,8 @@ simdutf_warn_unused size_t
 implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
-      [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16be(b, l);
+      [](const char16_t *b, size_t l, char *o) {
+        return convert_utf16_to_utf8_with_details<endianness::BIG>(b, l, o);
       },
       input, length, utf8_buffer);
 }

--- a/src/generic/utf16_to_utf8/utf16_to_utf8_with_replacement.h
+++ b/src/generic/utf16_to_utf8/utf16_to_utf8_with_replacement.h
@@ -6,37 +6,26 @@ namespace SIMDUTF_IMPLEMENTATION {
 namespace {
 namespace utf16_to_utf8 {
 
-// Convert possibly ill-formed UTF-16 to UTF-8, substituting each unpaired
-// surrogate with U+FFFD (0xEF 0xBF 0xBD). Runs the SIMD *_with_errors converter
-// at full speed and only pays extra where an unpaired surrogate is found.
-//
-// convert_with_errors behaves like convert_utf16{le,be}_to_utf8_with_errors: on
-// SUCCESS, result.count is the number of UTF-8 bytes written; on a SURROGATE
-// error, result.count is the index of the first unpaired surrogate.
-// utf8_length is utf8_length_from_utf16{le,be}; only ever called on a prefix
-// already proved valid, so it matches the bytes just written.
-template <typename ConvertWithErrors, typename Utf8Length>
+// Substitutes U+FFFD for each unpaired surrogate. convert_with_details reports
+// the bytes written alongside the input position, so the converted prefix never
+// has to be re-walked.
+template <typename ConvertWithDetails>
 simdutf_really_inline size_t convert_with_replacement_via(
-    ConvertWithErrors convert_with_errors, Utf8Length utf8_length,
-    const char16_t *buf, size_t len, char *utf8_output) {
+    ConvertWithDetails convert_with_details, const char16_t *buf, size_t len,
+    char *utf8_output) {
   char *const start = utf8_output;
   size_t pos = 0;
   while (pos < len) {
-    result r = convert_with_errors(buf + pos, len - pos, utf8_output);
+    full_result r = convert_with_details(buf + pos, len - pos, utf8_output);
+    utf8_output += r.output_count;
     if (r.error != error_code::SURROGATE) {
-      utf8_output += r.count; // SUCCESS: r.count == UTF-8 bytes written
       break;
     }
-    // buf[pos + r.count] is unpaired; the valid prefix is already written.
-    const size_t valid_units = r.count;
-    utf8_output += utf8_length(buf + pos, valid_units);
-    pos += valid_units;
-    // Emit U+FFFD and skip the offending code unit.
+    pos += r.input_count + 1;
     utf8_output[0] = char(0xef);
     utf8_output[1] = char(0xbf);
     utf8_output[2] = char(0xbd);
     utf8_output += 3;
-    pos += 1;
   }
   return size_t(utf8_output - start);
 }

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -717,60 +717,37 @@ simdutf_warn_unused size_t implementation::convert_utf16be_to_utf8(
   return saved_bytes;
 }
 
+template <endianness big_endian>
+simdutf_really_inline full_result convert_utf16_to_utf8_with_details(
+    const char16_t *buf, size_t len, char *utf8_output) {
+  std::pair<result, char *> ret =
+      haswell::avx2_convert_utf16_to_utf8_with_errors<big_endian>(buf, len,
+                                                                  utf8_output);
+  if (ret.first.error) {
+    return full_result(ret.first.error, ret.first.count,
+                       size_t(ret.second - utf8_output));
+  }
+  if (ret.first.count != len) {
+    full_result sres =
+        scalar::utf16_to_utf8::convert_with_errors<big_endian, false>(
+            buf + ret.first.count, len - ret.first.count, ret.second, 0);
+    return full_result(sres.error, ret.first.count + sres.input_count,
+                       size_t(ret.second - utf8_output) + sres.output_count);
+  }
+  return full_result(error_code::SUCCESS, len,
+                     size_t(ret.second - utf8_output));
+}
+
 simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  // ret.first.count is always the position in the buffer, not the number of
-  // code units written even if finished
-  std::pair<result, char *> ret =
-      haswell::avx2_convert_utf16_to_utf8_with_errors<endianness::LITTLE>(
-          buf, len, utf8_output);
-  if (ret.first.error) {
-    return ret.first;
-  } // Can return directly since scalar fallback already found correct
-    // ret.first.count
-  if (ret.first.count != len) { // All good so far, but not finished
-    result scalar_res =
-        scalar::utf16_to_utf8::convert_with_errors<endianness::LITTLE>(
-            buf + ret.first.count, len - ret.first.count, ret.second);
-    if (scalar_res.error) {
-      scalar_res.count += ret.first.count;
-      return scalar_res;
-    } else {
-      ret.second += scalar_res.count;
-    }
-  }
-  ret.first.count =
-      ret.second -
-      utf8_output; // Set count to the number of 8-bit code units written
-  return ret.first;
+  return convert_utf16_to_utf8_with_details<endianness::LITTLE>(buf, len,
+                                                                utf8_output);
 }
 
 simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  // ret.first.count is always the position in the buffer, not the number of
-  // code units written even if finished
-  std::pair<result, char *> ret =
-      haswell::avx2_convert_utf16_to_utf8_with_errors<endianness::BIG>(
-          buf, len, utf8_output);
-  if (ret.first.error) {
-    return ret.first;
-  } // Can return directly since scalar fallback already found correct
-    // ret.first.count
-  if (ret.first.count != len) { // All good so far, but not finished
-    result scalar_res =
-        scalar::utf16_to_utf8::convert_with_errors<endianness::BIG>(
-            buf + ret.first.count, len - ret.first.count, ret.second);
-    if (scalar_res.error) {
-      scalar_res.count += ret.first.count;
-      return scalar_res;
-    } else {
-      ret.second += scalar_res.count;
-    }
-  }
-  ret.first.count =
-      ret.second -
-      utf8_output; // Set count to the number of 8-bit code units written
-  return ret.first;
+  return convert_utf16_to_utf8_with_details<endianness::BIG>(buf, len,
+                                                             utf8_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_utf8(
@@ -1174,11 +1151,8 @@ simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
-      [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16le(b, l);
+      [](const char16_t *b, size_t l, char *o) {
+        return convert_utf16_to_utf8_with_details<endianness::LITTLE>(b, l, o);
       },
       input, length, utf8_buffer);
 }
@@ -1187,11 +1161,8 @@ simdutf_warn_unused size_t
 implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
-      [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16be(b, l);
+      [](const char16_t *b, size_t l, char *o) {
+        return convert_utf16_to_utf8_with_details<endianness::BIG>(b, l, o);
       },
       input, length, utf8_buffer);
 }

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -1035,32 +1035,32 @@ simdutf_warn_unused size_t implementation::convert_utf16be_to_utf8(
   return outlen;
 }
 
-simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
-    const char16_t *buf, size_t len, char *utf8_output) const noexcept {
+template <endianness big_endian>
+simdutf_really_inline full_result convert_utf16_to_utf8_with_details(
+    const char16_t *buf, size_t len, char *utf8_output) {
   size_t outlen;
-  size_t inlen = utf16_to_utf8_avx512i<endianness::LITTLE>(
+  size_t inlen = utf16_to_utf8_avx512i<big_endian>(
       buf, len, (unsigned char *)utf8_output, &outlen);
   if (inlen != len) {
-    result res = scalar::utf16_to_utf8::convert_with_errors<endianness::LITTLE>(
-        buf + inlen, len - inlen, utf8_output + outlen);
-    res.count += inlen;
-    return res;
+    full_result res =
+        scalar::utf16_to_utf8::convert_with_errors<big_endian, false>(
+            buf + inlen, len - inlen, utf8_output + outlen, 0);
+    return full_result(res.error, inlen + res.input_count,
+                       outlen + res.output_count);
   }
-  return {simdutf::SUCCESS, outlen};
+  return full_result(error_code::SUCCESS, len, outlen);
+}
+
+simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
+    const char16_t *buf, size_t len, char *utf8_output) const noexcept {
+  return convert_utf16_to_utf8_with_details<endianness::LITTLE>(buf, len,
+                                                                utf8_output);
 }
 
 simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  size_t outlen;
-  size_t inlen = utf16_to_utf8_avx512i<endianness::BIG>(
-      buf, len, (unsigned char *)utf8_output, &outlen);
-  if (inlen != len) {
-    result res = scalar::utf16_to_utf8::convert_with_errors<endianness::BIG>(
-        buf + inlen, len - inlen, utf8_output + outlen);
-    res.count += inlen;
-    return res;
-  }
-  return {simdutf::SUCCESS, outlen};
+  return convert_utf16_to_utf8_with_details<endianness::BIG>(buf, len,
+                                                             utf8_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_utf8(
@@ -1690,11 +1690,8 @@ simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
-      [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16le(b, l);
+      [](const char16_t *b, size_t l, char *o) {
+        return convert_utf16_to_utf8_with_details<endianness::LITTLE>(b, l, o);
       },
       input, length, utf8_buffer);
 }
@@ -1703,11 +1700,8 @@ simdutf_warn_unused size_t
 implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
-      [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16be(b, l);
+      [](const char16_t *b, size_t l, char *o) {
+        return convert_utf16_to_utf8_with_details<endianness::BIG>(b, l, o);
       },
       input, length, utf8_buffer);
 }

--- a/src/lasx/implementation.cpp
+++ b/src/lasx/implementation.cpp
@@ -813,60 +813,36 @@ simdutf_warn_unused size_t implementation::convert_utf16be_to_utf8(
   return saved_bytes;
 }
 
+template <endianness big_endian>
+simdutf_really_inline full_result convert_utf16_to_utf8_with_details(
+    const char16_t *buf, size_t len, char *utf8_output) {
+  std::pair<result, char *> ret =
+      lasx_convert_utf16_to_utf8_with_errors<big_endian>(buf, len, utf8_output);
+  if (ret.first.error) {
+    return full_result(ret.first.error, ret.first.count,
+                       size_t(ret.second - utf8_output));
+  }
+  if (ret.first.count != len) {
+    full_result sres =
+        scalar::utf16_to_utf8::convert_with_errors<big_endian, false>(
+            buf + ret.first.count, len - ret.first.count, ret.second, 0);
+    return full_result(sres.error, ret.first.count + sres.input_count,
+                       size_t(ret.second - utf8_output) + sres.output_count);
+  }
+  return full_result(error_code::SUCCESS, len,
+                     size_t(ret.second - utf8_output));
+}
+
 simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  // ret.first.count is always the position in the buffer, not the number of
-  // code units written even if finished
-  std::pair<result, char *> ret =
-      lasx_convert_utf16_to_utf8_with_errors<endianness::LITTLE>(buf, len,
-                                                                 utf8_output);
-  if (ret.first.error) {
-    return ret.first;
-  } // Can return directly since scalar fallback already found correct
-    // ret.first.count
-  if (ret.first.count != len) { // All good so far, but not finished
-    result scalar_res =
-        scalar::utf16_to_utf8::convert_with_errors<endianness::LITTLE>(
-            buf + ret.first.count, len - ret.first.count, ret.second);
-    if (scalar_res.error) {
-      scalar_res.count += ret.first.count;
-      return scalar_res;
-    } else {
-      ret.second += scalar_res.count;
-    }
-  }
-  ret.first.count =
-      ret.second -
-      utf8_output; // Set count to the number of 8-bit code units written
-  return ret.first;
+  return convert_utf16_to_utf8_with_details<endianness::LITTLE>(buf, len,
+                                                                utf8_output);
 }
 
 simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  // ret.first.count is always the position in the buffer, not the number of
-  // code units written even if finished
-  std::pair<result, char *> ret =
-      lasx_convert_utf16_to_utf8_with_errors<endianness::BIG>(buf, len,
-                                                              utf8_output);
-  if (ret.first.error) {
-    return ret.first;
-  } // Can return directly since scalar fallback already found correct
-    // ret.first.count
-  if (ret.first.count != len) { // All good so far, but not finished
-    result scalar_res =
-        scalar::utf16_to_utf8::convert_with_errors<endianness::BIG>(
-            buf + ret.first.count, len - ret.first.count, ret.second);
-    if (scalar_res.error) {
-      scalar_res.count += ret.first.count;
-      return scalar_res;
-    } else {
-      ret.second += scalar_res.count;
-    }
-  }
-  ret.first.count =
-      ret.second -
-      utf8_output; // Set count to the number of 8-bit code units written
-  return ret.first;
+  return convert_utf16_to_utf8_with_details<endianness::BIG>(buf, len,
+                                                             utf8_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_utf8(
@@ -1324,11 +1300,8 @@ simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
-      [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16le(b, l);
+      [](const char16_t *b, size_t l, char *o) {
+        return convert_utf16_to_utf8_with_details<endianness::LITTLE>(b, l, o);
       },
       input, length, utf8_buffer);
 }
@@ -1337,11 +1310,8 @@ simdutf_warn_unused size_t
 implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
-      [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16be(b, l);
+      [](const char16_t *b, size_t l, char *o) {
+        return convert_utf16_to_utf8_with_details<endianness::BIG>(b, l, o);
       },
       input, length, utf8_buffer);
 }

--- a/src/lsx/implementation.cpp
+++ b/src/lsx/implementation.cpp
@@ -715,60 +715,36 @@ simdutf_warn_unused size_t implementation::convert_utf16be_to_utf8(
   return saved_bytes;
 }
 
+template <endianness big_endian>
+simdutf_really_inline full_result convert_utf16_to_utf8_with_details(
+    const char16_t *buf, size_t len, char *utf8_output) {
+  std::pair<result, char *> ret =
+      lsx_convert_utf16_to_utf8_with_errors<big_endian>(buf, len, utf8_output);
+  if (ret.first.error) {
+    return full_result(ret.first.error, ret.first.count,
+                       size_t(ret.second - utf8_output));
+  }
+  if (ret.first.count != len) {
+    full_result sres =
+        scalar::utf16_to_utf8::convert_with_errors<big_endian, false>(
+            buf + ret.first.count, len - ret.first.count, ret.second, 0);
+    return full_result(sres.error, ret.first.count + sres.input_count,
+                       size_t(ret.second - utf8_output) + sres.output_count);
+  }
+  return full_result(error_code::SUCCESS, len,
+                     size_t(ret.second - utf8_output));
+}
+
 simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  // ret.first.count is always the position in the buffer, not the number of
-  // code units written even if finished
-  std::pair<result, char *> ret =
-      lsx_convert_utf16_to_utf8_with_errors<endianness::LITTLE>(buf, len,
+  return convert_utf16_to_utf8_with_details<endianness::LITTLE>(buf, len,
                                                                 utf8_output);
-  if (ret.first.error) {
-    return ret.first;
-  } // Can return directly since scalar fallback already found correct
-    // ret.first.count
-  if (ret.first.count != len) { // All good so far, but not finished
-    result scalar_res =
-        scalar::utf16_to_utf8::convert_with_errors<endianness::LITTLE>(
-            buf + ret.first.count, len - ret.first.count, ret.second);
-    if (scalar_res.error) {
-      scalar_res.count += ret.first.count;
-      return scalar_res;
-    } else {
-      ret.second += scalar_res.count;
-    }
-  }
-  ret.first.count =
-      ret.second -
-      utf8_output; // Set count to the number of 8-bit code units written
-  return ret.first;
 }
 
 simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  // ret.first.count is always the position in the buffer, not the number of
-  // code units written even if finished
-  std::pair<result, char *> ret =
-      lsx_convert_utf16_to_utf8_with_errors<endianness::BIG>(buf, len,
+  return convert_utf16_to_utf8_with_details<endianness::BIG>(buf, len,
                                                              utf8_output);
-  if (ret.first.error) {
-    return ret.first;
-  } // Can return directly since scalar fallback already found correct
-    // ret.first.count
-  if (ret.first.count != len) { // All good so far, but not finished
-    result scalar_res =
-        scalar::utf16_to_utf8::convert_with_errors<endianness::BIG>(
-            buf + ret.first.count, len - ret.first.count, ret.second);
-    if (scalar_res.error) {
-      scalar_res.count += ret.first.count;
-      return scalar_res;
-    } else {
-      ret.second += scalar_res.count;
-    }
-  }
-  ret.first.count =
-      ret.second -
-      utf8_output; // Set count to the number of 8-bit code units written
-  return ret.first;
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_utf8(
@@ -1210,11 +1186,8 @@ simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
-      [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16le(b, l);
+      [](const char16_t *b, size_t l, char *o) {
+        return convert_utf16_to_utf8_with_details<endianness::LITTLE>(b, l, o);
       },
       input, length, utf8_buffer);
 }
@@ -1223,11 +1196,8 @@ simdutf_warn_unused size_t
 implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
-      [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16be(b, l);
+      [](const char16_t *b, size_t l, char *o) {
+        return convert_utf16_to_utf8_with_details<endianness::BIG>(b, l, o);
       },
       input, length, utf8_buffer);
 }

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -526,22 +526,33 @@ simdutf_warn_unused size_t implementation::convert_utf16be_to_utf8(
       buf, len, utf8_output);
 }
 
+template <endianness big_endian>
+simdutf_really_inline full_result convert_utf16_to_utf8_with_details(
+    const char16_t *buf, size_t len, char *utf8_output) {
+  const auto vr =
+      ppc64_convert_utf16_to_utf8<big_endian>(buf, len, utf8_output);
+  const size_t consumed = size_t(vr.input - buf);
+  const size_t written = size_t(vr.output - utf8_output);
+  if (vr.err != error_code::SUCCESS) {
+    return full_result(vr.err, consumed, written);
+  }
+  full_result sr =
+      scalar::utf16_to_utf8::convert_with_errors<big_endian, false>(
+          vr.input, len - consumed, vr.output, 0);
+  return full_result(sr.error, consumed + sr.input_count,
+                     written + sr.output_count);
+}
+
 simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-
-  return convert_with_errors_impl(
-      ppc64_convert_utf16_to_utf8<endianness::LITTLE>,
-      scalar::utf16_to_utf8::simple_convert_with_errors<endianness::LITTLE>,
-      buf, len, utf8_output);
+  return convert_utf16_to_utf8_with_details<endianness::LITTLE>(buf, len,
+                                                                utf8_output);
 }
 
 simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-
-  return convert_with_errors_impl(
-      ppc64_convert_utf16_to_utf8<endianness::BIG>,
-      scalar::utf16_to_utf8::simple_convert_with_errors<endianness::BIG>, buf,
-      len, utf8_output);
+  return convert_utf16_to_utf8_with_details<endianness::BIG>(buf, len,
+                                                             utf8_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_utf8(
@@ -791,11 +802,8 @@ simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
-      [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16le(b, l);
+      [](const char16_t *b, size_t l, char *o) {
+        return convert_utf16_to_utf8_with_details<endianness::LITTLE>(b, l, o);
       },
       input, length, utf8_buffer);
 }
@@ -804,11 +812,8 @@ simdutf_warn_unused size_t
 implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
-      [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16be(b, l);
+      [](const char16_t *b, size_t l, char *o) {
+        return convert_utf16_to_utf8_with_details<endianness::BIG>(b, l, o);
       },
       input, length, utf8_buffer);
 }

--- a/src/rvv/implementation.cpp
+++ b/src/rvv/implementation.cpp
@@ -126,11 +126,8 @@ simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
-      [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16le(b, l);
+      [](const char16_t *b, size_t l, char *o) {
+        return rvv_utf16_to_utf8_with_details<simdutf_ByteFlip::NONE>(b, l, o);
       },
       input, length, utf8_buffer);
 }
@@ -140,10 +137,11 @@ implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
       [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16be(b, l);
+        return supports_zvbb()
+                   ? rvv_utf16_to_utf8_with_details<simdutf_ByteFlip::ZVBB>(
+                         b, l, o)
+                   : rvv_utf16_to_utf8_with_details<simdutf_ByteFlip::V>(b, l,
+                                                                         o);
       },
       input, length, utf8_buffer);
 }

--- a/src/rvv/rvv_utf16_to.inl.cpp
+++ b/src/rvv/rvv_utf16_to.inl.cpp
@@ -70,8 +70,8 @@ simdutf_warn_unused size_t implementation::convert_valid_utf16be_to_latin1(
 
 #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
 template <simdutf_ByteFlip bflip>
-simdutf_really_inline static result
-rvv_utf16_to_utf8_with_errors(const char16_t *src, size_t len, char *dst) {
+simdutf_really_inline static full_result
+rvv_utf16_to_utf8_with_details(const char16_t *src, size_t len, char *dst) {
   size_t n = len;
   const char16_t *srcBeg = src;
   const char *dstBeg = dst;
@@ -187,13 +187,16 @@ rvv_utf16_to_utf8_with_errors(const char16_t *src, size_t len, char *dst) {
         } else {
           // must be a surrogate pair
           if (n <= 1)
-            return result(error_code::SURROGATE, src - srcBeg);
+            return full_result(error_code::SURROGATE, size_t(src - srcBeg),
+                               size_t(dst - dstBeg));
           uint16_t diff = word - 0xD800;
           if (diff > 0x3FF)
-            return result(error_code::SURROGATE, src - srcBeg);
+            return full_result(error_code::SURROGATE, size_t(src - srcBeg),
+                               size_t(dst - dstBeg));
           uint16_t diff2 = simdutf_byteflip<bflip>(src[1]) - 0xDC00;
           if (diff2 > 0x3FF)
-            return result(error_code::SURROGATE, src - srcBeg);
+            return full_result(error_code::SURROGATE, size_t(src - srcBeg),
+                               size_t(dst - dstBeg));
 
           uint32_t value = ((diff + 0x40) << 10) + diff2;
 
@@ -209,7 +212,8 @@ rvv_utf16_to_utf8_with_errors(const char16_t *src, size_t len, char *dst) {
       }
   }
 
-  return result(error_code::SUCCESS, dst - dstBeg);
+  return full_result(error_code::SUCCESS, size_t(src - srcBeg),
+                     size_t(dst - dstBeg));
 }
 
 simdutf_warn_unused size_t implementation::convert_utf16le_to_utf8(
@@ -226,15 +230,16 @@ simdutf_warn_unused size_t implementation::convert_utf16be_to_utf8(
 
 simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
     const char16_t *src, size_t len, char *dst) const noexcept {
-  return rvv_utf16_to_utf8_with_errors<simdutf_ByteFlip::NONE>(src, len, dst);
+  return rvv_utf16_to_utf8_with_details<simdutf_ByteFlip::NONE>(src, len, dst);
 }
 
 simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
     const char16_t *src, size_t len, char *dst) const noexcept {
   if (supports_zvbb())
-    return rvv_utf16_to_utf8_with_errors<simdutf_ByteFlip::ZVBB>(src, len, dst);
+    return rvv_utf16_to_utf8_with_details<simdutf_ByteFlip::ZVBB>(src, len,
+                                                                  dst);
   else
-    return rvv_utf16_to_utf8_with_errors<simdutf_ByteFlip::V>(src, len, dst);
+    return rvv_utf16_to_utf8_with_details<simdutf_ByteFlip::V>(src, len, dst);
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_utf8(

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -745,60 +745,37 @@ simdutf_warn_unused size_t implementation::convert_utf16be_to_utf8(
   return saved_bytes;
 }
 
+template <endianness big_endian>
+simdutf_really_inline full_result convert_utf16_to_utf8_with_details(
+    const char16_t *buf, size_t len, char *utf8_output) {
+  std::pair<result, char *> ret =
+      westmere::sse_convert_utf16_to_utf8_with_errors<big_endian>(buf, len,
+                                                                  utf8_output);
+  if (ret.first.error) {
+    return full_result(ret.first.error, ret.first.count,
+                       size_t(ret.second - utf8_output));
+  }
+  if (ret.first.count != len) {
+    full_result sres =
+        scalar::utf16_to_utf8::convert_with_errors<big_endian, false>(
+            buf + ret.first.count, len - ret.first.count, ret.second, 0);
+    return full_result(sres.error, ret.first.count + sres.input_count,
+                       size_t(ret.second - utf8_output) + sres.output_count);
+  }
+  return full_result(error_code::SUCCESS, len,
+                     size_t(ret.second - utf8_output));
+}
+
 simdutf_warn_unused result implementation::convert_utf16le_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  // ret.first.count is always the position in the buffer, not the number of
-  // code units written even if finished
-  std::pair<result, char *> ret =
-      westmere::sse_convert_utf16_to_utf8_with_errors<endianness::LITTLE>(
-          buf, len, utf8_output);
-  if (ret.first.error) {
-    return ret.first;
-  } // Can return directly since scalar fallback already found correct
-    // ret.first.count
-  if (ret.first.count != len) { // All good so far, but not finished
-    result scalar_res =
-        scalar::utf16_to_utf8::convert_with_errors<endianness::LITTLE>(
-            buf + ret.first.count, len - ret.first.count, ret.second);
-    if (scalar_res.error) {
-      scalar_res.count += ret.first.count;
-      return scalar_res;
-    } else {
-      ret.second += scalar_res.count;
-    }
-  }
-  ret.first.count =
-      ret.second -
-      utf8_output; // Set count to the number of 8-bit code units written
-  return ret.first;
+  return convert_utf16_to_utf8_with_details<endianness::LITTLE>(buf, len,
+                                                                utf8_output);
 }
 
 simdutf_warn_unused result implementation::convert_utf16be_to_utf8_with_errors(
     const char16_t *buf, size_t len, char *utf8_output) const noexcept {
-  // ret.first.count is always the position in the buffer, not the number of
-  // code units written even if finished
-  std::pair<result, char *> ret =
-      westmere::sse_convert_utf16_to_utf8_with_errors<endianness::BIG>(
-          buf, len, utf8_output);
-  if (ret.first.error) {
-    return ret.first;
-  } // Can return directly since scalar fallback already found correct
-    // ret.first.count
-  if (ret.first.count != len) { // All good so far, but not finished
-    result scalar_res =
-        scalar::utf16_to_utf8::convert_with_errors<endianness::BIG>(
-            buf + ret.first.count, len - ret.first.count, ret.second);
-    if (scalar_res.error) {
-      scalar_res.count += ret.first.count;
-      return scalar_res;
-    } else {
-      ret.second += scalar_res.count;
-    }
-  }
-  ret.first.count =
-      ret.second -
-      utf8_output; // Set count to the number of 8-bit code units written
-  return ret.first;
+  return convert_utf16_to_utf8_with_details<endianness::BIG>(buf, len,
+                                                             utf8_output);
 }
 
 simdutf_warn_unused size_t implementation::convert_valid_utf16le_to_utf8(
@@ -1263,11 +1240,8 @@ simdutf_warn_unused size_t
 implementation::convert_utf16le_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
-      [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16le_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16le(b, l);
+      [](const char16_t *b, size_t l, char *o) {
+        return convert_utf16_to_utf8_with_details<endianness::LITTLE>(b, l, o);
       },
       input, length, utf8_buffer);
 }
@@ -1276,11 +1250,8 @@ simdutf_warn_unused size_t
 implementation::convert_utf16be_to_utf8_with_replacement(
     const char16_t *input, size_t length, char *utf8_buffer) const noexcept {
   return utf16_to_utf8::convert_with_replacement_via(
-      [this](const char16_t *b, size_t l, char *o) {
-        return this->convert_utf16be_to_utf8_with_errors(b, l, o);
-      },
-      [this](const char16_t *b, size_t l) {
-        return this->utf8_length_from_utf16be(b, l);
+      [](const char16_t *b, size_t l, char *o) {
+        return convert_utf16_to_utf8_with_details<endianness::BIG>(b, l, o);
       },
       input, length, utf8_buffer);
 }


### PR DESCRIPTION
`convert_with_replacement_via()` (added in #1011) calls `utf8_length_from_utf16` after each unpaired surrogate for one reason only: to learn how many UTF-8 bytes the converter had just written, so it can advance the output pointer. Every kernel already knows that number — it is discarded at the `implementation::convert_utf16{le,be}_to_utf8_with_errors` boundary, which narrows the kernel's `(input_pos, output_pos)` down to `result`'s single count.

This threads it through instead. Each backend gains an internal `convert_utf16_to_utf8_with_details()` returning `full_result`, and `convert_utf16{le,be}_to_utf8_with_errors` becomes a thin wrapper over it — `full_result::operator result()` already performs exactly the SUCCESS→`output_count`, error→`input_count` mapping those functions were doing by hand. So the SIMD-then-scalar assembly now exists once per backend rather than twice.
