### PR TITLE
icelake: align the reads and amortize the error check in validate_utf8_with_errors

### DIFF
--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -215,35 +215,70 @@ simdutf_warn_unused result implementation::validate_utf8_with_errors(
   const char *ptr = buf;
   const char *end = ptr + len;
   size_t count{0};
+  // Largest prefix that a clean error check has already cleared. On failure it
+  // is handed to the scalar rewind, which re-validates forward from there to
+  // the end of the buffer, so naming a position earlier than the error only
+  // costs scalar work on the error path.
+  size_t safe{0};
+  // Get the 512-bit reads onto a 64-byte boundary. A load whose address is not
+  // aligned touches two cache lines and costs two accesses, and callers rarely
+  // hand us an aligned buffer.
+  //
+  // The head has to be a full block rather than a masked one: the checker
+  // carries state from one block to the next, and zero padding in the middle
+  // of a character would read as a truncated sequence. The cross-block state
+  // is then re-seeded from the three bytes preceding the aligned start, which
+  // must be inside the buffer, hence the misalignment <= 61 guard.
+  if (len >= 2048) {
+    const uintptr_t misalignment = reinterpret_cast<uintptr_t>(ptr) % 64;
+    if (misalignment != 0 && misalignment <= 61) {
+      const size_t adjustment = 64 - misalignment;
+      checker.check_next_input(_mm512_loadu_si512((const __m512i *)ptr));
+      if (simdutf_unlikely(checker.errors())) {
+        return scalar::utf8::rewind_and_validate_with_errors(buf, buf, len);
+      }
+      ptr += adjustment;
+      count = adjustment;
+      // Only the top three lanes are read. Masked-out lanes never fault, so
+      // this is safe even though ptr - 64 may point before buf.
+      const __m512i prev3 = _mm512_maskz_loadu_epi8(
+          UINT64_C(0xE000000000000000), (const __m512i *)(ptr - 64));
+      checker.prev_input_block = prev3;
+      checker.prev_incomplete = is_incomplete(prev3);
+    }
+  }
+  // checker.error is a sticky OR-accumulator, so it does not have to be tested
+  // every 64 bytes. Testing it every eighth block takes a vptestmb, a ktest
+  // and a branch out of the hot loop; an error is then handed to the scalar
+  // rewind at most nine blocks early, which only lengthens the rare error
+  // path.
+  unsigned since = 0;
   for (; end - ptr >= 64; ptr += 64) {
     const __m512i utf8 = _mm512_loadu_si512((const __m512i *)ptr);
     checker.check_next_input(utf8);
-    if (checker.errors()) {
-      if (count != 0) {
-        count--;
-      } // Sometimes the error is only detected in the next chunk
-      result res = scalar::utf8::rewind_and_validate_with_errors(
-          reinterpret_cast<const char *>(buf),
-          reinterpret_cast<const char *>(buf + count), len - count);
-      res.count += count;
-      return res;
-    }
     count += 64;
+    if (++since == 8) {
+      since = 0;
+      if (simdutf_unlikely(checker.errors())) {
+        break;
+      }
+      safe = count >= 64 ? count - 64 : 0;
+    }
   }
-  if (end != ptr) {
+  if (!checker.errors() && end != ptr) {
     const __m512i utf8 = _mm512_maskz_loadu_epi8(
         ~UINT64_C(0) >> (64 - (end - ptr)), (const __m512i *)ptr);
     checker.check_next_input(utf8);
   }
   checker.check_eof();
   if (checker.errors()) {
-    if (count != 0) {
-      count--;
+    if (safe != 0) {
+      safe--;
     } // Sometimes the error is only detected in the next chunk
     result res = scalar::utf8::rewind_and_validate_with_errors(
         reinterpret_cast<const char *>(buf),
-        reinterpret_cast<const char *>(buf + count), len - count);
-    res.count += count;
+        reinterpret_cast<const char *>(buf + safe), len - safe);
+    res.count += safe;
     return res;
   }
   return result(error_code::SUCCESS, len);


### PR DESCRIPTION
Third in a series with #1023 (`validate_utf8`) and #1024 (the ASCII validators). Independent of both; happy to reorder or rebase.

## Two problems

**1. The reads are unaligned.** Same as #1023: a 512-bit load whose *address* is not 64-byte aligned touches two cache lines and costs two accesses, and callers rarely hand us an aligned buffer. Same fix — a full head block (a masked one would not work, since the checker carries state across blocks and zero padding mid-character reads as a truncated sequence), then re-seed `prev_input_block` / `prev_incomplete` from the three bytes preceding the aligned start.

**2. `checker.errors()` is tested every 64 bytes.** That is a `vptestmb`, a `ktest` and a branch per block which `validate_utf8` does not pay. The gap between the two functions is large on ASCII-heavy input — 99.6 vs 71.0 GB/s on Latin-Lipsum, **−29%**.

`checker.error` is a sticky OR-accumulator, so the test only needs to be frequent enough to bound how far the scalar rewind must back up. This tests it every eighth block and hands a detected error to `rewind_and_validate_with_errors` at most nine blocks early. Because that helper re-validates *forward* from the given position to the end of the buffer, naming an earlier position cannot change the reported error offset — it only lengthens the rare error path.

## Measurements

Intel Xeon Gold 6548N (Emerald Rapids), gcc 14.3, single core, best-of-7, 29-file corpus. Buffer at offset 24:

| input | before | after | |
|---|---|---|---|
| Latin-Lipsum | 63.2 | **80.5** GB/s | +27% |
| english | 47.1 | **60.2** GB/s | +28% |
| twitter.json | 35.9 | **43.0** GB/s | +20% |
| all 29 files | | | min −3.6%, **median +8.5%**, max +27.7% |

Already-aligned buffer: min −9.4%, **median +1.8%**, max +13.2%.

## The one regression

Both minima are `thai.utf8.txt` — 19.6 → 18.9 misaligned, 21.2 → 19.2 aligned. It reproduces across builds and runs. It is codegen, not work: the alignment change *alone* speeds thai up (21.2 → 21.3 aligned), and only restructuring the loop for the amortized check gives it back. Nothing distinguishes it from `hindi.utf8.txt`, which has almost the same non-ASCII density and improves.

Every other file in the corpus improves at both alignments. If you would rather not take that trade, the alignment half on its own is uniformly positive — misaligned min +0.9%, median +6.4%, max +13.1%; aligned min −2.0%, median −0.2% — and I can trim the PR down to just that.

## Correctness

- `ctest`: 91/91.
- Exhaustive cross-check against the unpatched build over **47,232 cases** — all 64 buffer alignments × valid and corrupted inputs × 12 lengths × 29 corpus files. Identical results, so every reported error position is unchanged.