### PR TITLE
generate the C API wrappers in add_function.py

### DIFF
--- a/scripts/README_ADD_FUNCTION.md
+++ b/scripts/README_ADD_FUNCTION.md
@@ -28,6 +28,7 @@ This guide explains how to use the `add_function.py` script to automate adding a
    ```shell
    python scripts/add_function.py new_function.sig
    ```
+   Pass `--no-c-api` if the function should not be part of the C API.
 
 3. **What the Script Does**:
    - Parses the signature file to extract the feature macro and all function signatures with their documentation.
@@ -35,15 +36,47 @@ This guide explains how to use the `add_function.py` script to automate adding a
    - Adds each as a virtual function in the `implementation` class.
    - Adds implementations in `src/implementation.cpp` (detect, unsupported, and standalone).
    - Adds stub implementations (`// TODO: implement`) in all `src/*/implementation.cpp` files.
+   - Adds a C wrapper to `include/simdutf_c.h` and `src/simdutf_c.cpp`, see below.
 
 4. **Post-Script Steps**:
    - Implement the actual function logic in each `src/*/implementation.cpp` file.
    - Update any tests or documentation as needed.
+   - Cover the C wrapper in `tests/straight_c_test.c` and `tests/nostdlibcxx_c_api_test.c`.
    - Rebuild and test the library.
+
+## The C API
+
+The C API is a thin forwarding layer: `simdutf_f(...)` calls `simdutf::f(...)`
+and converts the types that C cannot spell. The script writes that layer for
+you when every type of the signature has a C counterpart:
+
+- plain types (`size_t`, `bool`, `char`, `char16_t`, `char32_t`, pointers to
+  them, ...) are forwarded as they are;
+- `result` and `full_result` are returned as `simdutf_result` and
+  `simdutf_full_result`, through the `to_c_result` and `to_c_full_result`
+  converters (a new struct is one more entry in `C_RESULT_TYPES`);
+- `encoding_type`, `base64_options` and `last_chunk_handling_options` are cast
+  to and from their `simdutf_` counterparts.
+
+Anything else (references such as the `size_t &outlen` of
+`base64_to_binary_safe`, `std::span` overloads, templates, `char8_t`, ...)
+needs a wrapper written by hand: the script reports what it skipped and leaves
+the two C API files alone. The same is true of anything that is not a plain
+forwarding call, such as the `simdutf_base64_to_binary_safe` wrapper, which
+has to bounce `outlen` through a local variable.
+
+The wrappers land at the end of the `extern "C"` block of each file, so move
+them next to the functions they belong with, and check that the generated
+documentation reads well as a C comment. The C API sits behind a single `#if`
+requiring every feature, so no feature macro has to be threaded through.
+
+Note that the whole C API is regenerated into `singleheader/simdutf_c.h` by
+`singleheader/amalgamate.py`, so nothing else is needed for the single-header
+distribution.
 
 ## Warnings
 - This script modifies source files directly. Back up your repository before running it.
-- The script uses simple text manipulation; complex signatures may require manual adjustments.
+- The script uses simple text manipulation; complex signatures may require manual adjustments. Always review the diff.
 - Ensure the feature macro is correctly defined in the build system.
 
 If you encounter issues, check the script's output and verify the file paths.

--- a/scripts/add_function.py
+++ b/scripts/add_function.py
@@ -5,7 +5,7 @@ This script reads a file containing the function signatures and documentation,
 then adds the functions to the appropriate files in the codebase.
 
 Usage:
-    python add_function.py <signature_file>
+    python add_function.py [--no-c-api] <signature_file>
 
 Where <signature_file> is a file containing the function signatures, wrapped in a feature macro block, e.g.:
     #if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
@@ -21,6 +21,9 @@ Where <signature_file> is a file containing the function signatures, wrapped in 
     simdutf_warn_unused size_t utf8_length_from_utf16be(
         const char16_t *buf, size_t len) noexcept;
     #endif
+
+The C API (include/simdutf_c.h, src/simdutf_c.cpp) is updated as well, unless
+--no-c-api is given or the signature uses types that have no C counterpart.
 """
 
 import sys
@@ -86,7 +89,7 @@ def add_to_implementation_h(repo_root, feature_macro, functions):
     # Insert standalone functions
     standalone = ""
     for doc, signature, func_name in functions:
-        standalone_sig = signature.replace(' const ', ' ')
+        standalone_sig = signature.replace(' const noexcept', ' noexcept')
         standalone += f"""{doc}
 
 {standalone_sig}
@@ -288,15 +291,222 @@ def add_declaration_to_all_impl_files(repo_root, feature_macro, functions):
         print(f"Updating declarations for {file_path}...")
         add_declarations_to_impl_h(file_path, functions, feature_macro)
 
+# ---------------------------------------------------------------------------
+# C API generation (include/simdutf_c.h and src/simdutf_c.cpp)
+# ---------------------------------------------------------------------------
+
+# simdutf structs mirrored by the C API, with the converter that turns the C++
+# struct into the C one in src/simdutf_c.cpp.
+C_RESULT_TYPES = {
+    'result': ('simdutf_result', 'to_c_result'),
+    'full_result': ('simdutf_full_result', 'to_c_full_result'),
+}
+
+# simdutf enums mirrored value for value by the C API: they only need a cast.
+C_ENUM_TYPES = {
+    'encoding_type': 'simdutf_encoding_type',
+    'base64_options': 'simdutf_base64_options',
+    'last_chunk_handling_options': 'simdutf_last_chunk_handling_options',
+}
+
+# Types that spell the same thing in C and in C++.
+C_PLAIN_TYPES = {
+    'void', 'bool', 'char', 'char16_t', 'char32_t', 'signed', 'unsigned',
+    'short', 'int', 'long', 'float', 'double', 'size_t', 'ptrdiff_t',
+    'int8_t', 'int16_t', 'int32_t', 'int64_t',
+    'uint8_t', 'uint16_t', 'uint32_t', 'uint64_t',
+}
+
+# Qualifiers that have no place in a C declaration.
+CXX_QUALIFIERS = ('simdutf_warn_unused', 'simdutf_really_inline',
+                  'simdutf_constexpr', 'constexpr', 'inline', 'static')
+
+# We insert the wrappers at the end of the extern "C" block of each file.
+C_HEADER_ANCHOR = '#ifdef __cplusplus\n} /* extern "C" */'
+C_SOURCE_ANCHOR = '} // extern "C"'
+
+def split_declaration(text):
+    """Split 'const char16_t *buf' into ('const char16_t *', 'buf')."""
+    match = re.match(r'^(.*?)(\w+)$', text.strip(), re.DOTALL)
+    if not match:
+        return None, None
+    type_str = re.sub(r'\s*\*', ' *', match.group(1).strip())
+    return type_str.strip(), match.group(2)
+
+def base_type_name(type_str):
+    """Return the type name of a declaration, without cv-qualifiers or '*'."""
+    tokens = type_str.replace('*', ' ').replace('simdutf::', ' ').split()
+    tokens = [t for t in tokens if t not in ('const', 'volatile')]
+    return tokens[-1] if tokens else ''
+
+def check_c_type(type_str, base, allow_struct):
+    """Raise ValueError if the type cannot cross the C boundary as is."""
+    if '<' in type_str or '&' in type_str:
+        raise ValueError("'%s' has no C counterpart" % type_str)
+    if '::' in type_str.replace('simdutf::', ''):
+        raise ValueError("'%s' has no C counterpart" % type_str)
+    if base in C_RESULT_TYPES:
+        if not allow_struct:
+            raise ValueError("'%s' can only be converted on the way out" % base)
+    elif base not in C_PLAIN_TYPES and base not in C_ENUM_TYPES:
+        raise ValueError("type '%s' is not part of the C API" % base)
+
+def c_type_name(type_str, base):
+    """Rewrite a C++ declaration type into its C API spelling."""
+    if base in C_ENUM_TYPES:
+        c_base = C_ENUM_TYPES[base]
+    elif base in C_RESULT_TYPES:
+        c_base = C_RESULT_TYPES[base][0]
+    else:
+        c_base = base
+    return re.sub(r'(simdutf::)?\b%s\b' % re.escape(base), c_base, type_str)
+
+def declarator(type_str, name):
+    """Join a type and a name, keeping the '*' next to the name."""
+    return type_str + name if type_str.endswith('*') else type_str + ' ' + name
+
+def to_c_doc(doc):
+    """Turn a doxygen /** ... */ block into a plain C comment."""
+    body = re.sub(r'\*+/\s*$', '', re.sub(r'^\s*/\*+', '', doc.strip()))
+    lines = [re.sub(r'^\s*\*', '', line).strip() for line in body.splitlines()]
+    while lines and not lines[0]:
+        lines.pop(0)
+    while lines and not lines[-1]:
+        lines.pop()
+    if not lines:
+        return ''
+    if len(lines) == 1:
+        return '/* %s */' % lines[0]
+    body = ''.join('\n' + ('   ' + line).rstrip() for line in lines[1:])
+    return '/* ' + lines[0] + body + ' */'
+
+def c_api_wrapper(doc, signature, func_name):
+    """Build the C declaration and definition wrapping a simdutf function.
+
+    Raises ValueError when the signature uses something that has no C
+    counterpart (references, spans, templates, ...), in which case the
+    wrapper has to be written by hand.
+    """
+    sig = re.sub(r'\bnoexcept\b', ' ', signature.strip().rstrip(';'))
+    for qualifier in CXX_QUALIFIERS:
+        sig = re.sub(r'\b%s\b' % qualifier, ' ', sig)
+    # Drop the trailing const of the member function form.
+    sig = re.sub(r'\bconst\s*$', '', sig.strip()).strip()
+
+    match = re.match(r'^(?P<ret>.*?)\b(?P<name>\w+)\s*\((?P<params>.*)\)$',
+                     sig, re.DOTALL)
+    if not match or match.group('name') != func_name:
+        raise ValueError('cannot parse the signature')
+
+    ret_type = re.sub(r'\s*\*', ' *', match.group('ret').strip())
+    if not ret_type:
+        raise ValueError('cannot parse the return type')
+    ret_base = base_type_name(ret_type)
+    check_c_type(ret_type, ret_base, allow_struct=True)
+    c_ret_type = c_type_name(ret_type, ret_base)
+
+    c_params = []
+    args = []
+    for param in match.group('params').split(','):
+        if not param.strip():
+            continue
+        type_str, name = split_declaration(param)
+        if not type_str or not name:
+            raise ValueError("cannot parse the parameter '%s'" % param.strip())
+        base = base_type_name(type_str)
+        check_c_type(type_str, base, allow_struct=False)
+        c_params.append(declarator(c_type_name(type_str, base), name))
+        if base in C_ENUM_TYPES:
+            args.append('static_cast<simdutf::%s>(%s)' % (base, name))
+        else:
+            args.append(name)
+
+    prototype = '%s(%s)' % (declarator(c_ret_type, 'simdutf_' + func_name),
+                            ', '.join(c_params))
+    call = 'simdutf::%s(%s)' % (func_name, ', '.join(args))
+    if ret_base == 'void':
+        body = '  %s;' % call
+    elif ret_base in C_RESULT_TYPES:
+        body = '  return %s(%s);' % (C_RESULT_TYPES[ret_base][1], call)
+    elif ret_base in C_ENUM_TYPES:
+        body = '  return static_cast<%s>(%s);' % (C_ENUM_TYPES[ret_base], call)
+    else:
+        body = '  return %s;' % call
+
+    c_doc = to_c_doc(doc)
+    declaration = (c_doc + '\n' if c_doc else '') + prototype + ';'
+    definition = '%s {\n%s\n}' % (prototype, body)
+    return declaration, definition
+
+def insert_before_anchor(file_path, anchor, text, use_last):
+    """Insert text right before the anchor of the given file."""
+    with open(file_path, 'r') as f:
+        content = f.read()
+
+    insert_pos = content.rfind(anchor) if use_last else content.find(anchor)
+    if insert_pos == -1:
+        print(f"Warning: could not find the extern \"C\" block in {file_path}, "
+              "skipping it.")
+        return False
+
+    content = content[:insert_pos] + text + content[insert_pos:]
+    with open(file_path, 'w') as f:
+        f.write(content)
+    return True
+
+def add_to_c_api(repo_root, functions):
+    """Add wrappers to include/simdutf_c.h and src/simdutf_c.cpp.
+
+    The C API is a thin forwarding layer, so the wrappers can be generated
+    whenever every type of the signature has a C counterpart. Functions that
+    need more than forwarding are reported and left to the caller.
+    """
+    header = os.path.join(repo_root, 'include/simdutf_c.h')
+    source = os.path.join(repo_root, 'src/simdutf_c.cpp')
+    with open(header, 'r') as f:
+        header_content = f.read()
+
+    wrapped = []
+    declarations = []
+    definitions = []
+    for doc, signature, func_name in functions:
+        if f'simdutf_{func_name}(' in header_content:
+            print(f"'{func_name}' is already in the C API, skipping it.")
+            continue
+        try:
+            declaration, definition = c_api_wrapper(doc, signature, func_name)
+        except ValueError as e:
+            print(f"Skipping the C API for '{func_name}': {e}.")
+            print("  Add the wrapper by hand to include/simdutf_c.h and "
+                  "src/simdutf_c.cpp if it belongs to the C API.")
+            continue
+        wrapped.append(func_name)
+        declarations.append(declaration)
+        definitions.append(definition)
+
+    if not wrapped:
+        return []
+
+    print(f"Updating {header}...")
+    insert_before_anchor(header, C_HEADER_ANCHOR,
+                         '\n\n'.join(declarations) + '\n\n', use_last=False)
+    print(f"Updating {source}...")
+    insert_before_anchor(source, C_SOURCE_ANCHOR,
+                         '\n\n'.join(definitions) + '\n\n', use_last=True)
+    return wrapped
+
 def main():
-    if len(sys.argv) != 2:
-        print("Usage: python add_function.py <signature_file>")
+    args = list(sys.argv[1:])
+    generate_c_api = '--no-c-api' not in args
+    args = [a for a in args if a != '--no-c-api']
+    if len(args) != 1:
+        print("Usage: python add_function.py [--no-c-api] <signature_file>")
         sys.exit(1)
     
     script_dir = os.path.dirname(os.path.abspath(__file__))
     repo_root = os.path.abspath(os.path.join(script_dir, '..'))
     
-    sig_file = sys.argv[1]
+    sig_file = args[0]
     feature_macro, functions = read_signature_file(sig_file)
     
     # Ensure all signatures have const
@@ -315,11 +525,15 @@ def main():
     add_to_src_implementation_cpp(repo_root, feature_macro, functions)
     add_to_all_impl_files(repo_root, feature_macro, functions)
     add_declaration_to_all_impl_files(repo_root, feature_macro, functions)
+    c_api_names = add_to_c_api(repo_root, functions) if generate_c_api else []
     
     func_names = [name for _, _, name in functions]
     print(f"Functions '{', '.join(func_names)}' added successfully.")
     print("Please remember to implement the functions in the respective implementation.cpp files.")
     print("Also, consider adding tests for the new functions.")
+    if c_api_names:
+        print(f"C wrappers for '{', '.join(c_api_names)}' were added to include/simdutf_c.h and src/simdutf_c.cpp.")
+        print("Review them (documentation, placement) and cover them in tests/straight_c_test.c and tests/nostdlibcxx_c_api_test.c.")
     print("Run formatting tools to ensure code style consistency: ./scripts/clang_format_docker.sh ")
     print("Done.")
 


### PR DESCRIPTION
Follow-up to a review question on a downstream branch — *"Is this something that could at least partly be added to `add_function.py`?"*, asked about the hand-written C wrapper of a new function. Yes, most of it.

The C API is a thin forwarding layer: `simdutf_f(...)` calls `simdutf::f(...)` and converts the types C cannot spell. That part is mechanical, so `scripts/add_function.py` now writes it, and adding a function no longer means hand-copying a wrapper into two more files.

### What is generated

For each signature whose types have a C counterpart, the declaration goes into `include/simdutf_c.h` and the definition into `src/simdutf_c.cpp`:

- plain types (`size_t`, `bool`, `char16_t`, pointers to them, ...) are forwarded as they are;
- `result` and `full_result` are returned as `simdutf_result` and `simdutf_full_result` through the existing `to_c_result` / `to_c_full_result` (a new struct is one more entry in `C_RESULT_TYPES`);
- `encoding_type`, `base64_options` and `last_chunk_handling_options` are cast to and from their `simdutf_` counterparts;
- the doxygen block becomes a plain C comment.

Given this signature file:

```c++
#if SIMDUTF_FEATURE_UTF8 && SIMDUTF_FEATURE_UTF16
/**
 * Validate the demo way.
 */
simdutf_warn_unused result demo_validate(const char *buf, size_t len) noexcept;
#endif
```

the script now also produces, on top of what it did before:

```c
/* Validate the demo way. */
simdutf_result simdutf_demo_validate(const char *buf, size_t len);
```

```c++
simdutf_result simdutf_demo_validate(const char *buf, size_t len) {
  return to_c_result(simdutf::demo_validate(buf, len));
}
```

The wrappers land at the end of the `extern "C"` block of each file — which is also inside the single `#if` that gates the whole C API, so no feature macro has to be threaded through — and are meant to be reviewed and moved next to the functions they belong with. The final message now says so, and points at `tests/straight_c_test.c` and `tests/nostdlibcxx_c_api_test.c`.

### What is not

The "at least partly" part. Anything that is not a plain forwarding call is reported and left alone, with the two C API files untouched:

```
Skipping the C API for 'base64_to_binary_safe': 'size_t &' has no C counterpart.
  Add the wrapper by hand to include/simdutf_c.h and src/simdutf_c.cpp if it belongs to the C API.
```

That covers references (the `size_t &outlen` of `base64_to_binary_safe`, which needs a local), `std::span` overloads, templates, `char8_t`, `std::pair`, and unnamed parameters. Anything that is not a plain forwarding call stays manual, as do helpers that exist only because C has no member functions. A function already declared in the C header is skipped, so re-running is safe, and `--no-c-api` turns the step off for functions that should not be exposed.

### Drive-by fix

`add_to_implementation_h` stripped `' const '` from the signature to drop the trailing `const` of the member form; that also dropped the `const` of every `const char *buf` parameter, so the standalone declaration it wrote did not match the function it was declaring (`char16_t *buf` vs `const char16_t *buf`) and `src/simdutf_c.cpp` no longer compiled against it. It now strips `' const noexcept'` only, like `add_to_src_implementation_cpp` already did.

### Verification

Ran the script on a signature file covering all the shapes (plain, `result`, `void`, `base64_options` parameter, `encoding_type` return), on a clean `master` checkout:

- `src/simdutf_c.cpp` compiles with `-std=c++17 -Wall -Wextra -Werror` against the generated declarations, and a C program including the generated `include/simdutf_c.h` compiles with `-std=c99 -Wall -Wextra -Werror`;
- `clang-format` leaves the generated code alone except for wrapping long lines, and the result is indistinguishable from the hand-written wrappers next to it;
- the unsupported shapes above are each reported and skipped;
- re-running the script skips what is already in the C header, and `--no-c-api` leaves both C API files untouched.

`scripts/README_ADD_FUNCTION.md` documents the mapping table, the limits, and the review steps.
