### PR TITLE
icelake: align the reads in validate_utf8

### DIFF
--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -191,6 +191,32 @@ implementation::validate_utf8(const char *buf, size_t len) const noexcept {
   avx512_utf8_checker checker{};
   const char *ptr = buf;
   const char *end = ptr + len;
+  // Get the 512-bit reads onto a 64-byte boundary. A load whose address
+  // straddles a cache line costs two accesses, and callers rarely hand us an
+  // aligned buffer.
+  //
+  // We cannot simply mask-load a short head block to reach the boundary: the
+  // checker carries state from one block to the next, and zero padding in the
+  // middle of a character would read as a truncated sequence. Instead we
+  // consume one full (unaligned) block and re-seed the cross-block state from
+  // the three bytes preceding the aligned start. Those three bytes must lie
+  // inside the buffer, hence the requirement that the adjustment be at least
+  // three. Below a couple of kilobytes the fixed cost of the prologue is not
+  // repaid.
+  if (len >= 2048) {
+    const uintptr_t misalignment = reinterpret_cast<uintptr_t>(ptr) % 64;
+    if (misalignment != 0 && misalignment <= 61) {
+      const size_t adjustment = 64 - misalignment;
+      checker.check_next_input(_mm512_loadu_si512((const __m512i *)ptr));
+      ptr += adjustment;
+      // Only the top three lanes are read. Masked-out lanes never fault, so
+      // this is safe even though ptr - 64 may point before buf.
+      const __m512i prev3 = _mm512_maskz_loadu_epi8(
+          UINT64_C(0xE000000000000000), (const __m512i *)(ptr - 64));
+      checker.prev_input_block = prev3;
+      checker.prev_incomplete = is_incomplete(prev3);
+    }
+  }
   for (; end - ptr >= 64; ptr += 64) {
     const __m512i utf8 = _mm512_loadu_si512((const __m512i *)ptr);
     checker.check_next_input(utf8);


### PR DESCRIPTION
## Problem

`icelake::implementation::validate_utf8` reads 64 bytes at a time straight from the caller's pointer:

```cpp
for (; end - ptr >= 64; ptr += 64) {
  const __m512i utf8 = _mm512_loadu_si512((const __m512i *)ptr);
  checker.check_next_input(utf8);
}
```

A 512-bit load whose *address* is not 64-byte aligned touches two cache lines and costs two accesses. Callers rarely hand us an aligned buffer — a `std::string`'s data is typically 16-byte aligned, and any subrange is arbitrary — so this is the normal case, not the exceptional one.

(Note this is about the address, not the instruction: `vmovdqu64` on an aligned address is exactly as fast as `vmovdqa64`, which is why the fix keeps `_mm512_loadu_si512`. `util_find` in `icelake_find.inl.cpp` already aligns this way.)

## Why it needs care

We cannot simply mask-load a short head block to reach the boundary. The checker carries `prev_input_block` / `prev_incomplete` from one block to the next, and zero padding in the middle of a character reads as a truncated sequence.

So the prologue consumes one *full* unaligned block, then re-seeds the cross-block state from the three bytes preceding the aligned start:

```cpp
const __m512i prev3 = _mm512_maskz_loadu_epi8(
    UINT64_C(0xE000000000000000), (const __m512i *)(ptr - 64));
```

Masked-out lanes never fault, so `ptr - 64` pointing before `buf` is fine. But the three lanes we *do* read must be inside the buffer, which requires the adjustment to be at least 3 — hence the `misalignment <= 61` guard. When I first got that wrong it read two bytes before the buffer.

## Measurements

Intel Xeon Gold 6548N (Emerald Rapids), gcc 14.3, single core, best-of-7, 29-file corpus. Buffer at offset 24 from a 64-byte boundary:

| input | before | after | |
|---|---|---|---|
| Latin-Lipsum (pure ASCII) | 75.4 | **99.4** GB/s | +32% |
| english (1.2% non-ASCII) | 56.0 | **68.0** GB/s | +21% |
| twitter.json (15%) | 43.6 | **47.3** GB/s | +9% |
| Chinese-Lipsum (99.6%) | 16.4 | **17.5** GB/s | +6% |

Across all 29 files: min −0.6%, **median +5.5%**, max +31.8%.

The honest cost: on an already-64-byte-aligned buffer the untaken branch costs min −2.7%, median −1.0%, max +3.4%. And below a couple of kilobytes the fixed ~15–20 cycle prologue is not repaid, hence the `len >= 2048` guard.

## Correctness

- `ctest`: 91/91.
- An exhaustive cross-check against the unpatched build over **47,232 cases** — all 64 buffer alignments × valid and corrupted inputs × 12 lengths × 29 corpus files — hashing the results of `validate_utf8`, `validate_utf8_with_errors`, `validate_ascii` and `validate_ascii_with_errors`. Byte-identical results.

## Deliberately not included

I also tried skipping runs of ASCII four vectors per compare-and-branch on top of this. It is dramatic on ASCII-heavy input — Latin-Lipsum 75 → **159** GB/s, english 55 → **88**, twitter.json 43 → **54** — but it costs 3–7% on mixed text (german, thai, esperanto, hindi) *even on aligned buffers*, and the loss is codegen, not wasted loads: Chinese-Lipsum, where the skip never fires, still drops. I tried a run counter and an out-of-line helper; both variants land in the same place.

That is a real trade-off rather than a free win, so I left it out of this PR. Happy to open it separately if you want that shape — say the word and I will.