### PR TITLE
icelake: align the reads in the UTF-16 validators

### DIFF
--- a/src/icelake/implementation.cpp
+++ b/src/icelake/implementation.cpp
@@ -287,6 +287,21 @@ implementation::validate_utf16le_as_ascii(const char16_t *buf,
                                           size_t len) const noexcept {
   const char16_t *end = buf + len;
   __m512i limit = _mm512_set1_epi16(uint16_t(0x007F));
+  // Reach a 64-byte boundary; a 512-bit load that straddles a cache line costs
+  // two accesses. Nothing crosses a block boundary here, so the head is simply
+  // a shorter first block, and the zero fill of a masked load is itself ASCII.
+  if (len >= 32) {
+    const uintptr_t misalignment = reinterpret_cast<uintptr_t>(buf) % 64;
+    if (misalignment != 0) {
+      const size_t adjustment = (64 - misalignment) / sizeof(char16_t);
+      const __m512i head = _mm512_maskz_loadu_epi16(
+          __mmask32((1U << adjustment) - 1), (const __m512i *)buf);
+      if (_mm512_cmpgt_epu16_mask(head, limit)) {
+        return false;
+      }
+      buf += adjustment;
+    }
+  }
   for (; end - buf >= 32;) {
     __m512i in = _mm512_loadu_si512((__m512i *)buf);
     auto mask = _mm512_cmpgt_epu16_mask(in, limit);
@@ -315,6 +330,23 @@ implementation::validate_utf16be_as_ascii(const char16_t *buf,
       0x0e0f0c0d0a0b0809, 0x0607040502030001, 0x0e0f0c0d0a0b0809,
       0x0607040502030001, 0x0e0f0c0d0a0b0809);
   __m512i limit = _mm512_set1_epi16(uint16_t(0x007F));
+  // Reach a 64-byte boundary; a 512-bit load that straddles a cache line costs
+  // two accesses. Nothing crosses a block boundary here, so the head is simply
+  // a shorter first block, and the zero fill of a masked load is itself ASCII.
+  if (len >= 32) {
+    const uintptr_t misalignment = reinterpret_cast<uintptr_t>(buf) % 64;
+    if (misalignment != 0) {
+      const size_t adjustment = (64 - misalignment) / sizeof(char16_t);
+      const __m512i head = _mm512_shuffle_epi8(
+          _mm512_maskz_loadu_epi16(__mmask32((1U << adjustment) - 1),
+                                   (const __m512i *)buf),
+          byteflip);
+      if (_mm512_cmpgt_epu16_mask(head, limit)) {
+        return false;
+      }
+      buf += adjustment;
+    }
+  }
   for (; end - buf >= 32;) {
     __m512i in = _mm512_loadu_si512((__m512i *)buf);
     in = _mm512_shuffle_epi8(in, byteflip);
@@ -347,6 +379,26 @@ implementation::validate_utf16le(const char16_t *buf,
   const __m512i surr_range = _mm512_set1_epi16(uint16_t(0x0800));
   const __m512i high_range = _mm512_set1_epi16(uint16_t(0x0400));
 
+  // Reach a 64-byte boundary: a 512-bit load whose address straddles a cache
+  // line costs two accesses, and this loop is load-bound. The only state that
+  // crosses a block boundary here is a surrogate pair, so we may skip over the
+  // head only when it holds no surrogate at all -- which also makes the head
+  // valid, so nothing else about it needs checking. Input whose first code
+  // units are surrogates simply keeps to the unaligned path.
+  if (len >= 32) {
+    const uintptr_t misalignment = reinterpret_cast<uintptr_t>(buf) % 64;
+    if (misalignment != 0) {
+      const size_t adjustment = (64 - misalignment) / sizeof(char16_t);
+      const __m512i head = _mm512_maskz_loadu_epi16(
+          __mmask32((1U << adjustment) - 1), (const __m512i *)buf);
+      const __m512i headdiff =
+          _mm512_sub_epi16(head, _mm512_set1_epi16(uint16_t(0xD800)));
+      if (_mm512_cmplt_epu16_mask(headdiff,
+                                  _mm512_set1_epi16(uint16_t(0x0800))) == 0) {
+        buf += adjustment;
+      }
+    }
+  }
   for (; end - buf >= 64;) {
     __m512i in_1 = _mm512_loadu_si512((__m512i *)buf);
     __m512i in_2 = _mm512_loadu_si512((__m512i *)(buf + 32));
@@ -445,6 +497,28 @@ implementation::validate_utf16be(const char16_t *buf,
                                  size_t len) const noexcept {
   const char16_t *end = buf + len;
 
+  // Reach a 64-byte boundary: a 512-bit load whose address straddles a cache
+  // line costs two accesses, and this loop is load-bound. The only state that
+  // crosses a block boundary here is a surrogate pair, so we may skip over the
+  // head only when it holds no surrogate at all -- which also makes the head
+  // valid, so nothing else about it needs checking. Input whose first code
+  // units are surrogates simply keeps to the unaligned path.
+  if (len >= 32) {
+    const uintptr_t misalignment = reinterpret_cast<uintptr_t>(buf) % 64;
+    if (misalignment != 0) {
+      const size_t adjustment = (64 - misalignment) / sizeof(char16_t);
+      const __m512i head = _mm512_slli_epi16(
+          _mm512_maskz_loadu_epi16(__mmask32((1U << adjustment) - 1),
+                                   (const __m512i *)buf),
+          8);
+      const __m512i headdiff =
+          _mm512_sub_epi16(head, _mm512_set1_epi16(uint16_t(0xD800)));
+      if (_mm512_cmplt_epu16_mask(headdiff,
+                                  _mm512_set1_epi16(uint16_t(0x0800))) == 0) {
+        buf += adjustment;
+      }
+    }
+  }
   for (; end - buf >= 32;) {
     __m512i in = _mm512_slli_epi32(_mm512_loadu_si512((__m512i *)buf), 8);
     __m512i diff = _mm512_sub_epi16(in, _mm512_set1_epi16(uint16_t(0xD800)));
@@ -492,6 +566,26 @@ simdutf_warn_unused result implementation::validate_utf16le_with_errors(
     const char16_t *buf, size_t len) const noexcept {
   const char16_t *start_buf = buf;
   const char16_t *end = buf + len;
+  // Reach a 64-byte boundary: a 512-bit load whose address straddles a cache
+  // line costs two accesses, and this loop is load-bound. The only state that
+  // crosses a block boundary here is a surrogate pair, so we may skip over the
+  // head only when it holds no surrogate at all -- which also makes the head
+  // valid, so nothing else about it needs checking. Input whose first code
+  // units are surrogates simply keeps to the unaligned path.
+  if (len >= 32) {
+    const uintptr_t misalignment = reinterpret_cast<uintptr_t>(buf) % 64;
+    if (misalignment != 0) {
+      const size_t adjustment = (64 - misalignment) / sizeof(char16_t);
+      const __m512i head = _mm512_maskz_loadu_epi16(
+          __mmask32((1U << adjustment) - 1), (const __m512i *)buf);
+      const __m512i headdiff =
+          _mm512_sub_epi16(head, _mm512_set1_epi16(uint16_t(0xD800)));
+      if (_mm512_cmplt_epu16_mask(headdiff,
+                                  _mm512_set1_epi16(uint16_t(0x0800))) == 0) {
+        buf += adjustment;
+      }
+    }
+  }
   for (; end - buf >= 32;) {
     __m512i in = _mm512_loadu_si512((__m512i *)buf);
     __m512i diff = _mm512_sub_epi16(in, _mm512_set1_epi16(uint16_t(0xD800)));
@@ -550,6 +644,28 @@ simdutf_warn_unused result implementation::validate_utf16be_with_errors(
   const char16_t *start_buf = buf;
   const char16_t *end = buf + len;
 
+  // Reach a 64-byte boundary: a 512-bit load whose address straddles a cache
+  // line costs two accesses, and this loop is load-bound. The only state that
+  // crosses a block boundary here is a surrogate pair, so we may skip over the
+  // head only when it holds no surrogate at all -- which also makes the head
+  // valid, so nothing else about it needs checking. Input whose first code
+  // units are surrogates simply keeps to the unaligned path.
+  if (len >= 32) {
+    const uintptr_t misalignment = reinterpret_cast<uintptr_t>(buf) % 64;
+    if (misalignment != 0) {
+      const size_t adjustment = (64 - misalignment) / sizeof(char16_t);
+      const __m512i head = _mm512_slli_epi16(
+          _mm512_maskz_loadu_epi16(__mmask32((1U << adjustment) - 1),
+                                   (const __m512i *)buf),
+          8);
+      const __m512i headdiff =
+          _mm512_sub_epi16(head, _mm512_set1_epi16(uint16_t(0xD800)));
+      if (_mm512_cmplt_epu16_mask(headdiff,
+                                  _mm512_set1_epi16(uint16_t(0x0800))) == 0) {
+        buf += adjustment;
+      }
+    }
+  }
   for (; end - buf >= 32;) {
     __m512i in = _mm512_slli_epi16(_mm512_loadu_si512((__m512i *)buf), 8);
     __m512i diff = _mm512_sub_epi16(in, _mm512_set1_epi16(uint16_t(0xD800)));


### PR DESCRIPTION
Fifth in the series with #1023, #1024, #1025 and #1026. Independent of all of them.

Six functions in one PR — `validate_utf16le`/`be`, their `_with_errors` variants, and `validate_utf16le`/`be_as_ascii` — because it is one idea applied six times. Happy to split.

## Problem

All six read straight from the caller's pointer, and a 512-bit load whose *address* is not 64-byte aligned touches two cache lines and costs two accesses. These are the largest penalties in the UTF-16 family: **−43%** for `validate_utf16le` and **−36%** for `validate_utf16le_with_errors` on a buffer at offset 12 code units.

## Why it is not as simple as UTF-32

State does cross a block boundary here: a surrogate pair may straddle it, and the loops depend on that — they advance 31 rather than 32 code units when a block ends on a high surrogate, so the pair is seen whole next time round. A head cannot just be validated and skipped, and a block must never start on a low surrogate or `(highsurrogates << 1) != lowsurrogates` fires spuriously.

The way through: **a head containing no surrogate at all is both valid on its own and leaves no pending high surrogate.** So the prologue reads the head with a masked load and jumps to the boundary only when it holds no surrogate; otherwise `buf` is untouched and the existing unaligned path runs exactly as before.

That means non-BMP text keeps the old behaviour precisely. `Emoji-Lipsum`, which is entirely surrogate pairs, measures unchanged at both alignments — which is also a useful check that the gate does what it says.

`validate_utf16*_as_ascii` carries no state at all, so its head is unconditional.

## Measurements

Intel Xeon Gold 6548N (Emerald Rapids), gcc 14.3, single core, best-of-7, corpus transcoded to UTF-16LE. Buffer at offset 12 code units:

| | min | median | max |
|---|---|---|---|
| `validate_utf16le` | +0.4% | **+72.9%** | +77.3% |
| `validate_utf16le_with_errors` | +0.0% | **+56.4%** | +62.2% |

| input | `validate_utf16le` | `validate_utf16le_with_errors` |
|---|---|---|
| Latin-Lipsum | 76.0 → **132.0** GB/s | 75.5 → **118.4** GB/s |
| thai | 75.1 → **133.1** GB/s | 75.5 → **118.9** GB/s |
| Emoji-Lipsum (all surrogates) | 15.8 → 15.9 | 8.8 → 8.8 |

On an already-aligned buffer both are neutral, median −0.1%.

One soft spot, stated plainly: `validate_utf16le_with_errors` on Latin-Lipsum becomes *unstable* in the aligned case — 118.6, 112.6, 103.4 GB/s over three runs, against a rock-steady 118.4 for master. The prologue is skipped entirely when the buffer is already aligned, so this is code layout, not work. The misaligned figures, by contrast, reproduce to within 0.2%.

The benchmark covers the little-endian entry points; the big-endian ones get the identical transformation with the byte flip applied to the head.

## Correctness

- `ctest`: 91/91.
- Cross-check against the unpatched build over **44,208 cases**: every achievable buffer alignment (all 32 two-byte offsets), valid inputs plus inputs seeded with unpaired high and unpaired low surrogates, 10 lengths, corpus transcoded to both UTF-16LE and UTF-16BE, hashing the results of all six functions. Identical.