### PR TITLE
icelake: align and widen the ASCII validators

### DIFF
--- a/src/icelake/icelake_ascii_validation.inl.cpp
+++ b/src/icelake/icelake_ascii_validation.inl.cpp
@@ -3,17 +3,49 @@
 bool validate_ascii(const char *buf, size_t len) {
   const char *end = buf + len;
   const __m512i ascii = _mm512_set1_epi8((uint8_t)0x80);
-  __m512i running_or = _mm512_setzero_si512();
+  // Four accumulators so the loads are not serialized behind a single
+  // loop-carried vpternlogd, and 64-byte aligned reads: a 512-bit load whose
+  // address straddles a cache line costs two accesses, and this loop does
+  // nothing but load.
+  __m512i or0 = _mm512_setzero_si512();
+  __m512i or1 = _mm512_setzero_si512();
+  __m512i or2 = _mm512_setzero_si512();
+  __m512i or3 = _mm512_setzero_si512();
+  // Reach the next 64-byte boundary with a masked load. There is no
+  // cross-block state here and the zero fill is itself ASCII, so this is
+  // simply a shorter first block.
+  if (len >= 64) {
+    const uintptr_t misalignment = reinterpret_cast<uintptr_t>(buf) % 64;
+    if (misalignment != 0) {
+      const size_t adjustment = 64 - misalignment;
+      const __m512i head = _mm512_maskz_loadu_epi8(
+          ~UINT64_C(0) >> (64 - adjustment), (const __m512i *)buf);
+      or0 = _mm512_ternarylogic_epi32(or0, head, ascii, 0xf8);
+      buf += adjustment;
+    }
+  }
+  for (; end - buf >= 256; buf += 256) {
+    or0 = _mm512_ternarylogic_epi32(
+        or0, _mm512_loadu_si512((const __m512i *)buf), ascii, 0xf8);
+    or1 = _mm512_ternarylogic_epi32(
+        or1, _mm512_loadu_si512((const __m512i *)(buf + 64)), ascii, 0xf8);
+    or2 = _mm512_ternarylogic_epi32(
+        or2, _mm512_loadu_si512((const __m512i *)(buf + 128)), ascii, 0xf8);
+    or3 = _mm512_ternarylogic_epi32(
+        or3, _mm512_loadu_si512((const __m512i *)(buf + 192)), ascii, 0xf8);
+  }
   for (; end - buf >= 64; buf += 64) {
     const __m512i utf8 = _mm512_loadu_si512((const __m512i *)buf);
-    running_or = _mm512_ternarylogic_epi32(running_or, utf8, ascii,
-                                           0xf8); // running_or | (utf8 & ascii)
+    or0 = _mm512_ternarylogic_epi32(or0, utf8, ascii,
+                                    0xf8); // or0 | (utf8 & ascii)
   }
   if (buf < end) {
     const __m512i utf8 = _mm512_maskz_loadu_epi8(
         (uint64_t(1) << (end - buf)) - 1, (const __m512i *)buf);
-    running_or = _mm512_ternarylogic_epi32(running_or, utf8, ascii,
-                                           0xf8); // running_or | (utf8 & ascii)
+    or0 = _mm512_ternarylogic_epi32(or0, utf8, ascii,
+                                    0xf8); // or0 | (utf8 & ascii)
   }
+  const __m512i running_or =
+      _mm512_or_si512(_mm512_or_si512(or0, or1), _mm512_or_si512(or2, or3));
   return (_mm512_test_epi8_mask(running_or, running_or) == 0);
 }

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -261,6 +261,37 @@ simdutf_warn_unused result implementation::validate_ascii_with_errors(
   const char *buf_orig = buf;
   const char *end = buf + len;
   const __m512i ascii = _mm512_set1_epi8((uint8_t)0x80);
+  // Reach the next 64-byte boundary first: a 512-bit load whose address
+  // straddles a cache line costs two accesses, and this loop does nothing but
+  // load and compare. There is no cross-block state, so the head is simply a
+  // shorter first block handled with a masked load.
+  if (len >= 64) {
+    // A full first block, exactly as before, so that inputs whose first
+    // non-ASCII byte is near the start still return just as quickly. Once it
+    // is known to be ASCII we may jump to the boundary; re-reading the bytes
+    // in between is harmless because there is no cross-block state.
+    const __m512i head = _mm512_loadu_si512((const __m512i *)buf);
+    __mmask64 notascii = _mm512_cmp_epu8_mask(head, ascii, _MM_CMPINT_NLT);
+    if (notascii) {
+      return result(error_code::TOO_LARGE,
+                    buf - buf_orig + _tzcnt_u64(notascii));
+    }
+    const uintptr_t misalignment = reinterpret_cast<uintptr_t>(buf) % 64;
+    buf += (misalignment == 0) ? 64 : (64 - misalignment);
+  }
+  // Four vectors per compare-and-branch: the loads then issue back to back
+  // instead of being serialized by one branch per 64 bytes.
+  for (; end - buf >= 256; buf += 256) {
+    const __m512i b0 = _mm512_loadu_si512((const __m512i *)buf);
+    const __m512i b1 = _mm512_loadu_si512((const __m512i *)(buf + 64));
+    const __m512i b2 = _mm512_loadu_si512((const __m512i *)(buf + 128));
+    const __m512i b3 = _mm512_loadu_si512((const __m512i *)(buf + 192));
+    const __m512i any =
+        _mm512_or_si512(_mm512_or_si512(b0, b1), _mm512_or_si512(b2, b3));
+    if (_mm512_cmp_epu8_mask(any, ascii, _MM_CMPINT_NLT)) {
+      break; // the 64-byte loop below pinpoints it
+    }
+  }
   for (; end - buf >= 64; buf += 64) {
     const __m512i input = _mm512_loadu_si512((const __m512i *)buf);
     __mmask64 notascii = _mm512_cmp_epu8_mask(input, ascii, _MM_CMPINT_NLT);


### PR DESCRIPTION
Companion to #1023. Same root cause, different functions — and here the effect is much bigger, because these two loops do nothing but load.

I kept `validate_ascii` and `validate_ascii_with_errors` in one PR: it is the same change applied to the two halves of one feature, and splitting it would give two near-identical diffs. Happy to split if you would rather review them apart.

## Problem

Both walk the buffer 64 bytes at a time straight from the caller's pointer. A 512-bit load whose *address* is not 64-byte aligned touches two cache lines and costs two accesses — and callers rarely hand us an aligned buffer. Measured penalty for a buffer at offset 24: **−44%** for `validate_ascii`, **−42%** for `validate_ascii_with_errors`. That is the largest misalignment penalty of any icelake validator.

On top of that, `validate_ascii` chains every block into a single accumulator, so the loads serialize behind a loop-carried `vpternlogd`, and `validate_ascii_with_errors` takes a branch every 64 bytes.

## Fix

Neither function carries state across blocks, so aligning is straightforward:

- `validate_ascii`: masked load for the head — its zero fill is itself ASCII, so it needs no special casing — then four independent accumulators, 256 bytes per iteration.
- `validate_ascii_with_errors`: reads one *full* block first, exactly as master does, so that inputs whose first non-ASCII byte is near the start return just as quickly; only then does it jump to the boundary. Re-reading the bytes in between is harmless. Then four vectors per compare-and-branch, falling back to the 64-byte loop to pinpoint the byte.

## Measurements

Intel Xeon Gold 6548N (Emerald Rapids), gcc 14.3, single core, best-of-7, 29-file corpus.

**`validate_ascii`** — buffer at offset 24:

| | before | after | |
|---|---|---|---|
| Latin-Lipsum | 82.8 | **160.1** GB/s | +93% |
| across all 29 files | | | median **+92.9%**, min +18.9% |

already-aligned buffer: median **+7.1%** (min +5.2%, max +25.1%); Latin-Lipsum 148.6 → 159.8 GB/s.

**`validate_ascii_with_errors`** over a fully ASCII buffer:

| | before | after | |
|---|---|---|---|
| misaligned | 75.6 | **160.3** GB/s | +112% |
| aligned | 130.8 | **160.3** GB/s | +23% |

The early-exit path (first non-ASCII byte within the first block) is unchanged to slightly faster: 2.58 → 2.51 ns on Chinese-Lipsum, 2.74 → 2.30 ns on Bogatov1069.

**No regressions** in either function, on any corpus file, at either alignment.

## Correctness

- `ctest`: 91/91.
- Exhaustive cross-check against the unpatched build over **47,232 cases** — all 64 buffer alignments × valid and corrupted inputs × 12 lengths × 29 corpus files — hashing `validate_utf8`, `validate_utf8_with_errors`, `validate_ascii` and `validate_ascii_with_errors`, plus an independent scalar reference for the two ASCII entry points. Identical results.