### PR TITLE
better guard for POWER

### DIFF
--- a/include/simdutf/portability.h
+++ b/include/simdutf/portability.h
@@ -110,7 +110,7 @@
 #elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
   #define SIMDUTF_IS_ARM64 1
 #elif defined(__PPC64__) || defined(_M_PPC64)
-  #if defined(__VEC__) && defined(__ALTIVEC__)
+  #if defined(__VEC__) && defined(__ALTIVEC__) && defined(__POWER8_VECTOR__)
     #define SIMDUTF_IS_PPC64 1
   #endif
 #elif defined(__s390__)


### PR DESCRIPTION
Currently, we have no POWER kernel per se, but if we build one, it should require POWER8 at least.