### PR TITLE
Require POWER8 vector support to enable the ppc64 kernel

### DIFF
--- a/include/simdutf/portability.h
+++ b/include/simdutf/portability.h
@@ -110,7 +110,7 @@
 #elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
   #define SIMDUTF_IS_ARM64 1
 #elif defined(__PPC64__) || defined(_M_PPC64)
-  #if defined(__VEC__) && defined(__ALTIVEC__)
+  #if defined(__VEC__) && defined(__ALTIVEC__) && defined(__POWER8_VECTOR__)
     #define SIMDUTF_IS_PPC64 1
   #endif
 #elif defined(__s390__)


### PR DESCRIPTION
Short title (summary):
Require POWER8 vector support to enable the ppc64 kernel

Description
The ppc64 kernel uses VSX and POWER8 vector builtins (e.g. 64-bit
__vector types), but it is enabled whenever AltiVec is available.
On targets whose baseline CPU predates VSX (e.g. FreeBSD/powerpc64,
which targets the 970), enabling AltiVec alone makes the build fail:
simdutf.cpp:8339:37: error: use of 'long long' with '__vector' requires VSX support (available on POWER7 or later) to be enabled

Gate the kernel on __POWER8_VECTOR__ so such targets fall back to the
portable implementation, while ppc64le (POWER8 baseline) and builds
with -mcpu=power8 or newer are unaffected.

Type of change
- [x] Bug fix
- [ ] Optimization
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

How to verify / test
Try building on powerpc64.
