### PR TITLE
icelake: align and widen the UTF-32 validators

### DIFF
--- a/src/icelake/icelake_utf32_validation.inl.cpp
+++ b/src/icelake/icelake_utf32_validation.inl.cpp
@@ -7,29 +7,59 @@ bool validate_utf32(const char32_t *buf, size_t len) {
   const char32_t *end = buf + len;
 
   const __m512i offset = _mm512_set1_epi32((uint32_t)0xffff2000);
-  __m512i currentmax = _mm512_setzero_si512();
-  __m512i currentoffsetmax = _mm512_setzero_si512();
+  // Four independent accumulator pairs: in the 2x version below every block
+  // fed the same two accumulators, so the vpmaxud chains were serialized.
+  __m512i max0 = _mm512_setzero_si512();
+  __m512i max1 = _mm512_setzero_si512();
+  __m512i max2 = _mm512_setzero_si512();
+  __m512i max3 = _mm512_setzero_si512();
+  __m512i off0 = _mm512_setzero_si512();
+  __m512i off1 = _mm512_setzero_si512();
+  __m512i off2 = _mm512_setzero_si512();
+  __m512i off3 = _mm512_setzero_si512();
 
-  // Optimized: Process 32 values (2x 512-bit) per iteration for better
-  // throughput
-  while (end - buf >= 32) {
-    __m512i utf32_1 = _mm512_loadu_si512((const __m512i *)buf);
-    __m512i utf32_2 = _mm512_loadu_si512((const __m512i *)(buf + 16));
-    buf += 32;
-
-    // Process both blocks in parallel to maximize instruction-level parallelism
-    __m512i offsetmax_1 = _mm512_add_epi32(utf32_1, offset);
-    __m512i offsetmax_2 = _mm512_add_epi32(utf32_2, offset);
-
-    currentoffsetmax = _mm512_max_epu32(offsetmax_1, currentoffsetmax);
-    currentmax = _mm512_max_epu32(utf32_1, currentmax);
-
-    currentoffsetmax = _mm512_max_epu32(offsetmax_2, currentoffsetmax);
-    currentmax = _mm512_max_epu32(utf32_2, currentmax);
+  // Get the reads onto a 64-byte boundary: a 512-bit load whose address
+  // straddles a cache line costs two accesses, and this loop is load-bound.
+  // There is no state carried between blocks, so the head is simply a shorter
+  // first block: the zero fill of a masked load is itself a valid code point
+  // and can raise neither maximum.
+  if (len >= 16) {
+    const uintptr_t misalignment = reinterpret_cast<uintptr_t>(buf) % 64;
+    if (misalignment != 0) {
+      const size_t adjustment = (64 - misalignment) / sizeof(char32_t);
+      const __m512i head = _mm512_maskz_loadu_epi32(
+          __mmask16((1U << adjustment) - 1), (const __m512i *)buf);
+      off0 = _mm512_max_epu32(_mm512_add_epi32(head, offset), off0);
+      max0 = _mm512_max_epu32(head, max0);
+      buf += adjustment;
+    }
   }
 
-  // Handle remaining 16-31 values
-  if (end - buf >= 16) {
+  // Process 64 values (4x 512-bit) per iteration.
+  while (end - buf >= 64) {
+    __m512i utf32_1 = _mm512_loadu_si512((const __m512i *)buf);
+    __m512i utf32_2 = _mm512_loadu_si512((const __m512i *)(buf + 16));
+    __m512i utf32_3 = _mm512_loadu_si512((const __m512i *)(buf + 32));
+    __m512i utf32_4 = _mm512_loadu_si512((const __m512i *)(buf + 48));
+    buf += 64;
+
+    off0 = _mm512_max_epu32(_mm512_add_epi32(utf32_1, offset), off0);
+    max0 = _mm512_max_epu32(utf32_1, max0);
+    off1 = _mm512_max_epu32(_mm512_add_epi32(utf32_2, offset), off1);
+    max1 = _mm512_max_epu32(utf32_2, max1);
+    off2 = _mm512_max_epu32(_mm512_add_epi32(utf32_3, offset), off2);
+    max2 = _mm512_max_epu32(utf32_3, max2);
+    off3 = _mm512_max_epu32(_mm512_add_epi32(utf32_4, offset), off3);
+    max3 = _mm512_max_epu32(utf32_4, max3);
+  }
+
+  __m512i currentmax = _mm512_max_epu32(_mm512_max_epu32(max0, max1),
+                                        _mm512_max_epu32(max2, max3));
+  __m512i currentoffsetmax = _mm512_max_epu32(_mm512_max_epu32(off0, off1),
+                                              _mm512_max_epu32(off2, off3));
+
+  // Handle remaining 16-63 values
+  while (end - buf >= 16) {
     __m512i utf32 = _mm512_loadu_si512((const __m512i *)buf);
     buf += 16;
     currentoffsetmax =

--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -627,6 +627,52 @@ simdutf_warn_unused result implementation::validate_utf32_with_errors(
   const char32_t *buf_orig = buf;
   if (len >= 16) {
     const char32_t *end = buf + len - 16;
+    // One full block first, exactly as before, so that inputs whose first bad
+    // code point is near the start still return just as quickly. Once it is
+    // known to be clean we may jump to the 64-byte boundary; re-reading the
+    // values in between is harmless because no state crosses blocks.
+    {
+      __m512i utf32 = _mm512_loadu_si512((const __m512i *)buf);
+      __mmask16 outside_range = _mm512_cmp_epu32_mask(
+          utf32, _mm512_set1_epi32(0x10ffff), _MM_CMPINT_GT);
+      __m512i utf32_off =
+          _mm512_add_epi32(utf32, _mm512_set1_epi32(0xffff2000));
+      __mmask16 surrogate_range = _mm512_cmp_epu32_mask(
+          utf32_off, _mm512_set1_epi32(0xfffff7ff), _MM_CMPINT_GT);
+      if ((outside_range | surrogate_range)) {
+        auto outside_idx = _tzcnt_u32(outside_range);
+        auto surrogate_idx = _tzcnt_u32(surrogate_range);
+        if (outside_idx < surrogate_idx) {
+          return result(error_code::TOO_LARGE, buf - buf_orig + outside_idx);
+        }
+        return result(error_code::SURROGATE, buf - buf_orig + surrogate_idx);
+      }
+      const uintptr_t misalignment = reinterpret_cast<uintptr_t>(buf) % 64;
+      buf += (misalignment == 0) ? 16 : (64 - misalignment) / sizeof(char32_t);
+    }
+    // Screen four vectors per compare-and-branch; the 16-value loop below
+    // pinpoints the offending code point.
+    const __m512i toolarge = _mm512_set1_epi32(0x10ffff);
+    const __m512i offset = _mm512_set1_epi32(0xffff2000);
+    const __m512i surrmax = _mm512_set1_epi32(0xfffff7ff);
+    while (buf + 48 <= end) {
+      __m512i a = _mm512_loadu_si512((const __m512i *)buf);
+      __m512i b = _mm512_loadu_si512((const __m512i *)(buf + 16));
+      __m512i c = _mm512_loadu_si512((const __m512i *)(buf + 32));
+      __m512i d = _mm512_loadu_si512((const __m512i *)(buf + 48));
+      __m512i mx =
+          _mm512_max_epu32(_mm512_max_epu32(a, b), _mm512_max_epu32(c, d));
+      __m512i ox =
+          _mm512_max_epu32(_mm512_max_epu32(_mm512_add_epi32(a, offset),
+                                            _mm512_add_epi32(b, offset)),
+                           _mm512_max_epu32(_mm512_add_epi32(c, offset),
+                                            _mm512_add_epi32(d, offset)));
+      if (_mm512_cmp_epu32_mask(mx, toolarge, _MM_CMPINT_GT) |
+          _mm512_cmp_epu32_mask(ox, surrmax, _MM_CMPINT_GT)) {
+        break;
+      }
+      buf += 64;
+    }
     while (buf <= end) {
       __m512i utf32 = _mm512_loadu_si512((const __m512i *)buf);
       __mmask16 outside_range = _mm512_cmp_epu32_mask(


### PR DESCRIPTION
Fourth in the series with #1023, #1024 and #1025. Independent of all three.

Both UTF-32 validators in one PR: it is the same change applied to the two halves of one feature. Happy to split.

## Problem

Both read straight from the caller's pointer. A 512-bit load whose *address* is not 64-byte aligned touches two cache lines and costs two accesses — measured at **−28%** for `validate_utf32` and **−24%** for `validate_utf32_with_errors` on a buffer at offset 24.

Neither function carries state between blocks, so unlike the UTF-8 case there is nothing to re-seed and aligning is straightforward.

Beyond that, `validate_utf32`'s 2× loop fed both blocks into the *same* two accumulators:

```cpp
currentoffsetmax = _mm512_max_epu32(offsetmax_1, currentoffsetmax);
currentmax       = _mm512_max_epu32(utf32_1,     currentmax);
currentoffsetmax = _mm512_max_epu32(offsetmax_2, currentoffsetmax);  // waits on the line above
currentmax       = _mm512_max_epu32(utf32_2,     currentmax);
```

so the `vpmaxud` chains serialized.

## Fix

- `validate_utf32`: masked head load (its zero fill is a valid code point and can raise neither maximum), then 4 vectors per iteration into 4 independent accumulator pairs, reduced at the end.
- `validate_utf32_with_errors`: one *full* block first, exactly as master, so inputs whose first bad code point is near the start return just as quickly; then jump to the boundary and screen 4 vectors per compare-and-branch, falling back to the 16-value loop to pinpoint. The reported index and error code are unchanged.

## Measurements

Intel Xeon Gold 6548N (Emerald Rapids), gcc 14.3, single core, best-of-7, corpus transcoded to UTF-32. Buffer at offset 24:

| | min | median | max |
|---|---|---|---|
| `validate_utf32` | +0.4% | **+40.1%** | +50.3% |
| `validate_utf32_with_errors` | +18.4% | **+72.0%** | +80.7% |

| input | `validate_utf32` | `validate_utf32_with_errors` |
|---|---|---|
| Latin-Lipsum | 72.7 → **101.6** GB/s | 58.9 → **101.6** GB/s |
| thai | 63.0 → **94.8** GB/s | 53.0 → **95.8** GB/s |

Already-aligned buffer: `validate_utf32` median 0.0%, `validate_utf32_with_errors` median **+30.2%** (min −0.7%).

One caveat I want to be explicit about: the aligned spread for `validate_utf32` reaches −10% on `english` and `twitter.json`. Those are the two buffers that exceed L2 and are memory-bandwidth bound, and that number is run-to-run variance rather than a regression — re-running the same two binaries put patched `english` at 86.1 GB/s and then 97.4 GB/s against master's steady 92.7/92.9. The misaligned gains, by contrast, reproduce exactly.

## Correctness

- `ctest`: 91/91.
- Cross-check against the unpatched build over **44,208 cases**: every achievable buffer alignment (all 16 four-byte offsets), valid inputs plus inputs seeded with surrogate code points and values above `0x10FFFF`, 10 lengths, corpus transcoded to UTF-32. Results hashed and identical, and both entry points also cross-checked against an independent scalar reference.